### PR TITLE
add barebone entitlements files

### DIFF
--- a/Sources/Ticker/Ticker.entitlements
+++ b/Sources/Ticker/Ticker.entitlements
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+

--- a/docs/MAC_ENTITLEMENTS.md
+++ b/docs/MAC_ENTITLEMENTS.md
@@ -2,6 +2,12 @@
 
 Before signing/notarization, document the entitlements Ticker actually needs.
 
+## Entitlements file (tracked)
+
+- `Sources/Ticker/Ticker.entitlements`
+
+Keep this file under version control so signing/notarization is reproducible and reviewable.
+
 ## Known capabilities to audit
 
 - **Accessibility API usage** (SelectionReaderService): user permission prompt and behavior
@@ -19,4 +25,3 @@ For each entitlement/capability:
 ## Goal
 
 Keep entitlements minimal and justified. Avoid requesting capabilities you don’t use.
-


### PR DESCRIPTION
## Linked issue

Closes #6 

## Summary

Create empty/barebone entitlement documents in:
  - Sources/Ticker/Ticker.entitlements:1 (currently empty/minimal)
  - docs/MAC_ENTITLEMENTS.md:1 updated to point to the tracked entitlements file

## Changelog

- [ ] User-facing change: added an entry to `CHANGELOG.md`
- [X] Not user-facing / docs-only

