### PR TITLE
feat(D7): Export single stream to text (.md/.txt)

### DIFF
--- a/Web/src/components/UnifiedStreamEditor.tsx
+++ b/Web/src/components/UnifiedStreamEditor.tsx
@@ -230,6 +230,7 @@ export function UnifiedStreamEditor({
   const [title, setTitle] = useState(stream.title);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showExportMenu, setShowExportMenu] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   // Track if we've initialized the store for this stream
@@ -273,6 +274,7 @@ export function UnifiedStreamEditor({
     setTitle(stream.title);
     setIsEditingTitle(false);
     setShowDeleteConfirm(false);
+    setShowExportMenu(false);
   }, [stream.id, stream.title]);
 
   // Title editing handlers (same behavior as StreamEditor)
@@ -300,6 +302,12 @@ export function UnifiedStreamEditor({
       setIsEditingTitle(false);
     }
   }, [saveTitle, stream.title]);
+
+  // Export stream to file (fire-and-forget; NSSavePanel is modal)
+  const handleExport = useCallback((format: 'markdown' | 'text') => {
+    bridge.send({ type: 'exportStream', payload: { streamId: stream.id, format } });
+    setShowExportMenu(false);
+  }, [stream.id]);
 
   /**
    * Save pending edited cells (debounced).
@@ -1077,6 +1085,34 @@ export function UnifiedStreamEditor({
           </h1>
         )}
         <span className="stream-hint">Unified editor (auto-saves)</span>
+        <div className="export-menu-container">
+          <button
+            onClick={() => setShowExportMenu(!showExportMenu)}
+            className="export-stream-button"
+            title="Export stream"
+            type="button"
+          >
+            Export
+          </button>
+          {showExportMenu && (
+            <div className="export-menu-dropdown">
+              <button
+                onClick={() => handleExport('markdown')}
+                className="export-menu-item"
+                type="button"
+              >
+                Text (.md)
+              </button>
+              <button
+                onClick={() => handleExport('text')}
+                className="export-menu-item"
+                type="button"
+              >
+                Text (.txt)
+              </button>
+            </div>
+          )}
+        </div>
         <button
           onClick={() => setShowDeleteConfirm(true)}
           className="delete-stream-button"

--- a/Web/src/hooks/useBridgeMessages.ts
+++ b/Web/src/hooks/useBridgeMessages.ts
@@ -461,6 +461,20 @@ export function useBridgeMessages({ streamId, initialSources, editorAPI }: UseBr
         store.setError(cellId, displayError);
         store.completeRefreshing(cellId);
       }
+
+      // Export events
+      if (message.type === 'exportComplete' && message.payload?.path) {
+        const path = message.payload.path as string;
+        const filename = path.split('/').pop() || 'file';
+        toastStore.addToast(`Exported to ${filename}`, 'info');
+      }
+
+      if (message.type === 'exportError' && message.payload?.error) {
+        const error = formatError(message.payload.error, 'Export failed.');
+        toastStore.addToast(`Export failed: ${error}`, 'error');
+      }
+
+      // exportCanceled is silent (user intentionally canceled)
       } catch (err) {
         console.error('[useBridgeMessages] Error handling message:', message.type, err);
       }

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -372,6 +372,63 @@ body {
   background: rgba(239, 68, 68, 0.1);
 }
 
+/* Export menu */
+.export-menu-container {
+  position: relative;
+}
+
+.export-stream-button {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-tertiary);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.export-stream-button:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.export-menu-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: var(--spacing-xs);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  min-width: 160px;
+  overflow: hidden;
+}
+
+.export-menu-item {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.export-menu-item:hover {
+  background: var(--color-surface-hover);
+}
+
+.export-menu-item:not(:last-child) {
+  border-bottom: 1px solid var(--color-border);
+}
+
 /* Delete confirmation dialog */
 .delete-confirm-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- Add Export button to stream header with format dropdown (Text .md / Text .txt)
- NSSavePanel for native file save dialog
- Markdown-structured output: title as `#`, AI responses with model/prompt, quotes with source app, sources section
- Cell content HTML stripped to plain text (not converted to markdown syntax)
- Toast notifications for export success/error

## Changes
- `WebViewManager.swift`: `exportStream` handler, `formatStreamForExport`, `stripHTML`, `sanitizeFilename`
- `UnifiedStreamEditor.tsx`: Export button and dropdown menu
- `useBridgeMessages.ts`: Toast handlers for export events
- `index.css`: Export menu styles

## Test plan
- [ ] Click Export in stream header, verify dropdown appears
- [ ] Select "Text (.md)", verify NSSavePanel opens with .md extension
- [ ] Save file, verify content has markdown structure (headers, blockquotes, separators)
- [ ] Select "Text (.txt)", verify NSSavePanel opens with .txt extension
- [ ] Cancel NSSavePanel, verify no error toast
- [ ] Verify success toast shows filename after export