### PR TITLE
Stop re-prompting permissions on Cmd+;

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var webViewManager: WebViewManager?
     private var onboardingWindow: NSWindow?
     private var didCompleteStartup = false
+    private var didOpenScreenRecordingSettingsThisSession = false
 
     // Menu bar (status item)
     private var statusItem: NSStatusItem?
@@ -361,14 +362,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Screen recording permission is required for capturing other apps' windows.
         // Without it, macOS may redact capture output (e.g., Desktop only).
         if !CGPreflightScreenCaptureAccess() {
-            DebugLog.log("[Screenshot] Screen recording permission missing; requesting access")
-            _ = CGRequestScreenCaptureAccess()
+            DebugLog.log("[Screenshot] Screen recording permission missing; opening System Settings")
+            quickPanelManager?.showWithStatusMessage("Enable Screen Recording permission in System Settings (restart Ticker)")
 
-            // Permission changes typically require the app to be restarted.
-            guard CGPreflightScreenCaptureAccess() else {
-                quickPanelManager?.showWithStatusMessage("Enable Screen Recording permission (restart Ticker)")
-                return
+            if !didOpenScreenRecordingSettingsThisSession {
+                didOpenScreenRecordingSettingsThisSession = true
+                _ = SystemSettingsService.openPrivacyPane(.screenRecording)
             }
+            return
         }
 
         let pasteboardChangeCountBefore = ClipboardService.changeCount()

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -199,9 +199,8 @@ final class QuickPanelManager: ObservableObject {
         // Show accessibility warning if permission not granted and no context captured
         if !cursorService.hasAccessibilityPermission {
             if !capturedContext.hasContent {
-                statusMessage = "Grant Accessibility permission to capture text selections"
+                statusMessage = "Grant Accessibility permission in System Settings to capture text selections"
             }
-            cursorService.requestAccessibilityPermission()
         }
 
         // Create panel if needed

--- a/Sources/Ticker/Services/System/CursorPositionService.swift
+++ b/Sources/Ticker/Services/System/CursorPositionService.swift
@@ -9,7 +9,7 @@ final class CursorPositionService {
     // MARK: - Permission
 
     var hasAccessibilityPermission: Bool {
-        AXIsProcessTrustedWithOptions(nil)
+        AXIsProcessTrusted()
     }
 
     func requestAccessibilityPermission() {

--- a/Sources/Ticker/Services/System/SystemSettingsService.swift
+++ b/Sources/Ticker/Services/System/SystemSettingsService.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+enum SystemSettingsService {
+    enum PrivacyPane: String {
+        case accessibility = "Privacy_Accessibility"
+        case screenRecording = "Privacy_ScreenCapture"
+    }
+
+    @discardableResult
+    static func openPrivacyPane(_ pane: PrivacyPane) -> Bool {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane.rawValue)") else {
+            return false
+        }
+        return NSWorkspace.shared.open(url)
+    }
+}
+

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -55,10 +55,11 @@
 		A1000001000000000028 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000028 /* HotkeyService.swift */; };
 		A1000001000000000029 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000029 /* KeychainService.swift */; };
 		A100000100000000002A /* SelectionReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002A /* SelectionReaderService.swift */; };
-			A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
-			A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
-			A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
-			A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
+		A1000001000000000030 /* SystemSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* SystemSettingsService.swift */; };
+		A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
+		A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
+		A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
+		A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
 		/* End PBXBuildFile section */
 
 		/* Begin PBXContainerItemProxy section */
@@ -119,12 +120,13 @@
 		B1000001000000000028 /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
 		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
-			B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
-			B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
-			B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
-				B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
-				F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
-				F1000001000000000002 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B1000001000000000030 /* SystemSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsService.swift; sourceTree = "<group>"; };
+		B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
+		B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
+		B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
+		B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
+		F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
+		F1000001000000000002 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
 
 		/* Begin PBXFrameworksBuildPhase section */
@@ -283,18 +285,19 @@
 			path = Providers;
 			sourceTree = "<group>";
 		};
-			G1000001000000000008 /* System */ = {
-				isa = PBXGroup;
-				children = (
-					B1000001000000000026 /* ClipboardService.swift */,
+		G1000001000000000008 /* System */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000026 /* ClipboardService.swift */,
 				B1000001000000000027 /* CursorPositionService.swift */,
 				B1000001000000000028 /* HotkeyService.swift */,
 				B1000001000000000029 /* KeychainService.swift */,
 				B100000100000000002A /* SelectionReaderService.swift */,
+				B1000001000000000030 /* SystemSettingsService.swift */,
 			);
-				path = System;
-				sourceTree = "<group>";
-			};
+			path = System;
+			sourceTree = "<group>";
+		};
 			G1000001000000000009 /* Tests */ = {
 				isa = PBXGroup;
 				children = (
@@ -481,10 +484,11 @@
 				A1000001000000000028 /* HotkeyService.swift in Sources */,
 				A1000001000000000029 /* KeychainService.swift in Sources */,
 				A100000100000000002A /* SelectionReaderService.swift in Sources */,
+				A1000001000000000030 /* SystemSettingsService.swift in Sources */,
 				A100000100000000002C /* DeviceKeyService.swift in Sources */,
 				A100000100000000002D /* ProxyLLMService.swift in Sources */,
 				A100000100000000002E /* DebugLog.swift in Sources */,
-			);
+				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
 			T1000001000000000001 /* Sources */ = {


### PR DESCRIPTION
Fixes #105.

Problem:
- Using Cmd+; to take a screenshot repeatedly triggers OS permission prompts (Screen Recording + Accessibility).

Changes:
- Screenshot flow no longer calls `CGRequestScreenCaptureAccess()` on every attempt; if Screen Recording is missing we show an in-app status message and deep-link to System Settings (only once per session).
- Quick Panel no longer auto-calls `AXIsProcessTrustedWithOptions(prompt=true)` when permission is missing; it only shows an in-app message.
- Added `SystemSettingsService` helper for deep-linking.

How to verify:
1) Grant permissions, restart Ticker.
2) Press Cmd+; repeatedly — no permission dialogs should appear.