### PR TITLE
Docs: align device key/device_id storage notes

### DIFF
--- a/docs/ALPHA_READINESS_CHECKLIST.md
+++ b/docs/ALPHA_READINESS_CHECKLIST.md
@@ -32,7 +32,7 @@ This checklist is what “ready to invite users” means for Ticker alpha.
 - Logs retained for max 30 days; purge job in place
 
 ### In-app alpha support
-- Key entry + validation exists (Keychain storage)
+- Key entry + validation exists (device key stored locally in `~/Library/Application Support/Ticker/device.json`)
 - Settings shows usage + limits + reset timing
 - Clear UX for: offline, invalid key, quota exceeded, server errors
 - “Report bug / request feature” flow exists with optional attachments

--- a/docs/GITHUB_BACKLOG_ALPHA.md
+++ b/docs/GITHUB_BACKLOG_ALPHA.md
@@ -207,7 +207,7 @@ Implementation notes (source of truth for Epic D):
 #### Swift↔Web bridge messages to add (recommended contract)
 Web → Swift:
 - `loadProxyAuth`
-- `setProxyDeviceKey` `{ deviceKey }` (store in Keychain; validate)
+- `setProxyDeviceKey` `{ deviceKey }` (store in Application Support via `DeviceKeyService`; validate)
 - `clearProxyDeviceKey`
 - `validateProxyDeviceKey`
 - `proxyLlmRequest` `{ provider?, model, messages, stream, ... }` (used by “think” path)
@@ -234,12 +234,12 @@ Swift → Web:
   - Keep images small (downsample/compress); the proxy enforces a base64 payload size cap (currently ~20MB) and will reject oversized requests.
   - Avoid URL images for alpha even if some providers support them; base64 is the simplest path and avoids “provider fetch” failure modes.
 
-### D1 — Key entry + validation (Keychain)
+### D1 — Key entry + validation (device.json)
 - Labels: `alpha`, `type:feature`, `area:swift`, `area:web`, `p0`
 - AC:
   - Main window stream list is gated until a valid serial/device key is registered
   - Settings allows entering a device key and validating it against proxy
-  - Key stored in Keychain
+  - Key stored in `~/Library/Application Support/Ticker/device.json` (plaintext; best-effort restrictive permissions)
   - Never display/log raw key; show `support_id` instead
 
 ### D2 — Usage UI + limit messaging


### PR DESCRIPTION
Fixes #74

Updates alpha readiness + backlog docs to clarify where the Proxy device key and device_id live on disk (Application Support `device.json` via `DeviceKeyService`, not Keychain) and calls out restrictive permissions.