### PR TITLE
fix: stabilize dev permissions with stable + QA TCC lanes

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -33,6 +33,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // Quick Panel services
     private var hotkeyService: HotkeyService?
     private var quickPanelManager: QuickPanelManager?
+    private var didOpenScreenRecordingSettingsThisLaunch = false
 
     // Sparkle updater (lives for app lifetime)
     private let updaterController = SPUStandardUpdaterController(
@@ -355,6 +356,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    private func openScreenRecordingSystemSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") else {
+            return
+        }
+        _ = NSWorkspace.shared.open(url)
+    }
+
     /// Capture screenshot using system tool, then show Quick Panel
     @MainActor
     private func captureScreenshot() {
@@ -362,7 +370,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Without it, macOS may redact capture output (e.g., Desktop only).
         if !CGPreflightScreenCaptureAccess() {
             DebugLog.log("[Screenshot] Screen recording permission missing")
-            quickPanelManager?.showWithStatusMessage("Enable Screen Recording permission (restart Ticker)")
+
+            // Requesting access registers Ticker with macOS so it appears in the Screen Recording list.
+            let granted = CGRequestScreenCaptureAccess()
+            if granted {
+                quickPanelManager?.showWithStatusMessage("Screen Recording enabled. Restart Ticker.")
+                return
+            }
+
+            // If access is denied/already denied, deep-link once per launch so users land in the right pane.
+            if !didOpenScreenRecordingSettingsThisLaunch {
+                didOpenScreenRecordingSettingsThisLaunch = true
+                openScreenRecordingSystemSettings()
+            }
+            quickPanelManager?.showWithStatusMessage("Enable Screen Recording in System Settings, then restart Ticker")
             return
         }
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -50,12 +50,23 @@ This folder defines the “professional mode” workflow for Ticker and the mini
 Preferred entry point: `./tickerctl.sh` (menu + scripted commands).
 
 Common flows:
-- Dev (Debug + Vite): `./tickerctl.sh run-dev`
-- Prod-ish (Release + bundled web): `./tickerctl.sh run-prod`
+- Dev (Debug + Vite, stable lane): `./tickerctl.sh run-dev`
+- Dev (Debug + Vite, QA lane): `./tickerctl.sh run-dev-qa`
+- Prod-ish (Release + bundled web, stable lane): `./tickerctl.sh run-prod`
+- Prod-ish (Release + bundled web, QA lane): `./tickerctl.sh run-prod-qa`
+
+Permission debugging note:
+- Stable lane uses bundle ID `io.ticker.app` (default).
+- QA lane uses bundle ID `io.ticker.app.qa` (default) so TCC resets don't disrupt stable daily-dev permissions.
+- Reset only the lane you are testing:
+  - `./tickerctl.sh reset-accessibility` / `./tickerctl.sh reset-screen-recording`
+  - `./tickerctl.sh reset-accessibility-qa` / `./tickerctl.sh reset-screen-recording-qa`
 
 Legacy runner (still supported):
 - Dev: `./run.sh --dev`
+- Dev (QA lane): `./run.sh --dev --qa`
 - Prod: `./run.sh --prod`
+- Prod (QA lane): `./run.sh --prod --qa`
 
 If you hit SwiftPM/Sparkle artifact issues, run:
 - `./tickerctl.sh clean-derived-data -y`

--- a/run.sh
+++ b/run.sh
@@ -4,16 +4,20 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: ./run.sh [--dev|-d] [--prod|-p] [-h]
+Usage: ./run.sh [--dev|-d] [--prod|-p] [--qa|--stable] [-h]
 
   -d, --dev   (default) Build Debug + run Vite dev server (app loads http://localhost:5173)
   -p, --prod  Build Release + run bundled web UI (no dev server)
+      --qa    Run in QA lane (separate bundle ID / install path for TCC isolation)
+      --stable  Run in stable lane (default)
   -h          Show this help
 
 Notes:
   - This script builds an unsigned app (`CODE_SIGNING_ALLOWED=NO`) but will optionally
-    codesign the built .app if `SIGN_IDENTITY` is set (recommended so macOS permissions
-    like Accessibility/Screen Recording stick across rebuilds).
+    codesign the installed lane app if `SIGN_IDENTITY` is set (recommended so macOS
+    permissions like Accessibility/Screen Recording stick across rebuilds).
+  - Stable lane installs to `~/Applications/Ticker.app` by default.
+  - QA lane installs to `~/Applications/Ticker QA.app` by default.
   - Distribution builds should follow the signing/notarization runbook.
   - Override build output location with DERIVED_DATA_PATH (or TICKER_DERIVED_DATA_PATH), e.g.:
       DERIVED_DATA_PATH=/tmp/ticker-xcode-build ./run.sh --prod
@@ -29,8 +33,14 @@ fi
 DERIVED_DATA_PATH_DEFAULT="$ROOT_DIR/.build/xcode"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${TICKER_DERIVED_DATA_PATH:-$DERIVED_DATA_PATH_DEFAULT}}"
 APP="$DERIVED_DATA_PATH/Build/Products"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-io.ticker.app}"
+QA_APP_BUNDLE_ID="${QA_APP_BUNDLE_ID:-io.ticker.app.qa}"
+QA_APP_DISPLAY_NAME="${QA_APP_DISPLAY_NAME:-Ticker QA}"
+STABLE_APP_INSTALL_PATH="${STABLE_APP_INSTALL_PATH:-$HOME/Applications/Ticker.app}"
+QA_APP_INSTALL_PATH="${QA_APP_INSTALL_PATH:-$HOME/Applications/Ticker QA.app}"
 
 MODE="dev"
+LANE="stable"
 while [[ $# -gt 0 ]]; do
   case "$1" in
   -d | --dev)
@@ -39,6 +49,14 @@ while [[ $# -gt 0 ]]; do
     ;;
   -p | --prod)
     MODE="prod"
+    shift
+    ;;
+  --qa)
+    LANE="qa"
+    shift
+    ;;
+  --stable)
+    LANE="stable"
     shift
     ;;
   -h | --help)
@@ -53,6 +71,30 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+lane_bundle_id() {
+  if [[ "$LANE" == "qa" ]]; then
+    echo "$QA_APP_BUNDLE_ID"
+  else
+    echo "$APP_BUNDLE_ID"
+  fi
+}
+
+lane_display_name() {
+  if [[ "$LANE" == "qa" ]]; then
+    echo "$QA_APP_DISPLAY_NAME"
+  else
+    echo "Ticker"
+  fi
+}
+
+lane_install_path() {
+  if [[ "$LANE" == "qa" ]]; then
+    echo "$QA_APP_INSTALL_PATH"
+  else
+    echo "$STABLE_APP_INSTALL_PATH"
+  fi
+}
+
 codesign_app_if_configured() {
   local app_path="$1"
 
@@ -62,6 +104,7 @@ codesign_app_if_configured() {
 
   local identity="${SIGN_IDENTITY:-}"
   if [[ -z "$identity" ]]; then
+    echo "Warning: SIGN_IDENTITY is not set; TCC permissions may re-prompt across rebuilds." >&2
     return 0
   fi
 
@@ -88,6 +131,32 @@ codesign_app_if_configured() {
 
   # Best-effort verification (non-fatal).
   codesign --verify --deep "$app_path" >/dev/null 2>&1 || true
+}
+
+install_lane_app() {
+  local source_app="$1"
+  local target_app="$2"
+
+  if [[ ! -d "$source_app" ]]; then
+    echo "Error: built app not found at: $source_app" >&2
+    return 1
+  fi
+
+  if [[ -z "$target_app" || "$target_app" == "/" || "$target_app" == "$HOME" ]]; then
+    echo "Error: refusing to install app to unsafe path: '$target_app'" >&2
+    return 1
+  fi
+
+  local target_parent
+  target_parent="$(dirname "$target_app")"
+  mkdir -p "$target_parent"
+
+  if [[ -d "$target_app" ]]; then
+    rm -rf "$target_app"
+  fi
+
+  # Preserve bundle structure/metadata as-is.
+  ditto "$source_app" "$target_app"
 }
 
 resolve_package_dependencies_if_needed() {
@@ -132,6 +201,10 @@ build_app() {
     build_number="$(git rev-list --count HEAD 2>/dev/null || echo 1)"
     extra_build_settings+=("CURRENT_PROJECT_VERSION=$build_number")
   fi
+  if [[ "$LANE" == "qa" ]]; then
+    extra_build_settings+=("PRODUCT_BUNDLE_IDENTIFIER=$QA_APP_BUNDLE_ID")
+    extra_build_settings+=("INFOPLIST_KEY_CFBundleDisplayName=$QA_APP_DISPLAY_NAME")
+  fi
 
   local log_path
   log_path="$(mktemp -t ticker-xcodebuild.XXXXXX.log)"
@@ -167,11 +240,15 @@ build_app() {
 }
 
 run_dev() {
-  local app_path="$APP/Debug/Ticker.app"
-  local bin_path="$app_path/Contents/MacOS/Ticker"
+  local built_app_path="$APP/Debug/Ticker.app"
+  local launch_app_path
+  launch_app_path="$(lane_install_path)"
+  local bin_path="$launch_app_path/Contents/MacOS/Ticker"
 
+  echo "Lane: $LANE (bundle id: $(lane_bundle_id), name: $(lane_display_name))"
   build_app "Debug"
-  codesign_app_if_configured "$app_path"
+  install_lane_app "$built_app_path" "$launch_app_path"
+  codesign_app_if_configured "$launch_app_path"
 
   echo "Cleaning up port 5173..."
   lsof -ti:5173 | xargs kill -9 2>/dev/null || true
@@ -185,16 +262,19 @@ run_dev() {
 
   if [[ ! -x "$bin_path" ]]; then
     echo "Error: expected app executable not found at: $bin_path" >&2
-    echo "Build output should be at: $app_path" >&2
+    echo "Build output should be at: $built_app_path" >&2
+    echo "Installed app should be at: $launch_app_path" >&2
     exit 1
   fi
 
-  echo "Running Ticker (dev)..."
+  echo "Running $(lane_display_name) (dev) from: $launch_app_path"
   "$bin_path"
 }
 
 run_prod() {
-  local app_path="$APP/Release/Ticker.app"
+  local built_app_path="$APP/Release/Ticker.app"
+  local launch_app_path
+  launch_app_path="$(lane_install_path)"
 
   echo "Building bundled Web assets..."
   if [[ ! -d "$ROOT_DIR/Web/node_modules" ]]; then
@@ -202,16 +282,18 @@ run_prod() {
   fi
   (cd "$ROOT_DIR/Web" && npm run build)
 
+  echo "Lane: $LANE (bundle id: $(lane_bundle_id), name: $(lane_display_name))"
   build_app "Release"
-  codesign_app_if_configured "$app_path"
+  install_lane_app "$built_app_path" "$launch_app_path"
+  codesign_app_if_configured "$launch_app_path"
 
-  if [[ ! -d "$app_path" ]]; then
-    echo "Error: expected app bundle not found at: $app_path" >&2
+  if [[ ! -d "$launch_app_path" ]]; then
+    echo "Error: expected installed app bundle not found at: $launch_app_path" >&2
     exit 1
   fi
 
-  echo "Launching Ticker (prod)..."
-  open "$app_path"
+  echo "Launching $(lane_display_name) (prod) from: $launch_app_path"
+  open "$launch_app_path"
 }
 
 case "$MODE" in

--- a/tickerctl.local.example.sh
+++ b/tickerctl.local.example.sh
@@ -5,6 +5,16 @@
 # Developer ID identity for codesign (see: security find-identity -p codesigning -v)
 SIGN_IDENTITY='Developer ID Application: Nikolai Kozak (Z5DX2YK8FA)'
 
+# Optional: bundle/id defaults for dual-lane local runs (stable + QA).
+# Stable lane (default commands: run-dev / run-prod)
+# APP_BUNDLE_ID='io.ticker.app'
+# STABLE_APP_INSTALL_PATH="$HOME/Applications/Ticker.app"
+#
+# QA lane (commands: run-dev-qa / run-prod-qa)
+# QA_APP_BUNDLE_ID='io.ticker.app.qa'
+# QA_APP_DISPLAY_NAME='Ticker QA'
+# QA_APP_INSTALL_PATH="$HOME/Applications/Ticker QA.app"
+
 # notarytool Keychain profile name created via:
 #   xcrun notarytool store-credentials AC_PASSWORD --apple-id ... --team-id ... --password <APP_SPECIFIC_PASSWORD>
 NOTARY_PROFILE='AC_PASSWORD'

--- a/tickerctl.sh
+++ b/tickerctl.sh
@@ -16,15 +16,19 @@ Commands:
   clean-derived-data    Delete repo-local Xcode DerivedData (fixes stale SPM artifacts)
   install-sparkle-tools  Install Sparkle CLI tools into ./tools/sparkle (from SwiftPM artifacts)
   build-dev            Build Debug app (unsigned)
-  run-dev              Build Debug + run (starts Vite dev server)
+  run-dev              Build Debug + run stable lane (starts Vite dev server)
+  run-dev-qa           Build Debug + run QA lane (separate bundle ID for TCC isolation)
   build-prod           Build Release app (unsigned, bundles web UI)
-  run-prod             Build Release + run (bundled web UI)
+  run-prod             Build Release + run stable lane (bundled web UI)
+  run-prod-qa          Build Release + run QA lane (bundled web UI)
   release-alpha        Build+sign+notarize+zip+Sparkle-sign (+ optional publish/appcast)
   reset-onboarding     Clear onboarding completion flag (shows onboarding on next launch)
   reset-proxy-soft     Clear Device Key but keep device_id (edits Application Support file)
   reset-proxy-hard     Delete device.json (new device_id on next launch)
-  reset-accessibility  Reset Accessibility permission (TCC) for Ticker
-  reset-screen-recording  Reset Screen Recording permission (TCC) for Ticker
+  reset-accessibility  Reset Accessibility permission (TCC) for stable lane bundle ID
+  reset-accessibility-qa  Reset Accessibility permission (TCC) for QA lane bundle ID
+  reset-screen-recording  Reset Screen Recording permission (TCC) for stable lane bundle ID
+  reset-screen-recording-qa  Reset Screen Recording permission (TCC) for QA lane bundle ID
   reset-proxy-url      Clear proxy URL override (UserDefaults)
   reset-diagnostics    Clear diagnostics opt-out (UserDefaults; defaults to ON)
   reset-all            Convenience reset (onboarding + proxy-hard + proxy-url + diagnostics)
@@ -57,6 +61,8 @@ Config (optional):
 
 Notes:
   - Dev/prod commands build unsigned (CODE_SIGNING_ALLOWED=NO).
+  - `run-dev`/`run-prod` use stable lane (`io.ticker.app` by default).
+  - `run-dev-qa`/`run-prod-qa` use QA lane (`io.ticker.app.qa` by default).
   - Sparkle update testing requires an older build installed in /Applications
     and a newer build published in the appcast.
   - release-alpha also uploads a stable-named zip asset (Ticker-alpha-latest.zip)
@@ -73,6 +79,7 @@ if [[ -f "$CONFIG_FILE" ]]; then
 fi
 
 APP_BUNDLE_ID="${APP_BUNDLE_ID:-io.ticker.app}"
+QA_APP_BUNDLE_ID="${QA_APP_BUNDLE_ID:-io.ticker.app.qa}"
 TICKER_APP_SUPPORT_DIR="${TICKER_APP_SUPPORT_DIR:-$HOME/Library/Application Support/Ticker}"
 TICKER_DEVICE_JSON_PATH="${TICKER_DEVICE_JSON_PATH:-$TICKER_APP_SUPPORT_DIR/device.json}"
 
@@ -459,6 +466,10 @@ cmd_run_dev() {
   TICKER_DERIVED_DATA_PATH="$DERIVED_DATA_PATH" "$ROOT_DIR/run.sh" --dev
 }
 
+cmd_run_dev_qa() {
+  TICKER_DERIVED_DATA_PATH="$DERIVED_DATA_PATH" "$ROOT_DIR/run.sh" --dev --qa
+}
+
 cmd_build_prod() {
   echo "Building web assets…"
   build_web_assets
@@ -490,6 +501,10 @@ repair_release_swiftpm_artifacts_if_needed() {
 
 cmd_run_prod() {
   TICKER_DERIVED_DATA_PATH="$DERIVED_DATA_PATH" "$ROOT_DIR/run.sh" --prod
+}
+
+cmd_run_prod_qa() {
+  TICKER_DERIVED_DATA_PATH="$DERIVED_DATA_PATH" "$ROOT_DIR/run.sh" --prod --qa
 }
 
 cmd_clean_derived_data() {
@@ -1248,26 +1263,38 @@ cmd_reset_proxy_hard() {
   echo "Deleted. Relaunch Ticker to re-register."
 }
 
-cmd_reset_accessibility() {
+reset_tcc_permission() {
+  local service="$1"
+  local bundle_id="$2"
+  local description="$3"
+
   require_cmd tccutil
-  echo "Reset Accessibility permission for $APP_BUNDLE_ID."
-  if ! confirm_action "Run: tccutil reset Accessibility $APP_BUNDLE_ID ? [y/N] "; then
+  echo "Reset $description for $bundle_id."
+  if ! confirm_action "Run: tccutil reset $service $bundle_id ? [y/N] "; then
     echo "Canceled."
     return 0
   fi
-  tccutil reset Accessibility "$APP_BUNDLE_ID"
-  echo "Done. Relaunch Ticker and re-grant Accessibility when prompted."
+  tccutil reset "$service" "$bundle_id"
+}
+
+cmd_reset_accessibility() {
+  reset_tcc_permission "Accessibility" "$APP_BUNDLE_ID" "Accessibility permission (stable lane)"
+  echo "Done. Relaunch stable lane and re-grant Accessibility when prompted."
+}
+
+cmd_reset_accessibility_qa() {
+  reset_tcc_permission "Accessibility" "$QA_APP_BUNDLE_ID" "Accessibility permission (QA lane)"
+  echo "Done. Relaunch QA lane and re-grant Accessibility when prompted."
 }
 
 cmd_reset_screen_recording() {
-  require_cmd tccutil
-  echo "Reset Screen Recording permission for $APP_BUNDLE_ID."
-  if ! confirm_action "Run: tccutil reset ScreenCapture $APP_BUNDLE_ID ? [y/N] "; then
-    echo "Canceled."
-    return 0
-  fi
-  tccutil reset ScreenCapture "$APP_BUNDLE_ID"
-  echo "Done. Relaunch Ticker and re-grant Screen Recording when prompted."
+  reset_tcc_permission "ScreenCapture" "$APP_BUNDLE_ID" "Screen Recording permission (stable lane)"
+  echo "Done. Relaunch stable lane and re-grant Screen Recording when prompted."
+}
+
+cmd_reset_screen_recording_qa() {
+  reset_tcc_permission "ScreenCapture" "$QA_APP_BUNDLE_ID" "Screen Recording permission (QA lane)"
+  echo "Done. Relaunch QA lane and re-grant Screen Recording when prompted."
 }
 
 cmd_reset_proxy_url() {
@@ -1298,6 +1325,7 @@ cmd_reset_all() {
   cmd_reset_diagnostics
   echo "Done."
   echo "Optional: reset Accessibility via: ./tickerctl.sh reset-accessibility"
+  echo "Optional: reset QA Accessibility via: ./tickerctl.sh reset-accessibility-qa"
 }
 
 cmd_versions() {
@@ -1309,10 +1337,12 @@ cmd_versions() {
 cmd_menu() {
   PS3="Select an action: "
   select choice in \
-    "Build Debug (dev)" \
-    "Build + Run Debug (dev)" \
-    "Build Release (prod, unsigned)" \
-    "Build + Run Release (prod, unsigned)" \
+    "Build Debug (dev, stable lane)" \
+    "Build + Run Debug (dev, stable lane)" \
+    "Build + Run Debug (dev, QA lane)" \
+    "Build Release (prod, unsigned, stable lane)" \
+    "Build + Run Release (prod, stable lane)" \
+    "Build + Run Release (prod, QA lane)" \
     "Preflight (alpha): contracts + web typecheck + swift tests" \
     "Clean DerivedData (dev/prod + release)" \
     "Release (alpha): build+sign+notarize+zip+Sparkle-sign" \
@@ -1322,8 +1352,10 @@ cmd_menu() {
     "Reset: onboarding" \
     "Reset: proxy (soft)" \
     "Reset: proxy (hard)" \
-    "Reset: Accessibility permission" \
-    "Reset: Screen Recording permission" \
+    "Reset: Accessibility permission (stable lane)" \
+    "Reset: Accessibility permission (QA lane)" \
+    "Reset: Screen Recording permission (stable lane)" \
+    "Reset: Screen Recording permission (QA lane)" \
     "Reset: proxy URL override" \
     "Reset: diagnostics toggle" \
     "Reset: all (onboarding + proxy-hard + proxy-url + diagnostics)" \
@@ -1338,18 +1370,26 @@ cmd_menu() {
       break
       ;;
     3)
-      cmd_build_prod
+      cmd_run_dev_qa
       break
       ;;
     4)
-      cmd_run_prod
+      cmd_build_prod
       break
       ;;
     5)
-      cmd_preflight_alpha
+      cmd_run_prod
       break
       ;;
     6)
+      cmd_run_prod_qa
+      break
+      ;;
+    7)
+      cmd_preflight_alpha
+      break
+      ;;
+    8)
       echo "Clean which DerivedData?"
       select dd in \
         "Dev/Prod only (./.build/xcode)" \
@@ -1375,61 +1415,69 @@ cmd_menu() {
       done
       break
       ;;
-    7)
+    9)
       echo "Enter marketing version (e.g. 2025.12.1):"
       read -r v
       cmd_release_alpha --version "$v"
       break
       ;;
-    8)
+    10)
       echo "Enter marketing version (e.g. 2025.12.1):"
       read -r v
       cmd_release_alpha --version "$v" --promote
       break
       ;;
-    9)
+    11)
       echo "Enter marketing version (e.g. 2025.12.1):"
       read -r v
       cmd_release_alpha --version "$v" --skip-build --promote
       break
       ;;
-    10)
+    12)
       cmd_versions
       break
       ;;
-    11)
+    13)
       cmd_reset_onboarding
       break
       ;;
-    12)
+    14)
       cmd_reset_proxy_soft
       break
       ;;
-    13)
+    15)
       cmd_reset_proxy_hard
       break
       ;;
-    14)
+    16)
       cmd_reset_accessibility
       break
       ;;
-    15)
-      cmd_reset_screen_recording
-      break
-      ;;
-    16)
-      cmd_reset_proxy_url
-      break
-      ;;
     17)
-      cmd_reset_diagnostics
+      cmd_reset_accessibility_qa
       break
       ;;
     18)
+      cmd_reset_screen_recording
+      break
+      ;;
+    19)
+      cmd_reset_screen_recording_qa
+      break
+      ;;
+    20)
+      cmd_reset_proxy_url
+      break
+      ;;
+    21)
+      cmd_reset_diagnostics
+      break
+      ;;
+    22)
       cmd_reset_all
       break
       ;;
-    19) break ;;
+    23) break ;;
     *) echo "Invalid selection" ;;
     esac
   done
@@ -1450,14 +1498,18 @@ main() {
   install-sparkle-tools) cmd_install_sparkle_tools "$@" ;;
   build-dev) cmd_build_dev ;;
   run-dev) cmd_run_dev ;;
+  run-dev-qa) cmd_run_dev_qa ;;
   build-prod) cmd_build_prod ;;
   run-prod) cmd_run_prod ;;
+  run-prod-qa) cmd_run_prod_qa ;;
   release-alpha) cmd_release_alpha "$@" ;;
   reset-onboarding) cmd_reset_onboarding ;;
   reset-proxy-soft) cmd_reset_proxy_soft ;;
   reset-proxy-hard) cmd_reset_proxy_hard ;;
   reset-accessibility) cmd_reset_accessibility ;;
+  reset-accessibility-qa) cmd_reset_accessibility_qa ;;
   reset-screen-recording) cmd_reset_screen_recording ;;
+  reset-screen-recording-qa) cmd_reset_screen_recording_qa ;;
   reset-proxy-url) cmd_reset_proxy_url ;;
   reset-diagnostics) cmd_reset_diagnostics ;;
   reset-all) cmd_reset_all ;;


### PR DESCRIPTION
## Summary
- add dual local run lanes to stabilize macOS TCC behavior:
  - stable lane (`io.ticker.app`) via `run-dev` / `run-prod`
  - QA lane (`io.ticker.app.qa`) via `run-dev-qa` / `run-prod-qa`
- update `run.sh` to install lane apps to fixed locations and launch from there
  - stable: `~/Applications/Ticker.app`
  - QA: `~/Applications/Ticker QA.app`
- add QA-specific TCC reset commands in `tickerctl.sh`
  - `reset-accessibility-qa`
  - `reset-screen-recording-qa`
- improve runtime screenshot flow when Screen Recording permission is missing:
  - request/register access (`CGRequestScreenCaptureAccess()`)
  - deep-link to Screen Recording settings once per launch
  - show actionable status message
- document lane usage and config knobs in `docs/START_HERE.md` and `tickerctl.local.example.sh`

Closes #112.

## Test Plan
- `bash -n run.sh`
- `bash -n tickerctl.sh`
- `./run.sh --help`
- `./tickerctl.sh --help`
- `./tickerctl.sh swift-test`

## Manual Validation (required)
1. Run stable lane: `./tickerctl.sh run-dev`
2. Run QA lane: `./tickerctl.sh run-dev-qa`
3. Grant Accessibility + Screen Recording for both lanes.
4. Rebuild/relaunch both lanes and verify permissions persist.
5. Reset only QA permissions:
   - `./tickerctl.sh reset-accessibility-qa`
   - `./tickerctl.sh reset-screen-recording-qa`
6. Confirm stable lane remains granted while QA lane re-prompts.
