### PR TITLE
feat(D4+D5): Request correlation + Testing section

### DIFF
--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -101,6 +101,9 @@ final class ProxyLLMService: LLMProvider {
             // Extract request ID from response (proxy may override)
             let responseRequestId = httpResponse.value(forHTTPHeaderField: "X-Ticker-Request-Id") ?? requestId
 
+            // Record request ID for support bundle (D4)
+            await deviceKeyService.recordRequestId(responseRequestId, endpoint: "llm")
+
             // Handle non-200 responses
             if httpResponse.statusCode != 200 {
                 // Extract Retry-After header if present (for rate limits)

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -2733,6 +2733,170 @@ body {
   opacity: 0.8;
 }
 
+/* Feedback Form (D5) */
+.settings-feedback-type {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.settings-feedback-type button {
+  flex: 1;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.settings-feedback-type button:hover {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+}
+
+.settings-feedback-type button.active {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.settings-feedback-title {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.settings-feedback-title:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.settings-feedback-desc {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  resize: vertical;
+  min-height: 80px;
+  margin-bottom: var(--spacing-sm);
+  font-family: inherit;
+}
+
+.settings-feedback-desc:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.settings-screenshot-drop {
+  width: 100%;
+  min-height: 80px;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-md);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.settings-screenshot-drop:hover,
+.settings-screenshot-drop:focus {
+  border-color: var(--color-accent);
+  outline: none;
+}
+
+.settings-screenshot-preview {
+  position: relative;
+  padding: var(--spacing-sm);
+}
+
+.settings-screenshot-preview img {
+  max-width: 100%;
+  max-height: 150px;
+  border-radius: var(--radius-xs);
+}
+
+.settings-screenshot-remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-error);
+  color: white;
+  border: none;
+  border-radius: var(--radius-xs);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+
+.settings-screenshot-remove:hover {
+  opacity: 0.9;
+}
+
+.settings-feedback-submit {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.settings-feedback-submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.settings-feedback-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings-success {
+  color: var(--color-success, #22c55e);
+  font-size: var(--font-size-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.settings-success code {
+  background: var(--color-surface);
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  font-family: var(--font-mono);
+}
+
+.settings-support-bundle-btn {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.settings-support-bundle-btn:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
+}
+
 /* ==================== Dark Mode ==================== */
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary

- **D4**: Request ID ring buffer (last 50 entries) stored in memory, included in support bundle for troubleshooting
- **D5**: Testing section in Settings with bug/feature feedback forms, optional screenshot attachment upload (drag/drop or paste), and "Copy Support Bundle" button
- Response request IDs recorded from `X-Ticker-Request-Id` header (not local UUID)
- Auth state revalidated on 401 errors in feedback/attachment flows
- 10MB attachment limit enforced client-side (matches proxy OpenAPI spec)
- MIME type preserved for screenshots
- `related_request_id` included in feedback for triage correlation
- Better error mapping: 403 (forbidden), 404 (not found), 413 (payload too large)

## Files Changed

| File | Changes |
|------|---------|
| `DeviceKeyService.swift` | Request ID buffer, support bundle, feedback submission with 3-step attachment upload |
| `ProxyLLMService.swift` | Record request IDs after each LLM call |
| `WebViewManager.swift` | Bridge handlers for `submitFeedback`, `getSupportBundle` |
| `Settings.tsx` | Testing section UI with forms, drag/drop zone, support bundle button |
| `index.css` | Feedback form styles |

## Test plan

- [ ] Settings → Testing section visible
- [ ] Bug report form submits successfully, shows feedback_id
- [ ] Feature request form submits successfully, shows feedback_id
- [ ] Screenshot drag/drop works, preview shows correct type
- [ ] Screenshot paste works
- [ ] Screenshots > 10MB rejected with error message
- [ ] "Copy Support Bundle" copies JSON to clipboard
- [ ] Support bundle contains: app_version, device_id, support_id, recent_request_ids, usage (no keys/content)
- [ ] Build passes (`./tickerctl.sh build-dev`)
- [ ] Web typecheck passes (`cd Web && npm run typecheck`)