### PR TITLE
feat(D1+D2): Device key validation + usage UI

### DIFF
--- a/Sources/Ticker/Services/DeviceKeyService.swift
+++ b/Sources/Ticker/Services/DeviceKeyService.swift
@@ -1,0 +1,513 @@
+import Foundation
+
+// MARK: - Auth State
+
+/// Proxy authentication state machine
+enum ProxyAuthState: String, Codable {
+    case unregistered           // No key entered
+    case validating             // Currently validating key with server
+    case active                 // Key validated successfully
+    case blockedInvalid         // Key invalid or expired
+    case blockedRevoked         // Key revoked by admin
+    case blockedBoundElsewhere  // Key bound to different device
+    case degradedOffline        // Network unavailable, cached key present
+
+    var isUsable: Bool {
+        switch self {
+        case .active, .degradedOffline:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var requiresGate: Bool {
+        switch self {
+        case .active, .degradedOffline:
+            return false
+        default:
+            return true
+        }
+    }
+}
+
+// MARK: - Response Types
+
+/// Response from proxy `/v1/auth/validate` endpoint
+struct ProxyAuthValidationResponse: Codable {
+    let supportId: String
+    let boundDeviceId: String?
+    let limits: Limits?
+    let usage: Usage?
+
+    struct Limits: Codable {
+        let reqsPerMin: Int?
+        let tokensPerDay: Int?
+        let tokensPerMonth: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case reqsPerMin = "reqs_per_min"
+            case tokensPerDay = "tokens_per_day"
+            case tokensPerMonth = "tokens_per_month"
+        }
+    }
+
+    struct Usage: Codable {
+        let reqsThisMinute: Int?
+        let tokensToday: Int?
+        let tokensThisMonth: Int?
+        let dayResetAt: String?
+        let monthResetAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case reqsThisMinute = "reqs_this_minute"
+            case tokensToday = "tokens_today"
+            case tokensThisMonth = "tokens_this_month"
+            case dayResetAt = "day_reset_at"
+            case monthResetAt = "month_reset_at"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case supportId = "support_id"
+        case boundDeviceId = "bound_device_id"
+        case limits, usage
+    }
+}
+
+/// Proxy error response structure
+struct ProxyErrorResponse: Codable {
+    let error: ErrorDetail
+
+    struct ErrorDetail: Codable {
+        let code: String
+        let message: String
+    }
+}
+
+// MARK: - Stored Data
+
+/// Stored device data (non-sensitive fields can be cached to disk)
+struct DeviceKeyData: Codable {
+    var deviceId: String
+    var deviceKey: String?
+    var supportId: String?
+    var validatedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+        case deviceKey = "device_key"
+        case supportId = "support_id"
+        case validatedAt = "validated_at"
+    }
+}
+
+// MARK: - Errors
+
+/// Proxy error codes (from proxy API)
+enum ProxyErrorCode: String {
+    case invalidKey = "invalid_key"
+    case keyRevoked = "key_revoked"
+    case keyBoundElsewhere = "key_bound_elsewhere"
+    case rateLimited = "rate_limited"
+    case unknown
+
+    init(rawValue: String) {
+        switch rawValue {
+        case "invalid_key": self = .invalidKey
+        case "key_revoked": self = .keyRevoked
+        case "key_bound_elsewhere": self = .keyBoundElsewhere
+        case "rate_limited": self = .rateLimited
+        default: self = .unknown
+        }
+    }
+}
+
+/// Errors from device key operations
+enum DeviceKeyError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case invalidKey
+    case keyRevoked
+    case boundToOtherDevice
+    case rateLimited
+    case serverError(Int)
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid proxy URL"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .invalidKey:
+            return "Invalid or expired device key"
+        case .keyRevoked:
+            return "This device key has been revoked. Contact support for assistance."
+        case .boundToOtherDevice:
+            return "This key is bound to a different device. Contact support for assistance."
+        case .rateLimited:
+            return "Too many requests. Please try again in a minute."
+        case .serverError(let code):
+            return "Server error (\(code)). Please try again later."
+        case .networkError:
+            return "Unable to reach server. Check your internet connection."
+        }
+    }
+
+    /// Maps error to auth state, or nil for non-auth-fatal errors (like rate limiting)
+    var authState: ProxyAuthState? {
+        switch self {
+        case .invalidKey: return .blockedInvalid
+        case .keyRevoked: return .blockedRevoked
+        case .boundToOtherDevice: return .blockedBoundElsewhere
+        case .networkError: return .degradedOffline
+        case .rateLimited, .serverError, .invalidURL, .invalidResponse:
+            // These are transient/non-auth errors - don't change auth state
+            return nil
+        }
+    }
+}
+
+// MARK: - Service
+
+/// Manages device key storage and validation against Ticker-Proxy
+actor DeviceKeyService {
+    static let shared = DeviceKeyService()
+
+    // MARK: - State
+
+    private var cachedData: DeviceKeyData?
+    private(set) var currentState: ProxyAuthState = .unregistered
+
+    /// Cached limits from last validation
+    private var cachedLimits: ProxyAuthValidationResponse.Limits?
+    /// Cached usage from last validation
+    private var cachedUsage: ProxyAuthValidationResponse.Usage?
+
+    /// Callback invoked when auth state changes (called on MainActor)
+    /// Note: nonisolated to allow setting from outside actor context
+    nonisolated(unsafe) var onStateChange: ((ProxyAuthState) -> Void)?
+
+    // MARK: - Configuration
+
+    /// Proxy base URL - can be overridden via TICKER_PROXY_URL env var or UserDefaults
+    private var proxyBaseURL: String {
+        // Check environment variable first (for debugging)
+        if let envURL = ProcessInfo.processInfo.environment["TICKER_PROXY_URL"], !envURL.isEmpty {
+            return envURL
+        }
+        // Check UserDefaults (for dev builds)
+        if let defaultsURL = UserDefaults.standard.string(forKey: "TickerProxyURL"), !defaultsURL.isEmpty {
+            return defaultsURL
+        }
+        // Production default
+        return "https://ticker-proxy.fly.dev"
+    }
+
+    private var fileURL: URL {
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        let tickerDir = appSupport.appendingPathComponent("Ticker", isDirectory: true)
+        return tickerDir.appendingPathComponent("device.json")
+    }
+
+    // MARK: - Initialization
+
+    /// Initialize and determine initial state based on stored data
+    func initialize() async {
+        let data = loadOrCreate()
+
+        if data.deviceKey != nil {
+            // Have a cached key - need to validate with server
+            await revalidate()
+        } else {
+            await setState(.unregistered)
+        }
+    }
+
+    // MARK: - State Management
+
+    private func setState(_ newState: ProxyAuthState) async {
+        guard newState != currentState else { return }
+        currentState = newState
+
+        // Notify on main actor
+        await MainActor.run {
+            onStateChange?(newState)
+        }
+    }
+
+    // MARK: - Public API (canonical bridge names)
+
+    /// Load current proxy auth state - returns state + support_id if available
+    func loadProxyAuth() -> (state: ProxyAuthState, supportId: String?, deviceId: String) {
+        let data = loadOrCreate()
+        return (
+            state: currentState,
+            supportId: data.supportId,
+            deviceId: data.deviceId
+        )
+    }
+
+    /// Get cached limits and usage from last validation
+    func getLimitsAndUsage() -> (limits: ProxyAuthValidationResponse.Limits?, usage: ProxyAuthValidationResponse.Usage?) {
+        return (limits: cachedLimits, usage: cachedUsage)
+    }
+
+    /// Set and validate a device key
+    func setProxyDeviceKey(_ key: String) async throws -> ProxyAuthValidationResponse {
+        await setState(.validating)
+
+        do {
+            let response = try await validateWithServer(key: key)
+
+            // Store validated key
+            var data = loadOrCreate()
+            data.deviceKey = key
+            data.supportId = response.supportId
+            data.validatedAt = Date()
+            save(data)
+
+            // Cache limits and usage
+            cachedLimits = response.limits
+            cachedUsage = response.usage
+
+            await setState(.active)
+            return response
+
+        } catch let error as DeviceKeyError {
+            // For first-time key entry:
+            // - Network errors: stay unregistered (no cached key to fall back on)
+            // - Rate limit/transient errors: stay unregistered, let user retry
+            // - Auth errors (invalid/revoked/bound): transition to blocked state
+            if let newState = error.authState {
+                // Only network errors can go to degradedOffline, but not during first entry
+                if case .networkError = error {
+                    await setState(.unregistered)
+                } else {
+                    await setState(newState)
+                }
+            } else {
+                // Transient error (rate limit, server error) - stay unregistered
+                await setState(.unregistered)
+            }
+            throw error
+        } catch {
+            await setState(.blockedInvalid)
+            throw error
+        }
+    }
+
+    /// Clear stored key
+    func clearProxyDeviceKey() async {
+        var data = loadOrCreate()
+        data.deviceKey = nil
+        data.supportId = nil
+        data.validatedAt = nil
+        save(data)
+        await setState(.unregistered)
+    }
+
+    /// Re-validate cached key with server (called on startup or when needed)
+    func revalidate() async {
+        let data = loadOrCreate()
+        guard let key = data.deviceKey else {
+            await setState(.unregistered)
+            return
+        }
+
+        await setState(.validating)
+
+        do {
+            let response = try await validateWithServer(key: key)
+
+            // Update cached data
+            var updatedData = data
+            updatedData.supportId = response.supportId
+            updatedData.validatedAt = Date()
+            save(updatedData)
+
+            // Cache limits and usage
+            cachedLimits = response.limits
+            cachedUsage = response.usage
+
+            await setState(.active)
+
+        } catch let error as DeviceKeyError {
+            // Handle based on error type:
+            // - Network error: degraded offline (cached key still usable)
+            // - Auth errors (invalid/revoked/bound): clear key, transition to blocked
+            // - Transient errors (rate limit, server error): stay active if already active
+            if let newState = error.authState {
+                if case .degradedOffline = newState {
+                    // Network error - allow degraded mode
+                    await setState(.degradedOffline)
+                } else {
+                    // Auth error - key is invalid/revoked/bound elsewhere, clear it
+                    await clearProxyDeviceKey()
+                    await setState(newState)
+                }
+            } else {
+                // Transient error (rate limit, server error) - keep current state
+                // If we were validating from active, go back to active
+                // If we were validating from unregistered, stay unregistered
+                // For simplicity, just go back to active since we have a cached key
+                await setState(.active)
+            }
+        } catch {
+            await setState(.blockedInvalid)
+        }
+    }
+
+    /// Get credentials for proxy requests (used by other services)
+    func getCredentials() -> (deviceId: String, deviceKey: String)? {
+        guard currentState.isUsable else { return nil }
+        let data = loadOrCreate()
+        guard let key = data.deviceKey else { return nil }
+        return (data.deviceId, key)
+    }
+
+    /// Get required headers for proxy requests
+    func getProxyHeaders() -> [String: String]? {
+        guard let credentials = getCredentials() else { return nil }
+        return [
+            "Authorization": "Bearer \(credentials.deviceKey)",
+            "X-Ticker-Device-Id": credentials.deviceId,
+            "X-Ticker-App-Version": appVersion(),
+            "X-Ticker-Platform": "macOS",
+            "X-Ticker-OS-Version": osVersion()
+        ]
+    }
+
+    // MARK: - Private Implementation
+
+    /// Load existing data or create new with fresh device_id
+    private func loadOrCreate() -> DeviceKeyData {
+        if let cached = cachedData {
+            return cached
+        }
+
+        let fileManager = FileManager.default
+
+        // Ensure directory exists
+        let dir = fileURL.deletingLastPathComponent()
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // Try to load existing
+        if let data = try? Data(contentsOf: fileURL) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            if let decoded = try? decoder.decode(DeviceKeyData.self, from: data) {
+                cachedData = decoded
+                return decoded
+            }
+        }
+
+        // Create new with fresh device_id
+        let newData = DeviceKeyData(
+            deviceId: UUID().uuidString,
+            deviceKey: nil,
+            supportId: nil,
+            validatedAt: nil
+        )
+        save(newData)
+        return newData
+    }
+
+    /// Save device data to disk atomically
+    private func save(_ data: DeviceKeyData) {
+        cachedData = data
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .prettyPrinted
+
+        guard let encoded = try? encoder.encode(data) else { return }
+
+        // Write atomically to avoid corruption on crash
+        let tempURL = fileURL.appendingPathExtension("tmp")
+        do {
+            try encoded.write(to: tempURL, options: .atomic)
+            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        } catch {
+            // Fallback: try direct write
+            try? encoded.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    /// Validate key with server
+    private func validateWithServer(key: String) async throws -> ProxyAuthValidationResponse {
+        let data = loadOrCreate()
+
+        guard let url = URL(string: "\(proxyBaseURL)/v1/auth/validate") else {
+            throw DeviceKeyError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.setValue(data.deviceId, forHTTPHeaderField: "X-Ticker-Device-Id")
+        request.setValue(appVersion(), forHTTPHeaderField: "X-Ticker-App-Version")
+        request.setValue("macOS", forHTTPHeaderField: "X-Ticker-Platform")
+        request.setValue(osVersion(), forHTTPHeaderField: "X-Ticker-OS-Version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "X-Ticker-Request-Id")
+
+        let responseData: Data
+        let response: URLResponse
+        do {
+            (responseData, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw DeviceKeyError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw DeviceKeyError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            let validation = try decoder.decode(ProxyAuthValidationResponse.self, from: responseData)
+
+            // Check if bound to different device
+            if let boundDeviceId = validation.boundDeviceId, boundDeviceId != data.deviceId {
+                throw DeviceKeyError.boundToOtherDevice
+            }
+
+            return validation
+
+        case 401:
+            // Parse structured error code
+            if let errorResponse = try? JSONDecoder().decode(ProxyErrorResponse.self, from: responseData) {
+                switch ProxyErrorCode(rawValue: errorResponse.error.code) {
+                case .keyRevoked:
+                    throw DeviceKeyError.keyRevoked
+                case .keyBoundElsewhere:
+                    throw DeviceKeyError.boundToOtherDevice
+                default:
+                    throw DeviceKeyError.invalidKey
+                }
+            }
+            throw DeviceKeyError.invalidKey
+
+        case 429:
+            throw DeviceKeyError.rateLimited
+
+        default:
+            throw DeviceKeyError.serverError(httpResponse.statusCode)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func appVersion() -> String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    private func osVersion() -> String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+}

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A1000001000000000028 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000028 /* HotkeyService.swift */; };
 		A1000001000000000029 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000029 /* KeychainService.swift */; };
 		A100000100000000002A /* SelectionReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002A /* SelectionReaderService.swift */; };
+		A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -103,6 +104,7 @@
 		B1000001000000000028 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
 		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
+		B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
 		F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -205,6 +207,7 @@
 				B1000001000000000016 /* AssetService.swift */,
 				B1000001000000000017 /* ChunkingService.swift */,
 				B1000001000000000018 /* DependencyService.swift */,
+				B100000100000000002C /* DeviceKeyService.swift */,
 				B1000001000000000019 /* EmbeddingService.swift */,
 				B100000100000000001A /* MLXClassifier.swift */,
 				B100000100000000001B /* PerplexityService.swift */,
@@ -409,6 +412,7 @@
 				A1000001000000000028 /* HotkeyService.swift in Sources */,
 				A1000001000000000029 /* KeychainService.swift in Sources */,
 				A100000100000000002A /* SelectionReaderService.swift in Sources */,
+				A100000100000000002C /* DeviceKeyService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1810,6 +1810,202 @@ body {
   line-height: var(--line-height-relaxed);
 }
 
+.settings-error {
+  font-size: var(--font-size-sm);
+  color: var(--color-error);
+  margin: var(--spacing-xs) 0 0;
+}
+
+/* Device Key Section */
+.settings-device-key-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.settings-device-key-connected {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.settings-device-key-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: rgba(22, 163, 74, 0.1);
+  color: var(--color-success);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(22, 163, 74, 0.2);
+}
+
+.settings-device-key-support-id {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.settings-device-key-support-id code {
+  font-family: 'SF Mono', monospace;
+  background: var(--color-surface);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+}
+
+.settings-disconnect-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  align-self: flex-start;
+}
+
+.settings-disconnect-btn:hover {
+  border-color: var(--color-error);
+  color: var(--color-error);
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.settings-device-key-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+/* Auth Gate */
+.auth-gate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--spacing-xl);
+  background: var(--color-background);
+}
+
+.auth-gate-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 400px;
+}
+
+.auth-gate-icon {
+  font-size: 48px;
+  margin-bottom: var(--spacing-md);
+}
+
+.auth-gate-content h1 {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 var(--spacing-sm);
+}
+
+.auth-gate-content p {
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-lg);
+  line-height: var(--line-height-relaxed);
+}
+
+.auth-gate-content .loading-spinner {
+  margin-bottom: var(--spacing-md);
+}
+
+.auth-gate-content .primary-button {
+  min-width: 180px;
+}
+
+/* Usage Display */
+.usage-display {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.usage-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.usage-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.usage-label {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.usage-badge {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.usage-badge--warning {
+  background: rgba(202, 138, 4, 0.15);
+  color: var(--color-warning);
+}
+
+.usage-badge--error {
+  background: rgba(220, 38, 38, 0.15);
+  color: var(--color-error);
+}
+
+.usage-bar {
+  height: 8px;
+  background: var(--color-surface);
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+
+.usage-bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.usage-bar--warning .usage-bar-fill {
+  background: var(--color-warning);
+}
+
+.usage-bar--error .usage-bar-fill {
+  background: var(--color-error);
+}
+
+.usage-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.usage-count {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-family: 'SF Mono', monospace;
+}
+
+.usage-reset {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
 .settings-classifier-status {
   font-size: var(--font-size-sm);
   margin: var(--spacing-xs) 0 0;


### PR DESCRIPTION
## Linked Issues
Closes #19 
Closes #20 

D1 — Key Entry + Validation:
- Add DeviceKeyService actor for device key storage and proxy validation
- Store device key in ~/Library/Application Support/Ticker/device.json
- ProxyAuthState enum with full state machine (active, validating, blocked*, degradedOffline)
- Auth gate in App.tsx blocks main UI until key validated
- Server revalidation on startup via initialize()
- Bridge handlers: loadProxyAuth (pure read), setProxyDeviceKey, clearProxyDeviceKey, refreshProxyAuth

D2 — Usage UI + Limit Messaging:
- Display daily/monthly token usage with progress bars in Settings
- Warning state at 80%+, error state when limit reached
- Server-provided reset timestamps (day_reset_at, month_reset_at) with client fallback
- Proper snake_case CodingKeys for Limits and Usage structs

Fixes:
- loadProxyAuth is pure cached read (no network call)
- refreshProxyAuth triggers server revalidation explicitly
- 429 rate limit is non-auth-fatal (stays active if cached key exists)
- Consistent response shape across all proxy auth handlers
