### PR TITLE
App bundle: add Xcode project + bundle web assets (Sparkle prerequisite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Decide whether to run Swift build
         id: swift_changes
         uses: dorny/paths-filter@v3
@@ -33,6 +35,7 @@ jobs:
               - 'Package.swift'
               - 'Package.resolved'
               - '.swiftpm/**'
+              - 'Ticker.xcodeproj/**'
       - name: Set build flag (push to main always builds)
         id: swift_should_build
         run: |
@@ -59,19 +62,27 @@ jobs:
         if: steps.swift_should_build.outputs.should_build == 'true'
         with:
           xcode-version: latest-stable
-      - name: Ensure resource directory exists (CI placeholder)
+      - uses: actions/setup-node@v4
         if: steps.swift_should_build.outputs.should_build == 'true'
-        run: |
-          mkdir -p Sources/Ticker/Resources
-          echo "CI placeholder resource (web assets built elsewhere)" > Sources/Ticker/Resources/.ci-placeholder
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Web/package-lock.json
+      - name: Build Web assets
+        if: steps.swift_should_build.outputs.should_build == 'true'
+        working-directory: Web
+        run: npm ci && npm run build
       - name: Build (no code signing)
         if: steps.swift_should_build.outputs.should_build == 'true'
-        run: >
-          xcodebuild build
-          -scheme Ticker
-          -destination 'platform=OS X'
-          -derivedDataPath .build/xcode
-          CODE_SIGNING_ALLOWED=NO
+        run: |
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          xcodebuild build \
+            -project Ticker.xcodeproj \
+            -scheme Ticker \
+            -destination 'platform=macOS' \
+            -derivedDataPath .build/xcode \
+            CODE_SIGNING_ALLOWED=NO \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
 
   web-typecheck:
     name: web-typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ Sources/Ticker/Resources/
 # IDE
 .vscode/
 .idea/
-*.xcodeproj/
-*.xcworkspace/
+
+# Xcode user-specific data (project itself is tracked)
+*.xcodeproj/xcuserdata/
+*.xcodeproj/project.xcworkspace/xcuserdata/
+*.xcworkspace/xcuserdata/
 
 # Environment
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,15 @@ The user will share this summary with GPT for review. Only commit after approval
 ## Commands
 
 ```bash
-xcodebuild build -scheme Ticker -destination 'platform=OS X' -derivedDataPath .build/xcode
+xcodebuild build -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath .build/xcode
 cd Web && npm run typecheck
 ```
 
 **Never run the app** — only build. User runs to avoid orphaned processes.
+
+> **iCloud Note**: If building from an iCloud-synced workspace causes codesign/xattr errors ("resource fork, Finder information, or similar detritus not allowed"), move the repo out of iCloud (preferred) or use `-derivedDataPath /tmp/ticker-xcode-build` as a workaround.
+
+> **Build Number**: For release builds, set `CURRENT_PROJECT_VERSION=$(git rev-list --count HEAD)` to get monotonic build numbers. CI does this automatically.
 
 ## Architecture
 

--- a/Sources/Ticker/Info.plist
+++ b/Sources/Ticker/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string></string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Sources/Ticker/Ticker.entitlements
+++ b/Sources/Ticker/Ticker.entitlements
@@ -4,4 +4,3 @@
 <dict>
 </dict>
 </plist>
-

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -7,12 +7,96 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1000001000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000001 /* AppDelegate.swift */; };
+		A1000001000000000002 /* AssetSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000002 /* AssetSchemeHandler.swift */; };
+		A1000001000000000003 /* BridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000003 /* BridgeService.swift */; };
+		A1000001000000000004 /* DroppableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000004 /* DroppableWebView.swift */; };
+		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
+		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
+		A1000001000000000007 /* QuickPanelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000007 /* QuickPanelManager.swift */; };
+		A1000001000000000008 /* QuickPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000008 /* QuickPanelView.swift */; };
+		A1000001000000000009 /* QuickPanelWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000009 /* QuickPanelWindow.swift */; };
+		A100000100000000000A /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000A /* Colors.swift */; };
+		A100000100000000000B /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000B /* Spacing.swift */; };
+		A100000100000000000C /* BridgePayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000C /* BridgePayloads.swift */; };
+		A100000100000000000D /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000D /* Cell.swift */; };
+		A100000100000000000E /* ProcessingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000E /* ProcessingConfig.swift */; };
+		A100000100000000000F /* SourceBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000000F /* SourceBinding.swift */; };
+		A1000001000000000010 /* SourceChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000010 /* SourceChunk.swift */; };
+		A1000001000000000011 /* SourceReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000011 /* SourceReference.swift */; };
+		A1000001000000000012 /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000012 /* Stream.swift */; };
+		A1000001000000000013 /* AIOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000013 /* AIOrchestrator.swift */; };
+		A1000001000000000014 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000014 /* AIService.swift */; };
+		A1000001000000000015 /* AnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000015 /* AnthropicService.swift */; };
+		A1000001000000000016 /* AssetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000016 /* AssetService.swift */; };
+		A1000001000000000017 /* ChunkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000017 /* ChunkingService.swift */; };
+		A1000001000000000018 /* DependencyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000018 /* DependencyService.swift */; };
+		A1000001000000000019 /* EmbeddingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000019 /* EmbeddingService.swift */; };
+		A100000100000000001A /* MLXClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001A /* MLXClassifier.swift */; };
+		A100000100000000001B /* PerplexityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001B /* PerplexityService.swift */; };
+		A100000100000000001C /* PersistenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001C /* PersistenceService.swift */; };
+		A100000100000000001D /* ProcessingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001D /* ProcessingService.swift */; };
+		A100000100000000001E /* Prompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001E /* Prompts.swift */; };
+		A100000100000000001F /* LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000001F /* LLMProvider.swift */; };
+		A1000001000000000020 /* QueryClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000020 /* QueryClassifier.swift */; };
+		A1000001000000000021 /* RAGMigrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000021 /* RAGMigrationService.swift */; };
+		A1000001000000000022 /* RetrievalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000022 /* RetrievalService.swift */; };
+		A1000001000000000023 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000023 /* SearchService.swift */; };
+		A1000001000000000024 /* SettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000024 /* SettingsService.swift */; };
+		A1000001000000000025 /* SourceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000025 /* SourceService.swift */; };
+		A1000001000000000026 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000026 /* ClipboardService.swift */; };
+		A1000001000000000027 /* CursorPositionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000027 /* CursorPositionService.swift */; };
+		A1000001000000000028 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000028 /* HotkeyService.swift */; };
+		A1000001000000000029 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000029 /* KeychainService.swift */; };
+		A100000100000000002A /* SelectionReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002A /* SelectionReaderService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ticker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ticker.entitlements; sourceTree = "<group>"; };
+		B1000001000000000001 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B1000001000000000002 /* AssetSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSchemeHandler.swift; sourceTree = "<group>"; };
+		B1000001000000000003 /* BridgeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeService.swift; sourceTree = "<group>"; };
+		B1000001000000000004 /* DroppableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroppableWebView.swift; sourceTree = "<group>"; };
+		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
+		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		B1000001000000000007 /* QuickPanelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPanelManager.swift; sourceTree = "<group>"; };
+		B1000001000000000008 /* QuickPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPanelView.swift; sourceTree = "<group>"; };
+		B1000001000000000009 /* QuickPanelWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickPanelWindow.swift; sourceTree = "<group>"; };
+		B100000100000000000A /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		B100000100000000000B /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
+		B100000100000000000C /* BridgePayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgePayloads.swift; sourceTree = "<group>"; };
+		B100000100000000000D /* Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
+		B100000100000000000E /* ProcessingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingConfig.swift; sourceTree = "<group>"; };
+		B100000100000000000F /* SourceBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceBinding.swift; sourceTree = "<group>"; };
+		B1000001000000000010 /* SourceChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceChunk.swift; sourceTree = "<group>"; };
+		B1000001000000000011 /* SourceReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceReference.swift; sourceTree = "<group>"; };
+		B1000001000000000012 /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
+		B1000001000000000013 /* AIOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIOrchestrator.swift; sourceTree = "<group>"; };
+		B1000001000000000014 /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
+		B1000001000000000015 /* AnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicService.swift; sourceTree = "<group>"; };
+		B1000001000000000016 /* AssetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetService.swift; sourceTree = "<group>"; };
+		B1000001000000000017 /* ChunkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkingService.swift; sourceTree = "<group>"; };
+		B1000001000000000018 /* DependencyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyService.swift; sourceTree = "<group>"; };
+		B1000001000000000019 /* EmbeddingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingService.swift; sourceTree = "<group>"; };
+		B100000100000000001A /* MLXClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXClassifier.swift; sourceTree = "<group>"; };
+		B100000100000000001B /* PerplexityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerplexityService.swift; sourceTree = "<group>"; };
+		B100000100000000001C /* PersistenceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceService.swift; sourceTree = "<group>"; };
+		B100000100000000001D /* ProcessingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingService.swift; sourceTree = "<group>"; };
+		B100000100000000001E /* Prompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompts.swift; sourceTree = "<group>"; };
+		B100000100000000001F /* LLMProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMProvider.swift; sourceTree = "<group>"; };
+		B1000001000000000020 /* QueryClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryClassifier.swift; sourceTree = "<group>"; };
+		B1000001000000000021 /* RAGMigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAGMigrationService.swift; sourceTree = "<group>"; };
+		B1000001000000000022 /* RetrievalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrievalService.swift; sourceTree = "<group>"; };
+		B1000001000000000023 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		B1000001000000000024 /* SettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsService.swift; sourceTree = "<group>"; };
+		B1000001000000000025 /* SourceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceService.swift; sourceTree = "<group>"; };
+		B1000001000000000026 /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
+		B1000001000000000027 /* CursorPositionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorPositionService.swift; sourceTree = "<group>"; };
+		B1000001000000000028 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
+		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,10 +137,116 @@
 		E8A1B2C3D4E5F6A7B8C9D103 /* Ticker */ = {
 			isa = PBXGroup;
 			children = (
+				G1000001000000000001 /* App */,
+				G1000001000000000002 /* Design */,
+				G1000001000000000003 /* Models */,
+				G1000001000000000004 /* Services */,
 				E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */,
 				E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */,
 			);
 			path = Ticker;
+			sourceTree = "<group>";
+		};
+		G1000001000000000001 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000001 /* AppDelegate.swift */,
+				B1000001000000000002 /* AssetSchemeHandler.swift */,
+				B1000001000000000003 /* BridgeService.swift */,
+				B1000001000000000004 /* DroppableWebView.swift */,
+				B1000001000000000005 /* WebViewManager.swift */,
+				G1000001000000000005 /* Onboarding */,
+				G1000001000000000006 /* QuickPanel */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		G1000001000000000002 /* Design */ = {
+			isa = PBXGroup;
+			children = (
+				B100000100000000000A /* Colors.swift */,
+				B100000100000000000B /* Spacing.swift */,
+			);
+			path = Design;
+			sourceTree = "<group>";
+		};
+		G1000001000000000003 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B100000100000000000C /* BridgePayloads.swift */,
+				B100000100000000000D /* Cell.swift */,
+				B100000100000000000E /* ProcessingConfig.swift */,
+				B100000100000000000F /* SourceBinding.swift */,
+				B1000001000000000010 /* SourceChunk.swift */,
+				B1000001000000000011 /* SourceReference.swift */,
+				B1000001000000000012 /* Stream.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		G1000001000000000004 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000013 /* AIOrchestrator.swift */,
+				B1000001000000000014 /* AIService.swift */,
+				B1000001000000000015 /* AnthropicService.swift */,
+				B1000001000000000016 /* AssetService.swift */,
+				B1000001000000000017 /* ChunkingService.swift */,
+				B1000001000000000018 /* DependencyService.swift */,
+				B1000001000000000019 /* EmbeddingService.swift */,
+				B100000100000000001A /* MLXClassifier.swift */,
+				B100000100000000001B /* PerplexityService.swift */,
+				B100000100000000001C /* PersistenceService.swift */,
+				B100000100000000001D /* ProcessingService.swift */,
+				B100000100000000001E /* Prompts.swift */,
+				B1000001000000000020 /* QueryClassifier.swift */,
+				B1000001000000000021 /* RAGMigrationService.swift */,
+				B1000001000000000022 /* RetrievalService.swift */,
+				B1000001000000000023 /* SearchService.swift */,
+				B1000001000000000024 /* SettingsService.swift */,
+				B1000001000000000025 /* SourceService.swift */,
+				G1000001000000000007 /* Providers */,
+				G1000001000000000008 /* System */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		G1000001000000000005 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000006 /* OnboardingView.swift */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		G1000001000000000006 /* QuickPanel */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000007 /* QuickPanelManager.swift */,
+				B1000001000000000008 /* QuickPanelView.swift */,
+				B1000001000000000009 /* QuickPanelWindow.swift */,
+			);
+			path = QuickPanel;
+			sourceTree = "<group>";
+		};
+		G1000001000000000007 /* Providers */ = {
+			isa = PBXGroup;
+			children = (
+				B100000100000000001F /* LLMProvider.swift */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		G1000001000000000008 /* System */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000026 /* ClipboardService.swift */,
+				B1000001000000000027 /* CursorPositionService.swift */,
+				B1000001000000000028 /* HotkeyService.swift */,
+				B1000001000000000029 /* KeychainService.swift */,
+				B100000100000000002A /* SelectionReaderService.swift */,
+			);
+			path = System;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -127,6 +317,48 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1000001000000000001 /* AppDelegate.swift in Sources */,
+				A1000001000000000002 /* AssetSchemeHandler.swift in Sources */,
+				A1000001000000000003 /* BridgeService.swift in Sources */,
+				A1000001000000000004 /* DroppableWebView.swift in Sources */,
+				A1000001000000000005 /* WebViewManager.swift in Sources */,
+				A1000001000000000006 /* OnboardingView.swift in Sources */,
+				A1000001000000000007 /* QuickPanelManager.swift in Sources */,
+				A1000001000000000008 /* QuickPanelView.swift in Sources */,
+				A1000001000000000009 /* QuickPanelWindow.swift in Sources */,
+				A100000100000000000A /* Colors.swift in Sources */,
+				A100000100000000000B /* Spacing.swift in Sources */,
+				A100000100000000000C /* BridgePayloads.swift in Sources */,
+				A100000100000000000D /* Cell.swift in Sources */,
+				A100000100000000000E /* ProcessingConfig.swift in Sources */,
+				A100000100000000000F /* SourceBinding.swift in Sources */,
+				A1000001000000000010 /* SourceChunk.swift in Sources */,
+				A1000001000000000011 /* SourceReference.swift in Sources */,
+				A1000001000000000012 /* Stream.swift in Sources */,
+				A1000001000000000013 /* AIOrchestrator.swift in Sources */,
+				A1000001000000000014 /* AIService.swift in Sources */,
+				A1000001000000000015 /* AnthropicService.swift in Sources */,
+				A1000001000000000016 /* AssetService.swift in Sources */,
+				A1000001000000000017 /* ChunkingService.swift in Sources */,
+				A1000001000000000018 /* DependencyService.swift in Sources */,
+				A1000001000000000019 /* EmbeddingService.swift in Sources */,
+				A100000100000000001A /* MLXClassifier.swift in Sources */,
+				A100000100000000001B /* PerplexityService.swift in Sources */,
+				A100000100000000001C /* PersistenceService.swift in Sources */,
+				A100000100000000001D /* ProcessingService.swift in Sources */,
+				A100000100000000001E /* Prompts.swift in Sources */,
+				A100000100000000001F /* LLMProvider.swift in Sources */,
+				A1000001000000000020 /* QueryClassifier.swift in Sources */,
+				A1000001000000000021 /* RAGMigrationService.swift in Sources */,
+				A1000001000000000022 /* RetrievalService.swift in Sources */,
+				A1000001000000000023 /* SearchService.swift in Sources */,
+				A1000001000000000024 /* SettingsService.swift in Sources */,
+				A1000001000000000025 /* SourceService.swift in Sources */,
+				A1000001000000000026 /* ClipboardService.swift in Sources */,
+				A1000001000000000027 /* CursorPositionService.swift in Sources */,
+				A1000001000000000028 /* HotkeyService.swift in Sources */,
+				A1000001000000000029 /* KeychainService.swift in Sources */,
+				A100000100000000002A /* SelectionReaderService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C1000001000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000001 /* GRDB */; };
+		C1000001000000000002 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000002 /* MLXLLM */; };
 		A1000001000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000001 /* AppDelegate.swift */; };
 		A1000001000000000002 /* AssetSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000002 /* AssetSchemeHandler.swift */; };
 		A1000001000000000003 /* BridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000003 /* BridgeService.swift */; };
@@ -104,6 +106,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1000001000000000001 /* GRDB in Frameworks */,
+				C1000001000000000002 /* MLXLLM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -265,6 +269,10 @@
 			dependencies = (
 			);
 			name = Ticker;
+			packageProductDependencies = (
+				D1000001000000000001 /* GRDB */,
+				D1000001000000000002 /* MLXLLM */,
+			);
 			productName = Ticker;
 			productReference = E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */;
 			productType = "com.apple.product-type.application";
@@ -293,6 +301,10 @@
 				Base,
 			);
 			mainGroup = E8A1B2C3D4E5F6A7B8C9D100;
+			packageReferences = (
+				P1000001000000000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */,
+				P1000001000000000002 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+			);
 			productRefGroup = E8A1B2C3D4E5F6A7B8C9D102 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -553,6 +565,38 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		P1000001000000000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/groue/GRDB.swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.24.0;
+			};
+		};
+		P1000001000000000002 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.29.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D1000001000000000001 /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = P1000001000000000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */;
+			productName = GRDB;
+		};
+		D1000001000000000002 /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = P1000001000000000002 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLLM;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E8A1B2C3D4E5F6A7B8C9D001 /* Project object */;
 }

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C1000001000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000001 /* GRDB */; };
 		C1000001000000000002 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000002 /* MLXLLM */; };
+		R1000001000000000001 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F1000001000000000001 /* Resources */; };
 		A1000001000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000001 /* AppDelegate.swift */; };
 		A1000001000000000002 /* AssetSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000002 /* AssetSchemeHandler.swift */; };
 		A1000001000000000003 /* BridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000003 /* BridgeService.swift */; };
@@ -99,6 +100,7 @@
 		B1000001000000000028 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
 		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
+		F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 				G1000001000000000002 /* Design */,
 				G1000001000000000003 /* Models */,
 				G1000001000000000004 /* Services */,
+				F1000001000000000001 /* Resources */,
 				E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */,
 				E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */,
 			);
@@ -260,6 +263,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */;
 			buildPhases = (
+				S1000001000000000001 /* Build Web Assets */,
 				E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */,
 				E8A1B2C3D4E5F6A7B8C9D0F1 /* Frameworks */,
 				E8A1B2C3D4E5F6A7B8C9D0F2 /* Resources */,
@@ -319,10 +323,36 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				R1000001000000000001 /* Resources in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		S1000001000000000001 /* Build Web Assets */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Web/package-lock.json",
+				"$(SRCROOT)/Web/vite.config.ts",
+				"$(SRCROOT)/Web/tsconfig.json",
+			);
+			name = "Build Web Assets";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Sources/Ticker/Resources/index.html",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"$SRCROOT/Web\" && npm ci && npm run build\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */ = {
@@ -511,6 +541,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				MARKETING_VERSION = 2025.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.ticker.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -526,6 +557,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Sources/Ticker/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -1,0 +1,326 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ticker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ticker.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E8A1B2C3D4E5F6A7B8C9D0F1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E8A1B2C3D4E5F6A7B8C9D100 = {
+			isa = PBXGroup;
+			children = (
+				E8A1B2C3D4E5F6A7B8C9D101 /* Sources */,
+				E8A1B2C3D4E5F6A7B8C9D102 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E8A1B2C3D4E5F6A7B8C9D101 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				E8A1B2C3D4E5F6A7B8C9D103 /* Ticker */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		E8A1B2C3D4E5F6A7B8C9D102 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E8A1B2C3D4E5F6A7B8C9D103 /* Ticker */ = {
+			isa = PBXGroup;
+			children = (
+				E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */,
+				E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */,
+			);
+			path = Ticker;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */;
+			buildPhases = (
+				E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */,
+				E8A1B2C3D4E5F6A7B8C9D0F1 /* Frameworks */,
+				E8A1B2C3D4E5F6A7B8C9D0F2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Ticker;
+			productName = Ticker;
+			productReference = E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E8A1B2C3D4E5F6A7B8C9D001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					E8A1B2C3D4E5F6A7B8C9D0E0 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D004 /* Build configuration list for PBXProject "Ticker" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E8A1B2C3D4E5F6A7B8C9D100;
+			productRefGroup = E8A1B2C3D4E5F6A7B8C9D102 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E8A1B2C3D4E5F6A7B8C9D0F2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E8A1B2C3D4E5F6A7B8C9D005 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E8A1B2C3D4E5F6A7B8C9D006 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		E8A1B2C3D4E5F6A7B8C9D111 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Sources/Ticker/Ticker.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Sources/Ticker/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMainNibFile = "";
+				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 2025.12.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.ticker.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E8A1B2C3D4E5F6A7B8C9D112 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Sources/Ticker/Ticker.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Sources/Ticker/Info.plist;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMainNibFile = "";
+				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 2025.12.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.ticker.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E8A1B2C3D4E5F6A7B8C9D004 /* Build configuration list for PBXProject "Ticker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8A1B2C3D4E5F6A7B8C9D005 /* Debug */,
+				E8A1B2C3D4E5F6A7B8C9D006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8A1B2C3D4E5F6A7B8C9D111 /* Debug */,
+				E8A1B2C3D4E5F6A7B8C9D112 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E8A1B2C3D4E5F6A7B8C9D001 /* Project object */;
+}

--- a/Ticker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Ticker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Ticker.xcodeproj/xcshareddata/xcschemes/Ticker.xcscheme
+++ b/Ticker.xcodeproj/xcshareddata/xcschemes/Ticker.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8A1B2C3D4E5F6A7B8C9D0E0"
+               BuildableName = "Ticker.app"
+               BlueprintName = "Ticker"
+               ReferencedContainer = "container:Ticker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8A1B2C3D4E5F6A7B8C9D0E0"
+            BuildableName = "Ticker.app"
+            BlueprintName = "Ticker"
+            ReferencedContainer = "container:Ticker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8A1B2C3D4E5F6A7B8C9D0E0"
+            BuildableName = "Ticker.app"
+            BlueprintName = "Ticker"
+            ReferencedContainer = "container:Ticker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
PR description

  Closes #38 

  ## Summary
  - Adds a committed `Ticker.xcodeproj` macOS App target so builds produce a real `Ticker.app` bundle (required for Sparkle, signing, notarization).
  - Adds committed `Sources/Ticker/Info.plist` and uses `io.ticker.app` bundle id with `MARKETING_VERSION=2025.12.0`.
  - Wires all Swift sources into the app target (keeps existing `@main` entrypoint).
  - Adds Xcode SPM dependencies for `GRDB` and `MLXLLM`.
  - Bundles Web assets into the app via a build phase (`npm ci && npm run build`) and copies `Sources/Ticker/Resources` into the app bundle.
  - Updates CI + `CLAUDE.md` to build via `-project Ticker.xcodeproj` and to build Web assets in CI.
  - Uses monotonic build numbers via `CURRENT_PROJECT_VERSION=$(git rev-list --count HEAD)` in CI.

  ## How to verify
  - [ ] `xcodebuild -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' build`
  - [ ] Confirm `Ticker.app/Contents/MacOS/Ticker` exists (Mach-O)
  - [ ] Confirm `Ticker.app/Contents/Info.plist` has:
        - `CFBundleIdentifier = io.ticker.app`
        - `CFBundleShortVersionString = 2025.12.0`
        - `CFBundleVersion` is monotonic (commit count in CI)
  - [ ] Confirm `Ticker.app/Contents/Resources/Resources/index.html` exists (Web UI bundled)

  ## Compatibility / migrations
  - Data migration needed? No
  - Bridge/proxy contract changes? No
  - Rollback plan: revert PR (pre-Sparkle; no user distribution yet)

  ## Notes
  - iCloud-synced workspaces can cause codesign/xattr issues; preferred fix is to move the repo out of iCloud (see `CLAUDE.md`).
  - Sparkle work remains blocked until this PR lands (see `docs/SPARKLE_2_ALPHA_CHANNEL.md`).

  ## Changelog
  - [ ] User-facing change: added an entry to `CHANGELOG.md`
  - [x] Not user-facing / build-system + packaging

