### PR TITLE
fix: redact ProxyLLMService debug logs

### DIFF
--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -29,7 +29,7 @@ final class ProxyLLMService: LLMProvider {
 
     private func debugLog(_ message: String) {
         guard proxyDebugEnabled else { return }
-        print("[ProxyLLMService] \(message)")
+        DebugLog.log("[ProxyLLMService] \(message)")
     }
 
     /// Proxy base URL - matches DeviceKeyService
@@ -389,7 +389,7 @@ final class ProxyLLMService: LLMProvider {
                 return nil
             }
 
-            debugLog("Restatement generated: \(trimmed.prefix(50))...")
+            debugLog("Restatement generated (len=\(trimmed.count))")
             return trimmed
 
         } catch {
@@ -468,7 +468,7 @@ final class ProxyLLMService: LLMProvider {
         }
 
         let label = outputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        debugLog("Label generated: \(label)")
+        debugLog("Label generated (len=\(label.count))")
         return label
     }
 


### PR DESCRIPTION
Fixes #73.

Changes:
- Route `ProxyLLMService` debug logging through `DebugLog.log` (DEBUG-only).
- Remove prompt-derived content from debug logs (restatement preview + modifier label).

Test plan:
- CI: `bridge-contract`, `web-typecheck`, `swift-build`.
- Manual: `./tickerctl.sh run-prod`, then run think + modifier and confirm Console contains no prompt-derived strings.
