### PR TITLE
ci: add swift build and web typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,22 @@ on:
 jobs:
   swift-build:
     name: swift-build
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Web/package-lock.json
+      - name: Build web assets (for Swift resources)
+        working-directory: Web
+        run: |
+          npm ci
+          npm run build
       - name: Build (no code signing)
         run: >
           xcodebuild build
@@ -21,7 +34,7 @@ jobs:
 
   web-typecheck:
     name: web-typecheck
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -35,4 +48,3 @@ jobs:
       - name: Typecheck
         working-directory: Web
         run: npm run typecheck
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  swift-build:
+    name: swift-build
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (no code signing)
+        run: >
+          xcodebuild build
+          -scheme Ticker
+          -destination 'platform=OS X'
+          -derivedDataPath .build/xcode
+          CODE_SIGNING_ALLOWED=NO
+
+  web-typecheck:
+    name: web-typecheck
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Web/package-lock.json
+      - name: Install
+        working-directory: Web
+        run: npm ci
+      - name: Typecheck
+        working-directory: Web
+        run: npm run typecheck
+


### PR DESCRIPTION
## Linked issue

Closes #3 

## Summary

- Add CI spec to .github.
- Runs swift-build 
- Runs web-typecheck

## How to verify

- If CI runs on PR, then it's working.

## Compatibility / migrations

- Data migration needed?  No
- Bridge/proxy contract changes? No
- Rollback plan (1–2 sentences): None

## Changelog

- [ ] User-facing change: added an entry to `CHANGELOG.md`
- [X] Not user-facing / docs-only

