### PR TITLE
Issue #76: Add XCTest coverage for DeviceKeyService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           filters: |
             swift:
               - 'Sources/**'
+              - 'Tests/**'
               - 'Package.swift'
               - 'Package.resolved'
               - '.swiftpm/**'
@@ -92,11 +93,11 @@ jobs:
         if: steps.swift_should_build.outputs.should_build == 'true'
         working-directory: Web
         run: npm ci && npm run build
-      - name: Build (no code signing)
+      - name: Test (no code signing)
         if: steps.swift_should_build.outputs.should_build == 'true'
         run: |
           BUILD_NUMBER=$(git rev-list --count HEAD)
-          xcodebuild build \
+          xcodebuild test \
             -project Ticker.xcodeproj \
             -scheme Ticker \
             -destination 'platform=macOS' \

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -227,6 +227,16 @@ final class WebViewManager: NSObject {
 
     /// Load the MLX classifier in the background (only if smart routing enabled)
     private func loadMLXClassifier() {
+        // Unit tests should not trigger heavyweight MLX model downloads or background loading.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            DebugLog.log("MLX classifier skipped: running unit tests")
+            classifierSkipped = true
+            isClassifierReady = true
+            classifierReady?.resume()
+            classifierReady = nil
+            return
+        }
+
         // Only load classifier if smart routing is enabled
         // Note: No vendor keys required - classifier runs locally, proxy handles routing
         guard SettingsService.shared.smartRoutingEnabled else {

--- a/Sources/Ticker/Services/DeviceKeyService.swift
+++ b/Sources/Ticker/Services/DeviceKeyService.swift
@@ -229,6 +229,9 @@ actor DeviceKeyService {
 
     // MARK: - State
 
+    private let fileManager: FileManager
+    private let fileURL: URL
+
     private var cachedData: DeviceKeyData?
     private(set) var currentState: ProxyAuthState = .unregistered
 
@@ -263,8 +266,12 @@ actor DeviceKeyService {
         return "https://ticker-proxy.fly.dev"
     }
 
-    private var fileURL: URL {
-        let fileManager = FileManager.default
+    init(fileURL: URL? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        self.fileURL = fileURL ?? Self.defaultFileURL(fileManager: fileManager)
+    }
+
+    private static func defaultFileURL(fileManager: FileManager) -> URL {
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
         let tickerDir = appSupport.appendingPathComponent("Ticker", isDirectory: true)
@@ -278,7 +285,7 @@ actor DeviceKeyService {
 
     /// Ensure Application Support directory exists and is private to the user (best effort).
     /// `device.json` contains the plaintext device key, so we prefer restrictive permissions.
-    private func ensureDeviceDirectoryExists(fileManager: FileManager = .default) {
+    private func ensureDeviceDirectoryExists() {
         let dir = deviceDirectoryURL
         do {
             try fileManager.createDirectory(
@@ -297,7 +304,7 @@ actor DeviceKeyService {
 
     /// Stale temp files created by prior versions of `save(_:)` or interrupted writes.
     /// These can contain plaintext device keys and must be cleaned up on startup.
-    private func cleanupStaleDeviceTempFiles(fileManager: FileManager = .default) {
+    private func cleanupStaleDeviceTempFiles() {
         let dir = deviceDirectoryURL
 
         // Old implementation wrote to this fixed filename.
@@ -319,7 +326,7 @@ actor DeviceKeyService {
     }
 
     /// Best-effort permission hardening for the device file (contains plaintext device key).
-    private func hardenDeviceFilePermissions(fileManager: FileManager = .default) {
+    private func hardenDeviceFilePermissions() {
         try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
     }
 
@@ -843,10 +850,8 @@ actor DeviceKeyService {
             return cached
         }
 
-        let fileManager = FileManager.default
-
-        ensureDeviceDirectoryExists(fileManager: fileManager)
-        cleanupStaleDeviceTempFiles(fileManager: fileManager)
+        ensureDeviceDirectoryExists()
+        cleanupStaleDeviceTempFiles()
 
         // Try to load existing
         if let data = try? Data(contentsOf: fileURL) {
@@ -877,9 +882,7 @@ actor DeviceKeyService {
         encoder.outputFormatting = .prettyPrinted
 
         guard let encoded = try? encoder.encode(data) else { return }
-
-        let fileManager = FileManager.default
-        ensureDeviceDirectoryExists(fileManager: fileManager)
+        ensureDeviceDirectoryExists()
 
         // Write to a unique temp file in the same directory, then atomically replace.
         // This avoids leaving a fixed `device.json.tmp` file behind.
@@ -894,7 +897,7 @@ actor DeviceKeyService {
                 try fileManager.moveItem(at: tempURL, to: fileURL)
             }
 
-            hardenDeviceFilePermissions(fileManager: fileManager)
+            hardenDeviceFilePermissions()
         } catch {
             // Best-effort cleanup; temp file may contain plaintext key.
             try? fileManager.removeItem(at: tempURL)
@@ -902,7 +905,7 @@ actor DeviceKeyService {
             // Fallback: direct atomic write (system-managed temp). Still harden perms afterwards.
             do {
                 try encoded.write(to: fileURL, options: .atomic)
-                hardenDeviceFilePermissions(fileManager: fileManager)
+                hardenDeviceFilePermissions()
             } catch {
                 // If even fallback fails, we keep cachedData in memory; caller will still function
                 // for this session (but persistence is compromised).

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import Ticker
+
+final class DeviceKeyServiceTests: XCTestCase {
+    func test_loadProxyAuth_createsDeviceJsonWithPrivatePermissions() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("device.json")
+        let service = DeviceKeyService(fileURL: fileURL)
+
+        _ = await service.loadProxyAuth()
+
+        XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
+
+        let dirAttrs = try fileManager.attributesOfItem(atPath: tempDir.path)
+        let dirPerms = dirAttrs[.posixPermissions] as? NSNumber
+        XCTAssertEqual(dirPerms?.intValue, 0o700)
+
+        let fileAttrs = try fileManager.attributesOfItem(atPath: fileURL.path)
+        let filePerms = fileAttrs[.posixPermissions] as? NSNumber
+        XCTAssertEqual(filePerms?.intValue, 0o600)
+    }
+
+    func test_loadProxyAuth_cleansUpStaleTempFiles() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("device.json")
+
+        let legacyTempURL = fileURL.appendingPathExtension("tmp")
+        try "legacy".data(using: .utf8)?.write(to: legacyTempURL)
+
+        let newTempURL = tempDir.appendingPathComponent("device.json.tmp.\(UUID().uuidString)")
+        try "new".data(using: .utf8)?.write(to: newTempURL)
+
+        XCTAssertTrue(fileManager.fileExists(atPath: legacyTempURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: newTempURL.path))
+
+        let service = DeviceKeyService(fileURL: fileURL)
+        _ = await service.loadProxyAuth()
+
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyTempURL.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: newTempURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
+    }
+
+    func test_getSupportBundle_neverIncludesDeviceKey() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("device.json")
+
+        var device = DeviceKeyData(deviceId: UUID().uuidString, deviceKey: "tk_live_test_key")
+        device.supportId = "sup_test"
+        device.validatedAt = Date()
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let encoded = try encoder.encode(device)
+        try encoded.write(to: fileURL)
+
+        let service = DeviceKeyService(fileURL: fileURL)
+        _ = await service.loadProxyAuth()
+
+        let bundle = await service.getSupportBundle()
+        XCTAssertNil(bundle["device_key"])
+
+        let bundleData = try JSONSerialization.data(withJSONObject: bundle, options: [.sortedKeys])
+        let bundleString = String(data: bundleData, encoding: .utf8)
+        XCTAssertFalse(bundleString?.contains("tk_live_test_key") ?? false)
+    }
+
+    func test_recordRequestId_capsAt50() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("device.json")
+        let service = DeviceKeyService(fileURL: fileURL)
+
+        _ = await service.loadProxyAuth()
+
+        for i in 0..<60 {
+            await service.recordRequestId("req-\(i)", endpoint: "llm")
+        }
+
+        let bundle = await service.getSupportBundle()
+        guard let recent = bundle["recent_request_ids"] as? [[String: Any]] else {
+            XCTFail("Expected recent_request_ids array")
+            return
+        }
+
+        XCTAssertEqual(recent.count, 50)
+        XCTAssertEqual(recent.first?["request_id"] as? String, "req-10")
+        XCTAssertEqual(recent.last?["request_id"] as? String, "req-59")
+    }
+}
+

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -6,11 +6,11 @@
 	objectVersion = 56;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		C1000001000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000001 /* GRDB */; };
-		C1000001000000000002 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000002 /* MLXLLM */; };
-		C1000001000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000003 /* Sparkle */; };
-		R1000001000000000001 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F1000001000000000001 /* Resources */; };
+		/* Begin PBXBuildFile section */
+			C1000001000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000001 /* GRDB */; };
+			C1000001000000000002 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000002 /* MLXLLM */; };
+			C1000001000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D1000001000000000003 /* Sparkle */; };
+			R1000001000000000001 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F1000001000000000001 /* Resources */; };
 		A1000001000000000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000001 /* AppDelegate.swift */; };
 		A1000001000000000002 /* AssetSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000002 /* AssetSchemeHandler.swift */; };
 		A100000100000000002B /* BundleSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002B /* BundleSchemeHandler.swift */; };
@@ -54,15 +54,27 @@
 		A1000001000000000028 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000028 /* HotkeyService.swift */; };
 		A1000001000000000029 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000029 /* KeychainService.swift */; };
 		A100000100000000002A /* SelectionReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002A /* SelectionReaderService.swift */; };
-		A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
-		A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
-		A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
-/* End PBXBuildFile section */
+			A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
+			A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
+			A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
+			A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
+		/* End PBXBuildFile section */
 
-/* Begin PBXFileReference section */
-		E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ticker.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ticker.entitlements; sourceTree = "<group>"; };
+		/* Begin PBXContainerItemProxy section */
+			T1000001000000000004 /* PBXContainerItemProxy */ = {
+				isa = PBXContainerItemProxy;
+				containerPortal = E8A1B2C3D4E5F6A7B8C9D001 /* Project object */;
+				proxyType = 1;
+				remoteGlobalIDString = E8A1B2C3D4E5F6A7B8C9D0E0;
+				remoteInfo = Ticker;
+			};
+		/* End PBXContainerItemProxy section */
+
+		/* Begin PBXFileReference section */
+			E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ticker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+			E8A1B2C3D4E5F6A7B8C9D0E5 /* TickerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TickerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+			E8A1B2C3D4E5F6A7B8C9D0E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+			E8A1B2C3D4E5F6A7B8C9D0E3 /* Ticker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ticker.entitlements; sourceTree = "<group>"; };
 		B1000001000000000001 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B1000001000000000002 /* AssetSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSchemeHandler.swift; sourceTree = "<group>"; };
 		B100000100000000002B /* BundleSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSchemeHandler.swift; sourceTree = "<group>"; };
@@ -106,34 +118,43 @@
 		B1000001000000000028 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
 		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
-		B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
-		B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
-		B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
-		F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
-/* End PBXFileReference section */
+			B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
+			B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
+			B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
+			B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
+			F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
+		/* End PBXFileReference section */
 
-/* Begin PBXFrameworksBuildPhase section */
-		E8A1B2C3D4E5F6A7B8C9D0F1 /* Frameworks */ = {
+		/* Begin PBXFrameworksBuildPhase section */
+			E8A1B2C3D4E5F6A7B8C9D0F1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				C1000001000000000001 /* GRDB in Frameworks */,
 				C1000001000000000002 /* MLXLLM in Frameworks */,
 				C1000001000000000003 /* Sparkle in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+			};
+			T1000001000000000002 /* Frameworks */ = {
+				isa = PBXFrameworksBuildPhase;
+				buildActionMask = 2147483647;
+				files = (
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+			};
+		/* End PBXFrameworksBuildPhase section */
 
-/* Begin PBXGroup section */
-		E8A1B2C3D4E5F6A7B8C9D100 = {
-			isa = PBXGroup;
-			children = (
-				E8A1B2C3D4E5F6A7B8C9D101 /* Sources */,
-				E8A1B2C3D4E5F6A7B8C9D102 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
+		/* Begin PBXGroup section */
+			E8A1B2C3D4E5F6A7B8C9D100 = {
+				isa = PBXGroup;
+				children = (
+					E8A1B2C3D4E5F6A7B8C9D101 /* Sources */,
+					G1000001000000000009 /* Tests */,
+					E8A1B2C3D4E5F6A7B8C9D102 /* Products */,
+				);
+				sourceTree = "<group>";
+			};
 		E8A1B2C3D4E5F6A7B8C9D101 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -142,14 +163,15 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		E8A1B2C3D4E5F6A7B8C9D102 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+			E8A1B2C3D4E5F6A7B8C9D102 /* Products */ = {
+				isa = PBXGroup;
+				children = (
+					E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */,
+					E8A1B2C3D4E5F6A7B8C9D0E5 /* TickerTests.xctest */,
+				);
+				name = Products;
+				sourceTree = "<group>";
+			};
 		E8A1B2C3D4E5F6A7B8C9D103 /* Ticker */ = {
 			isa = PBXGroup;
 			children = (
@@ -258,22 +280,38 @@
 			path = Providers;
 			sourceTree = "<group>";
 		};
-		G1000001000000000008 /* System */ = {
-			isa = PBXGroup;
-			children = (
-				B1000001000000000026 /* ClipboardService.swift */,
+			G1000001000000000008 /* System */ = {
+				isa = PBXGroup;
+				children = (
+					B1000001000000000026 /* ClipboardService.swift */,
 				B1000001000000000027 /* CursorPositionService.swift */,
 				B1000001000000000028 /* HotkeyService.swift */,
 				B1000001000000000029 /* KeychainService.swift */,
 				B100000100000000002A /* SelectionReaderService.swift */,
 			);
-			path = System;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
+				path = System;
+				sourceTree = "<group>";
+			};
+			G1000001000000000009 /* Tests */ = {
+				isa = PBXGroup;
+				children = (
+					G100000100000000000A /* TickerTests */,
+				);
+				path = Tests;
+				sourceTree = "<group>";
+			};
+			G100000100000000000A /* TickerTests */ = {
+				isa = PBXGroup;
+				children = (
+					B100000100000000002F /* DeviceKeyServiceTests.swift */,
+				);
+				path = TickerTests;
+				sourceTree = "<group>";
+			};
+		/* End PBXGroup section */
 
-/* Begin PBXNativeTarget section */
-		E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */ = {
+		/* Begin PBXNativeTarget section */
+			E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */;
 			buildPhases = (
@@ -293,24 +331,44 @@
 				D1000001000000000003 /* Sparkle */,
 			);
 			productName = Ticker;
-			productReference = E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */;
-			productType = "com.apple.product-type.application";
-		};
-/* End PBXNativeTarget section */
+				productReference = E8A1B2C3D4E5F6A7B8C9D0E1 /* Ticker.app */;
+				productType = "com.apple.product-type.application";
+			};
+			E8A1B2C3D4E5F6A7B8C9D0E4 /* TickerTests */ = {
+				isa = PBXNativeTarget;
+				buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D120 /* Build configuration list for PBXNativeTarget "TickerTests" */;
+				buildPhases = (
+					T1000001000000000001 /* Sources */,
+					T1000001000000000002 /* Frameworks */,
+				);
+				buildRules = (
+				);
+				dependencies = (
+					T1000001000000000003 /* PBXTargetDependency */,
+				);
+				name = TickerTests;
+				productName = TickerTests;
+				productReference = E8A1B2C3D4E5F6A7B8C9D0E5 /* TickerTests.xctest */;
+				productType = "com.apple.product-type.bundle.unit-test";
+			};
+		/* End PBXNativeTarget section */
 
-/* Begin PBXProject section */
-		E8A1B2C3D4E5F6A7B8C9D001 /* Project object */ = {
-			isa = PBXProject;
+		/* Begin PBXProject section */
+			E8A1B2C3D4E5F6A7B8C9D001 /* Project object */ = {
+				isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1500;
-				TargetAttributes = {
-					E8A1B2C3D4E5F6A7B8C9D0E0 = {
-						CreatedOnToolsVersion = 15.0;
+					TargetAttributes = {
+						E8A1B2C3D4E5F6A7B8C9D0E0 = {
+							CreatedOnToolsVersion = 15.0;
+						};
+						E8A1B2C3D4E5F6A7B8C9D0E4 = {
+							CreatedOnToolsVersion = 15.0;
+						};
 					};
 				};
-			};
 			buildConfigurationList = E8A1B2C3D4E5F6A7B8C9D004 /* Build configuration list for PBXProject "Ticker" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
@@ -328,11 +386,12 @@
 			productRefGroup = E8A1B2C3D4E5F6A7B8C9D102 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (
-				E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */,
-			);
-		};
-/* End PBXProject section */
+				targets = (
+					E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */,
+					E8A1B2C3D4E5F6A7B8C9D0E4 /* TickerTests */,
+				);
+			};
+		/* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E8A1B2C3D4E5F6A7B8C9D0F2 /* Resources */ = {
@@ -370,8 +429,8 @@
 		};
 /* End PBXShellScriptBuildPhase section */
 
-/* Begin PBXSourcesBuildPhase section */
-		E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */ = {
+		/* Begin PBXSourcesBuildPhase section */
+			E8A1B2C3D4E5F6A7B8C9D0F0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -422,14 +481,30 @@
 				A100000100000000002D /* ProxyLLMService.swift in Sources */,
 				A100000100000000002E /* DebugLog.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
+				runOnlyForDeploymentPostprocessing = 0;
+			};
+			T1000001000000000001 /* Sources */ = {
+				isa = PBXSourcesBuildPhase;
+				buildActionMask = 2147483647;
+				files = (
+					A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */,
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+			};
+		/* End PBXSourcesBuildPhase section */
 
-/* Begin XCBuildConfiguration section */
-		E8A1B2C3D4E5F6A7B8C9D005 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
+		/* Begin PBXTargetDependency section */
+			T1000001000000000003 /* PBXTargetDependency */ = {
+				isa = PBXTargetDependency;
+				target = E8A1B2C3D4E5F6A7B8C9D0E0 /* Ticker */;
+				targetProxy = T1000001000000000004 /* PBXContainerItemProxy */;
+			};
+		/* End PBXTargetDependency section */
+
+		/* Begin XCBuildConfiguration section */
+			E8A1B2C3D4E5F6A7B8C9D005 /* Debug */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -570,9 +645,9 @@
 			};
 			name = Debug;
 		};
-		E8A1B2C3D4E5F6A7B8C9D112 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
+			E8A1B2C3D4E5F6A7B8C9D112 /* Release */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Sources/Ticker/Ticker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -592,13 +667,39 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+				};
+				name = Release;
 			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
+			E8A1B2C3D4E5F6A7B8C9D121 /* Debug */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					BUNDLE_LOADER = "$(TEST_HOST)";
+					CODE_SIGN_STYLE = Automatic;
+					GENERATE_INFOPLIST_FILE = YES;
+					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.appTests;
+					PRODUCT_NAME = "$(TARGET_NAME)";
+					SWIFT_VERSION = 5.0;
+					TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ticker.app/Contents/MacOS/Ticker";
+				};
+				name = Debug;
+			};
+			E8A1B2C3D4E5F6A7B8C9D122 /* Release */ = {
+				isa = XCBuildConfiguration;
+				buildSettings = {
+					BUNDLE_LOADER = "$(TEST_HOST)";
+					CODE_SIGN_STYLE = Automatic;
+					GENERATE_INFOPLIST_FILE = YES;
+					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.appTests;
+					PRODUCT_NAME = "$(TARGET_NAME)";
+					SWIFT_VERSION = 5.0;
+					TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ticker.app/Contents/MacOS/Ticker";
+				};
+				name = Release;
+			};
+		/* End XCBuildConfiguration section */
 
-/* Begin XCConfigurationList section */
-		E8A1B2C3D4E5F6A7B8C9D004 /* Build configuration list for PBXProject "Ticker" */ = {
+		/* Begin XCConfigurationList section */
+			E8A1B2C3D4E5F6A7B8C9D004 /* Build configuration list for PBXProject "Ticker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E8A1B2C3D4E5F6A7B8C9D005 /* Debug */,
@@ -607,16 +708,25 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E8A1B2C3D4E5F6A7B8C9D111 /* Debug */,
-				E8A1B2C3D4E5F6A7B8C9D112 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
+			E8A1B2C3D4E5F6A7B8C9D110 /* Build configuration list for PBXNativeTarget "Ticker" */ = {
+				isa = XCConfigurationList;
+				buildConfigurations = (
+					E8A1B2C3D4E5F6A7B8C9D111 /* Debug */,
+					E8A1B2C3D4E5F6A7B8C9D112 /* Release */,
+				);
+				defaultConfigurationIsVisible = 0;
+				defaultConfigurationName = Release;
+			};
+			E8A1B2C3D4E5F6A7B8C9D120 /* Build configuration list for PBXNativeTarget "TickerTests" */ = {
+				isa = XCConfigurationList;
+				buildConfigurations = (
+					E8A1B2C3D4E5F6A7B8C9D121 /* Debug */,
+					E8A1B2C3D4E5F6A7B8C9D122 /* Release */,
+				);
+				defaultConfigurationIsVisible = 0;
+				defaultConfigurationName = Release;
+			};
+		/* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		P1000001000000000001 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {

--- a/Ticker.xcodeproj/xcshareddata/xcschemes/Ticker.xcscheme
+++ b/Ticker.xcodeproj/xcshareddata/xcschemes/Ticker.xcscheme
@@ -29,6 +29,27 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8A1B2C3D4E5F6A7B8C9D0E4"
+               BuildableName = "TickerTests.xctest"
+               BlueprintName = "TickerTests"
+               ReferencedContainer = "container:Ticker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8A1B2C3D4E5F6A7B8C9D0E0"
+            BuildableName = "Ticker.app"
+            BlueprintName = "Ticker"
+            ReferencedContainer = "container:Ticker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"


### PR DESCRIPTION
Adds an Xcode XCTest target (TickerTests) and DeviceKeyService unit tests for data-safety critical paths.

Key changes:
- Refactors DeviceKeyService to allow injecting a file URL + FileManager for deterministic tests.
- Adds DeviceKeyServiceTests covering:
  - private permissions on Application Support dir + device.json (0700/0600)
  - stale temp cleanup (device.json.tmp + device.json.tmp.<uuid>)
  - support bundle never includes device_key
  - request-id ring buffer caps at 50
- Skips MLX classifier background loading when running unit tests to avoid heavyweight model downloads.
- Updates CI to run xcodebuild test (and includes Tests/** in swift change detection).

How to test:
1) ./tickerctl.sh clean-derived-data -y (if you hit stale Sparkle artifacts)
2) xcodebuild test -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath .build/xcode CODE_SIGNING_ALLOWED=NO

Fixes #76
