### PR TITLE
ci: skip expensive jobs when irrelevant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,26 +5,55 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   swift-build:
     name: swift-build
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - name: Decide whether to run Swift build
+        id: swift_changes
+        uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            swift:
+              - 'Sources/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.swiftpm/**'
+      - name: Set build flag (push to main always builds)
+        id: swift_should_build
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ steps.swift_changes.outputs.swift }}" == "true" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip Swift build (no relevant changes)
+        if: steps.swift_should_build.outputs.should_build != 'true'
+        run: echo "No Swift/SPM changes detected; skipping Swift build."
       - uses: maxim-lobanov/setup-xcode@v1
+        if: steps.swift_should_build.outputs.should_build == 'true'
         with:
           xcode-version: latest-stable
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: Web/package-lock.json
-      - name: Build web assets (for Swift resources)
-        working-directory: Web
+      - name: Ensure resource directory exists (CI placeholder)
+        if: steps.swift_should_build.outputs.should_build == 'true'
         run: |
-          npm ci
-          npm run build
+          mkdir -p Sources/Ticker/Resources
+          echo "CI placeholder resource (web assets built elsewhere)" > Sources/Ticker/Resources/.ci-placeholder
       - name: Build (no code signing)
+        if: steps.swift_should_build.outputs.should_build == 'true'
         run: >
           xcodebuild build
           -scheme Ticker
@@ -34,17 +63,32 @@ jobs:
 
   web-typecheck:
     name: web-typecheck
-    runs-on: macos-15
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Decide whether to run Web typecheck
+        id: web_changes
+        uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            web:
+              - 'Web/**'
       - uses: actions/setup-node@v4
+        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: Web/package-lock.json
       - name: Install
+        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
         working-directory: Web
         run: npm ci
       - name: Typecheck
+        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
         working-directory: Web
         run: npm run typecheck
+      - name: Skip Web typecheck (no relevant changes)
+        if: github.event_name == 'pull_request' && steps.web_changes.outputs.web != 'true'
+        run: echo "No Web changes detected; skipping Web typecheck."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -20,7 +24,9 @@ jobs:
         id: swift_changes
         uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         with:
+          token: ${{ github.token }}
           filters: |
             swift:
               - 'Sources/**'
@@ -31,6 +37,12 @@ jobs:
         id: swift_should_build
         run: |
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ steps.swift_changes.outcome }}" != "success" ]]; then
+            echo "Swift change detection failed; defaulting to build."
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -71,24 +83,26 @@ jobs:
         id: web_changes
         uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         with:
+          token: ${{ github.token }}
           filters: |
             web:
               - 'Web/**'
       - uses: actions/setup-node@v4
-        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
+        if: github.event_name != 'pull_request' || steps.web_changes.outcome != 'success' || steps.web_changes.outputs.web == 'true'
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: Web/package-lock.json
       - name: Install
-        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
+        if: github.event_name != 'pull_request' || steps.web_changes.outcome != 'success' || steps.web_changes.outputs.web == 'true'
         working-directory: Web
         run: npm ci
       - name: Typecheck
-        if: github.event_name != 'pull_request' || steps.web_changes.outputs.web == 'true'
+        if: github.event_name != 'pull_request' || steps.web_changes.outcome != 'success' || steps.web_changes.outputs.web == 'true'
         working-directory: Web
         run: npm run typecheck
       - name: Skip Web typecheck (no relevant changes)
-        if: github.event_name == 'pull_request' && steps.web_changes.outputs.web != 'true'
+        if: github.event_name == 'pull_request' && steps.web_changes.outcome == 'success' && steps.web_changes.outputs.web != 'true'
         run: echo "No Web changes detected; skipping Web typecheck."


### PR DESCRIPTION
## Linked issue

Closes #32 

## Summary

• Updated .github/workflows/ci.yml:1 to make CI much faster on most PRs:

  - Skips the expensive swift-build job on PRs that don’t touch Swift/SPM files (Sources/**, Package.swift,
    Package.resolved, .swiftpm/**) while still reporting a green required check.
  - Skips web-typecheck on PRs that don’t touch Web/** (runs on ubuntu-latest for speed).
  - Adds concurrency so new pushes cancel in-progress runs (prevents wasted 5–10 minute compiles).
  - Removes npm run build from the Swift job; instead creates Sources/Ticker/Resources + a tiny CI placeholder file
    so SwiftPM resource copying doesn’t fail.
