### PR TITLE
feat: backup DB before pending migrations

### DIFF
--- a/docs/DATA_MIGRATIONS.md
+++ b/docs/DATA_MIGRATIONS.md
@@ -14,7 +14,8 @@ Avoid:
 
 ### Before any schema migration
 - Copy the SQLite DB to a timestamped backup:
-  - Keep last N backups (e.g., 5–10)
+  - Create backups only when migrations are pending (avoid doing this on every launch)
+  - Keep last N backups (alpha default: 5)
   - Store alongside the DB under Application Support
 
 ### Before any location migration
@@ -31,4 +32,3 @@ Avoid:
 
 - Migrations should be forward-only, but releases must retain a downgrade path via appcast history.
 - Avoid breaking schema changes unless the migration is thoroughly tested on real data snapshots.
-


### PR DESCRIPTION
(cherry picked from commit b40d415ec740bd7ade54cb04162751b1392937a1)

## Linked issue

Closes #8 

## Summary

• Implemented “backup before pending migrations” with retention N=5.

  - Code: Sources/Ticker/Services/PersistenceService.swift:1
      - Detects pending migrations via migrator.hasCompletedMigrations(db) (after registering migrations).
      - If DB already existed and migrations are pending, creates a GRDB SQLite backup at ~/Library/Application
        Support/Ticker/backups/ticker-YYYYMMDD-HHmmss.db.
      - Rotates backups to keep the newest 5 (older ones deleted best-effort).
  - Docs: docs/DATA_MIGRATIONS.md:13 updated to reflect “only when pending” + N=5.
  - Commit: b40d415 (“feat: backup DB before pending migrations”)
