### PR TITLE
chore(web): use debugLog for dev-only logging

### DIFF
--- a/Web/src/components/UnifiedStreamEditor.tsx
+++ b/Web/src/components/UnifiedStreamEditor.tsx
@@ -742,9 +742,7 @@ export function UnifiedStreamEditor({
       // Check if the cell is empty
       if (!isCellNodeEmpty(cellInfo.node)) continue;
 
-      if (IS_DEV) {
-        console.log('[UnifiedStreamEditor] Auto-resetting empty AI cell to text:', cellId);
-      }
+      debugLog('[UnifiedStreamEditor] Auto-resetting empty AI cell to text', { cellId });
 
       // Reset to text type in store
       updateBlock(cellId, {


### PR DESCRIPTION
Fixes #75.

Replaces a direct `console.log` in `UnifiedStreamEditor` with `debugLog(...)` so all DEV logging goes through the centralized helper.
