### PR TITLE
feat(D6): Diagnostics toggle with disclosure and opt-out

### DIFF
--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -1011,6 +1011,11 @@ final class WebViewManager: NSObject {
                 NotificationCenter.default.post(name: .appearanceDidChange, object: nil)
             }
 
+            // Save diagnostics setting if provided
+            if let diagnosticsEnabled = payload["diagnosticsEnabled"]?.value as? Bool {
+                SettingsService.shared.diagnosticsEnabled = diagnosticsEnabled
+            }
+
             // Send back updated settings
             let settings = settingsWithClassifierState()
             bridgeService.send(BridgeMessage(

--- a/Sources/Ticker/Services/SettingsService.swift
+++ b/Sources/Ticker/Services/SettingsService.swift
@@ -15,6 +15,7 @@ final class SettingsService {
         static let appearance = "appearance"
         static let hasCompletedKeychainMigration = "has_completed_keychain_migration"
         static let hasCompletedOnboarding = "has_completed_onboarding"
+        static let diagnosticsEnabled = "diagnostics_enabled"
         // Legacy keys (for migration)
         static let legacyOpenaiAPIKey = "openai_api_key"
         static let legacyAnthropicAPIKey = "anthropic_api_key"
@@ -198,6 +199,21 @@ final class SettingsService {
         }
     }
 
+    // MARK: - Diagnostics
+
+    /// Whether to send diagnostic data (app version, request IDs, etc.)
+    /// Defaults to true if not explicitly set
+    var diagnosticsEnabled: Bool {
+        get {
+            // Default to true if not set
+            if defaults.object(forKey: Keys.diagnosticsEnabled) == nil {
+                return true
+            }
+            return defaults.bool(forKey: Keys.diagnosticsEnabled)
+        }
+        set { defaults.set(newValue, forKey: Keys.diagnosticsEnabled) }
+    }
+
     // MARK: - Settings Dictionary (for bridge)
 
     /// Get all settings as a dictionary for sending to React
@@ -208,7 +224,8 @@ final class SettingsService {
             "hasPerplexityKey": isPerplexityConfigured,
             "smartRoutingEnabled": smartRoutingEnabled,
             "defaultModel": defaultModel.rawValue,
-            "appearance": appearance.rawValue
+            "appearance": appearance.rawValue,
+            "diagnosticsEnabled": diagnosticsEnabled
         ]
 
         // Include masked key preview if set

--- a/Web/src/components/Settings.tsx
+++ b/Web/src/components/Settings.tsx
@@ -18,6 +18,7 @@ interface SettingsData {
   classifierLoading?: boolean;
   classifierError?: string;
   appearance: Appearance;
+  diagnosticsEnabled: boolean;
 }
 
 // Proxy auth state (matches Swift ProxyAuthState enum)
@@ -420,6 +421,31 @@ export function Settings({ onClose }: SettingsProps) {
             </div>
           </section>
         )}
+
+        {/* Privacy section (D6) */}
+        <section className="settings-section">
+          <h2>Privacy</h2>
+          <div className="settings-field">
+            <label className="settings-toggle-label">
+              <input
+                type="checkbox"
+                checked={settings?.diagnosticsEnabled ?? true}
+                onChange={(e) => {
+                  bridge.send({
+                    type: 'saveSettings',
+                    payload: { diagnosticsEnabled: e.target.checked },
+                  });
+                }}
+              />
+              <span>Send diagnostics</span>
+            </label>
+            <p className="settings-hint">
+              When enabled, Ticker sends request IDs and app/OS version with each
+              request to help troubleshoot issues. No note content or prompts are
+              collected.
+            </p>
+          </div>
+        </section>
 
         {/* Testing section - only visible when connected (D5) */}
         {(proxyAuth?.state === 'active' || proxyAuth?.state === 'degradedOffline') && (


### PR DESCRIPTION
## Summary

- Add `diagnosticsEnabled` setting (default ON) with Privacy section in Settings
- Centralized `applyDiagnosticsHeaders()` helper gates all diagnostic headers
- When OFF, only functional headers sent (Authorization, X-Ticker-Device-Id)
- Support bundle includes `diagnostics_enabled` field for support triage

## Diagnostic headers (conditional)

- `X-Ticker-App-Version`
- `X-Ticker-Platform`
- `X-Ticker-OS-Version`
- `X-Ticker-Request-Id`

## Endpoints updated

| Endpoint | Uses Helper |
|----------|-------------|
| `/v1/auth/validate` | Yes |
| `/v1/llm/request` | Yes |
| `/v1/feedback` | Yes |
| `/v1/feedback/.../attachments` | Yes |
| `/v1/feedback/.../complete` | Yes |

## Files changed

| File | Changes |
|------|---------|
| `SettingsService.swift` | Add `diagnosticsEnabled` property (default true) |
| `DeviceKeyService.swift` | Add `applyDiagnosticsHeaders()` helper, update all endpoints |
| `ProxyLLMService.swift` | Use helper for diagnostic headers |
| `WebViewManager.swift` | Handle `diagnosticsEnabled` in saveSettings |
| `Settings.tsx` | Add Privacy section with toggle and disclosure |

## Test plan

- [ ] Settings shows Privacy section with "Send diagnostics" toggle
- [ ] Toggle defaults to ON
- [ ] When OFF, diagnostic headers not sent (verify via proxy logs)
- [ ] Functional headers still sent when OFF
- [ ] Support bundle includes `diagnostics_enabled` field
- [ ] Build passes (`./tickerctl.sh build-dev`)
- [ ] Web typecheck passes (`cd Web && npm run typecheck`)

Closes #24