### PR TITLE
Issue #85: make preflight-alpha run Swift tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,17 @@ The user will share this summary with GPT for review. Only commit after approval
 ./tickerctl.sh build-prod   # Build Release (unsigned, bundles web)
 ./tickerctl.sh run-prod     # Build + run Release (bundled web)
 
+# Preflight (PR/release gate)
+./tickerctl.sh preflight-alpha   # contracts + web typecheck + swift tests
+./tickerctl.sh swift-test        # swift tests only
+
 # Legacy runner (still supported; prefer tickerctl.sh)
 ./run.sh --dev
 ./run.sh --prod
 
 # Direct xcodebuild (if needed)
 xcodebuild build -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath .build/xcode
+xcodebuild test -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath .build/xcode CODE_SIGNING_ALLOWED=NO
 
 # Web typecheck only
 cd Web && npm run typecheck

--- a/docs/ENGINEERING_WORKFLOW.md
+++ b/docs/ENGINEERING_WORKFLOW.md
@@ -52,9 +52,10 @@ Every PR includes:
 
 ## CI baseline (must exist)
 
-- Swift: `xcodebuild build -scheme Ticker -destination 'platform=OS X' -derivedDataPath .build/xcode`
-- Web: `cd Web && npm run typecheck`
-- Bridge contract: `node tools/contracts/check_bridge_contract.mjs`
+- Preferred single entry point: `./tickerctl.sh preflight-alpha`
+- Swift: `./tickerctl.sh swift-test` (runs `xcodebuild test`, no code signing)
+- Web: `./tickerctl.sh web-typecheck`
+- Bridge contract: `./tickerctl.sh contracts`
 
 ## Review checklist (fast but strict)
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -19,7 +19,7 @@ Rationale: GitHub asset URLs typically redirect; Sparkle update checks are more 
 - `CHANGELOG.md` updated for the release
 - Tag created: `vYYYY.MM.patch`
 - Preflight checks pass:
-  - `./tickerctl.sh preflight-alpha`
+  - `./tickerctl.sh preflight-alpha` (contracts + web typecheck + swift tests)
 - Signed + notarized build produced (see `docs/MAC_DISTRIBUTION.md`)
 - Sparkle appcast updated and published
 - Rollback available: last 2–3 releases remain in appcast

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -105,6 +105,14 @@ Verify: `https://nikokozak.github.io/Ticker/appcast-alpha.xml` should return the
 
 ## Release Steps
 
+### 0.5 Automated preflight (required)
+
+If you’re using `./tickerctl.sh release-alpha`, this runs automatically, but it’s still useful to run explicitly before you start a long signing/notarization cycle:
+
+```bash
+./tickerctl.sh preflight-alpha
+```
+
 ### 0. Pre-release data safety check (recommended)
 
 Before shipping a build that includes schema changes, confirm that a pending migration creates a timestamped backup DB in:

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -7,9 +7,10 @@ Ticker is a note-taking app with persistence and an AI/proxy integration. For al
 
 ## Required checks on every PR
 
-- Swift build succeeds (`xcodebuild ...`)
-- Web typecheck succeeds (`npm run typecheck`)
-- Bridge contract tests succeed (`node tools/contracts/check_bridge_contract.mjs`)
+- Preferred: `./tickerctl.sh preflight-alpha` (runs the 3 automated gates below)
+- Swift tests succeed (`./tickerctl.sh swift-test`)
+- Web typecheck succeeds (`./tickerctl.sh web-typecheck`)
+- Bridge contract tests succeed (`./tickerctl.sh contracts`)
 - Prod console sanity: `./tickerctl.sh run-prod` + Web Inspector Console is quiet (no prompt/content/key logging)
 
 ## Smoke coverage (must-have before inviting users)

--- a/tickerctl.sh
+++ b/tickerctl.sh
@@ -9,9 +9,10 @@ Usage: ./tickerctl.sh [command] [options]
 Commands:
   help [command]       Show help/manual (more verbose than --help)
   menu                 Interactive menu (default)
-  preflight-alpha      Run preflight checks (contract + web typecheck)
+  preflight-alpha      Run preflight checks (contracts + web typecheck + swift tests)
   contracts            Run bridge contract tests (if present in this checkout)
   web-typecheck        Run Web TypeScript typecheck
+  swift-test           Run Swift tests (xcodebuild test, no code signing)
   clean-derived-data    Delete repo-local Xcode DerivedData (fixes stale SPM artifacts)
   install-sparkle-tools  Install Sparkle CLI tools into ./tools/sparkle (from SwiftPM artifacts)
   build-dev            Build Debug app (unsigned)
@@ -127,9 +128,25 @@ preflight-alpha
 Runs cheap checks that catch “protocol breakage” before you ship:
 - Bridge contract tests (if present in this checkout)
 - Web TypeScript typecheck
+- Swift tests (xcodebuild test, no code signing; builds Web assets first)
 
 Run it:
   ./tickerctl.sh preflight-alpha
+EOF
+      return 0
+      ;;
+    swift-test)
+      cat <<'EOF'
+swift-test
+
+Runs the Swift XCTest suite with code signing disabled.
+
+Notes:
+- Builds Web assets first (matches CI); the app target expects bundled Web output.
+- Uses repo-local DerivedData by default: ./.build/xcode
+
+Run it:
+  ./tickerctl.sh swift-test
 EOF
       return 0
       ;;
@@ -346,14 +363,48 @@ cmd_web_typecheck() {
 
 cmd_contracts() {
   local script="$ROOT_DIR/tools/contracts/check_bridge_contract.mjs"
+  local tools_dir="$ROOT_DIR/tools/contracts"
   if [[ ! -f "$script" ]]; then
     echo "Bridge contract tests not found at: $script"
     echo "Tip: update to a commit that includes the contract tests, or skip this step."
     return 0
   fi
   require_cmd node
+  require_cmd npm
+  (cd "$tools_dir" && {
+    if [[ ! -d node_modules ]]; then
+      npm ci
+    fi
+  })
   echo "Bridge contract tests…"
   node "$script"
+}
+
+swift_test() {
+  require_cmd git
+  require_cmd xcodebuild
+
+  cd "$ROOT_DIR"
+
+  echo "Building web assets…"
+  build_web_assets
+
+  local build_num
+  build_num="$(build_number)"
+
+  xcodebuild test \
+    -project Ticker.xcodeproj \
+    -scheme Ticker \
+    -destination 'platform=macOS' \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    CODE_SIGNING_ALLOWED=NO \
+    CURRENT_PROJECT_VERSION="$build_num" \
+    -quiet
+}
+
+cmd_swift_test() {
+  echo "Swift tests…"
+  swift_test
 }
 
 cmd_preflight_alpha() {
@@ -377,6 +428,7 @@ cmd_preflight_alpha() {
 
   cmd_contracts
   cmd_web_typecheck
+  cmd_swift_test
 }
 
 cmd_build_dev() {
@@ -1178,7 +1230,7 @@ cmd_menu() {
     "Build + Run Debug (dev)" \
     "Build Release (prod, unsigned)" \
     "Build + Run Release (prod, unsigned)" \
-    "Preflight (alpha): contract + web typecheck" \
+    "Preflight (alpha): contracts + web typecheck + swift tests" \
     "Clean DerivedData (fix stale SPM artifacts)" \
     "Release (alpha): build+sign+notarize+zip+Sparkle-sign" \
     "Release (alpha) + promote: publish + update appcast" \
@@ -1283,6 +1335,7 @@ main() {
   preflight-alpha) cmd_preflight_alpha "$@" ;;
   contracts) cmd_contracts ;;
   web-typecheck) cmd_web_typecheck ;;
+  swift-test) cmd_swift_test ;;
   clean-derived-data) cmd_clean_derived_data "$@" ;;
   install-sparkle-tools) cmd_install_sparkle_tools "$@" ;;
   build-dev) cmd_build_dev ;;


### PR DESCRIPTION
Closes #85.

## What changed
- `./tickerctl.sh swift-test`: runs `xcodebuild test` (no code signing) and builds Web assets first (matches CI expectations).
- `./tickerctl.sh preflight-alpha`: now runs contracts + web typecheck + swift tests.
- `./tickerctl.sh contracts`: auto-runs `npm ci` in `tools/contracts` on fresh clones.
- Docs aligned to treat `preflight-alpha` as the canonical PR/release gate.

## Test plan
- `./tickerctl.sh help preflight-alpha`
- `./tickerctl.sh help swift-test`
- `./tickerctl.sh preflight-alpha`

Notes: if you hit the common Sparkle SwiftPM artifact issue (missing `Sparkle.xcframework`), run `./tickerctl.sh clean-derived-data -y` and retry.
