### PR TITLE
B2 standardize data location application support migrate

### DIFF
--- a/Sources/Ticker/App/AssetSchemeHandler.swift
+++ b/Sources/Ticker/App/AssetSchemeHandler.swift
@@ -7,7 +7,9 @@ import UniformTypeIdentifiers
 final class AssetSchemeHandler: NSObject, WKURLSchemeHandler {
     /// Base directory for all assets - must match AssetService.assetsBaseDirectory
     private static var assetsBaseDirectory: URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
         return appSupport.appendingPathComponent("Ticker/assets", isDirectory: true)
     }
 

--- a/Sources/Ticker/App/AssetSchemeHandler.swift
+++ b/Sources/Ticker/App/AssetSchemeHandler.swift
@@ -7,8 +7,8 @@ import UniformTypeIdentifiers
 final class AssetSchemeHandler: NSObject, WKURLSchemeHandler {
     /// Base directory for all assets - must match AssetService.assetsBaseDirectory
     private static var assetsBaseDirectory: URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".config/ticker/assets", isDirectory: true)
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("Ticker/assets", isDirectory: true)
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {

--- a/Sources/Ticker/Services/AssetService.swift
+++ b/Sources/Ticker/Services/AssetService.swift
@@ -7,7 +7,8 @@ final class AssetService {
 
     /// Base directory for all stream assets
     private var assetsBaseDirectory: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
         return appSupport.appendingPathComponent("Ticker/assets", isDirectory: true)
     }
 

--- a/Sources/Ticker/Services/AssetService.swift
+++ b/Sources/Ticker/Services/AssetService.swift
@@ -7,8 +7,8 @@ final class AssetService {
 
     /// Base directory for all stream assets
     private var assetsBaseDirectory: URL {
-        let home = fileManager.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".config/ticker/assets", isDirectory: true)
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("Ticker/assets", isDirectory: true)
     }
 
     /// Get the assets directory for a specific stream

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -18,7 +18,9 @@ final class PersistenceService {
     }
 
     private static func databasePath() -> String {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
         let tickerDir = appSupport.appendingPathComponent("Ticker", isDirectory: true)
         return tickerDir.appendingPathComponent("ticker.db").path
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -18,8 +18,9 @@ final class PersistenceService {
     }
 
     private static func databasePath() -> String {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return "\(home)/.config/ticker/ticker.db"
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let tickerDir = appSupport.appendingPathComponent("Ticker", isDirectory: true)
+        return tickerDir.appendingPathComponent("ticker.db").path
     }
 
     // MARK: - Migrations


### PR DESCRIPTION
## Linked issue

Closes #7 

## Summary

• Made the force-unwrap fix and committed it on your b2-standardize-data-location-application-support-migrate branch.

  - Replaced .first! with a safe fallback to ~/Library/Application Support in:
      - Sources/Ticker/Services/PersistenceService.swift:20
      - Sources/Ticker/Services/AssetService.swift:9
      - Sources/Ticker/App/AssetSchemeHandler.swift:8
  - Commit: 134a3b2 (“fix: remove force unwraps for app support paths”)

  I did not delete any existing local data (since you said you’ll dump it anyway, but destructive deletes shouldn’t
  be hidden in a code change).

- [X ] Not user-facing / docs-only

