### PR TITLE
Fix quick panel screenshot/text insertion order drift

### DIFF
--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -391,20 +391,15 @@ final class QuickPanelManager: ObservableObject {
             // Get target stream (may create new one)
             let (streamId, isNewStream) = try getTargetStreamId()
 
-            // Get insertion order - inserts before trailing empty cell if one exists
-            // This bumps the empty cell's order, so we only call it once
-            var nextOrder = try persistence.getInsertionOrderForQuickPanel(streamId: streamId)
-
-            var cellsToAdd: [Cell] = []
+            var pendingCells: [Cell] = []
             var contextCellId: UUID?
+            var triggerAICellId: UUID?
 
             // 1. If we have context (selection or image), create a quote cell
             if let ctx = context, ctx.hasContent {
-                let contextCell = createContextCell(from: ctx, streamId: streamId, order: nextOrder)
-                cellsToAdd.append(contextCell)
+                let contextCell = createContextCell(from: ctx, streamId: streamId)
+                pendingCells.append(contextCell)
                 contextCellId = contextCell.id
-                try persistence.saveCell(contextCell)
-                nextOrder += 1
             }
 
             // 2. If we have input text
@@ -418,31 +413,25 @@ final class QuickPanelManager: ObservableObject {
                         content: "",  // Will be filled by AI
                         originalPrompt: trimmedInput,
                         type: .aiResponse,
-                        order: nextOrder,
+                        order: 0,  // Final order assigned atomically at persistence time.
                         references: contextCellId.map { [$0] }
                     )
-                    cellsToAdd.append(aiCell)
-                    try persistence.saveCell(aiCell)
-
-                    // Notify frontend to trigger AI on this cell
-                    notifyFrontend(streamId: streamId, cells: cellsToAdd, triggerAI: aiCell.id, isNewStream: isNewStream)
+                    pendingCells.append(aiCell)
+                    triggerAICellId = aiCell.id
                 } else {
                     // Create plain text cell
                     let textCell = Cell(
                         streamId: streamId,
                         content: "<p>\(escapeHtml(trimmedInput))</p>",
                         type: .text,
-                        order: nextOrder
+                        order: 0  // Final order assigned atomically at persistence time.
                     )
-                    cellsToAdd.append(textCell)
-                    try persistence.saveCell(textCell)
-
-                    notifyFrontend(streamId: streamId, cells: cellsToAdd, triggerAI: nil, isNewStream: isNewStream)
+                    pendingCells.append(textCell)
                 }
-            } else {
-                // Context only - just notify
-                notifyFrontend(streamId: streamId, cells: cellsToAdd, triggerAI: nil, isNewStream: isNewStream)
             }
+
+            let persistedCells = try persistence.insertQuickPanelCells(streamId: streamId, cells: pendingCells)
+            notifyFrontend(streamId: streamId, cells: persistedCells, triggerAI: triggerAICellId, isNewStream: isNewStream)
 
             // Success - hide panel
             hide()
@@ -514,7 +503,7 @@ final class QuickPanelManager: ObservableObject {
     }
 
     /// Create a quote cell from captured context
-    private func createContextCell(from ctx: QuickPanelContext, streamId: UUID, order: Int) -> Cell {
+    private func createContextCell(from ctx: QuickPanelContext, streamId: UUID) -> Cell {
         var content = ""
 
         // Build source attribution: "App — Window Title" or just "App"
@@ -550,7 +539,7 @@ final class QuickPanelManager: ObservableObject {
             streamId: streamId,
             content: content,
             type: .quote,
-            order: order,
+            order: 0,  // Final order assigned atomically at persistence time.
             sourceApp: ctx.activeApp
         )
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -14,9 +14,8 @@ final class PersistenceService {
 #endif
     }
 
-    init() throws {
-        let fileManager = FileManager.default
-        let databaseURL = Self.databaseURL(fileManager: fileManager)
+    init(databaseURL: URL? = nil, fileManager: FileManager = .default) throws {
+        let databaseURL = databaseURL ?? Self.databaseURL(fileManager: fileManager)
         self.databaseURL = databaseURL
         self.didDatabaseExistOnInit = fileManager.fileExists(atPath: databaseURL.path)
 
@@ -481,42 +480,38 @@ final class PersistenceService {
     /// Also bumps the order of the trailing empty cell if one exists
     func getInsertionOrderForQuickPanel(streamId: UUID) throws -> Int {
         try dbQueue.write { db in
-            // Find the last cell - check if it's empty
-            let lastCell = try Row.fetchOne(db, sql: """
-                SELECT id, position, content
-                FROM cells
-                WHERE stream_id = ?
-                ORDER BY position DESC
-                LIMIT 1
-            """, arguments: [streamId.uuidString])
+            try getInsertionOrderForQuickPanel(streamId: streamId, insertionCount: 1, db: db)
+        }
+    }
 
-            guard let lastCell = lastCell else {
-                // No cells - start at 0
-                return 0
+    /// Insert a batch of Quick Panel cells atomically at the next insertion point.
+    /// Returns the persisted cells with finalized sequential order values.
+    func insertQuickPanelCells(streamId: UUID, cells: [Cell]) throws -> [Cell] {
+        guard !cells.isEmpty else { return [] }
+
+        return try dbQueue.write { db in
+            let insertionOrder = try getInsertionOrderForQuickPanel(
+                streamId: streamId,
+                insertionCount: cells.count,
+                db: db
+            )
+
+            var persisted: [Cell] = []
+            persisted.reserveCapacity(cells.count)
+
+            for (offset, baseCell) in cells.enumerated() {
+                var cell = baseCell
+                cell.order = insertionOrder + offset
+                try saveCell(cell, in: db, updateStreamTimestamp: false)
+                persisted.append(cell)
             }
 
-            let lastContent = lastCell["content"] as? String ?? ""
-            let lastOrder = lastCell["position"] as? Int ?? 0
+            try db.execute(
+                sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
+                arguments: [Date().timeIntervalSince1970, streamId.uuidString]
+            )
 
-            // Check if last cell is empty (no content or just empty HTML tags)
-            let trimmedContent = lastContent
-                .replacingOccurrences(of: "<p>", with: "")
-                .replacingOccurrences(of: "</p>", with: "")
-                .replacingOccurrences(of: "<br>", with: "")
-                .replacingOccurrences(of: "&nbsp;", with: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-            if trimmedContent.isEmpty {
-                // Last cell is empty - bump its order and insert at its old position
-                let lastCellId = lastCell["id"] as? String ?? ""
-                try db.execute(sql: """
-                    UPDATE cells SET position = position + 10 WHERE id = ?
-                """, arguments: [lastCellId])
-                return lastOrder
-            } else {
-                // Last cell has content - insert after it
-                return lastOrder + 1
-            }
+            return persisted
         }
     }
 
@@ -524,99 +519,161 @@ final class PersistenceService {
 
     func saveCell(_ cell: Cell) throws {
         try dbQueue.write { db in
-            let bindingJson: String?
-            if let binding = cell.sourceBinding {
-                bindingJson = String(data: try JSONEncoder().encode(binding), encoding: .utf8)
-            } else {
-                bindingJson = nil
-            }
+            try saveCell(cell, in: db, updateStreamTimestamp: true)
+        }
+    }
 
-            let metadataJson = "{}"  // Simplified for now
+    private func saveCell(_ cell: Cell, in db: Database, updateStreamTimestamp: Bool) throws {
+        let bindingJson: String?
+        if let binding = cell.sourceBinding {
+            bindingJson = String(data: try JSONEncoder().encode(binding), encoding: .utf8)
+        } else {
+            bindingJson = nil
+        }
 
-            // Encode modifier stack fields
-            let modifiersJson: String?
-            if let modifiers = cell.modifiers {
-                modifiersJson = String(data: try JSONEncoder().encode(modifiers), encoding: .utf8)
-            } else {
-                modifiersJson = nil
-            }
+        let metadataJson = "{}"  // Simplified for now
 
-            let versionsJson: String?
-            if let versions = cell.versions {
-                versionsJson = String(data: try JSONEncoder().encode(versions), encoding: .utf8)
-            } else {
-                versionsJson = nil
-            }
+        // Encode modifier stack fields
+        let modifiersJson: String?
+        if let modifiers = cell.modifiers {
+            modifiersJson = String(data: try JSONEncoder().encode(modifiers), encoding: .utf8)
+        } else {
+            modifiersJson = nil
+        }
 
-            let activeVersionIdStr = cell.activeVersionId?.uuidString
+        let versionsJson: String?
+        if let versions = cell.versions {
+            versionsJson = String(data: try JSONEncoder().encode(versions), encoding: .utf8)
+        } else {
+            versionsJson = nil
+        }
 
-            // Encode processing fields
-            let processingConfigJson: String?
-            if let processingConfig = cell.processingConfig {
-                processingConfigJson = String(data: try JSONEncoder().encode(processingConfig), encoding: .utf8)
-            } else {
-                processingConfigJson = nil
-            }
+        let activeVersionIdStr = cell.activeVersionId?.uuidString
 
-            let referencesJson: String?
-            if let references = cell.references {
-                referencesJson = String(data: try JSONEncoder().encode(references), encoding: .utf8)
-            } else {
-                referencesJson = nil
-            }
+        // Encode processing fields
+        let processingConfigJson: String?
+        if let processingConfig = cell.processingConfig {
+            processingConfigJson = String(data: try JSONEncoder().encode(processingConfig), encoding: .utf8)
+        } else {
+            processingConfigJson = nil
+        }
 
-            try db.execute(
-                sql: """
-                    INSERT INTO cells (id, stream_id, type, content, original_prompt, state, source_binding_json, metadata_json, created_at, updated_at, position, modifiers_json, versions_json, active_version_id, processing_config_json, references_json, block_name, source_app)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(id) DO UPDATE SET
-                        content = excluded.content,
-                        original_prompt = CASE
-                            WHEN excluded.type = 'aiResponse' AND excluded.original_prompt IS NULL
-                            THEN cells.original_prompt
-                            ELSE excluded.original_prompt
-                        END,
-                        type = excluded.type,
-                        state = excluded.state,
-                        source_binding_json = excluded.source_binding_json,
-                        updated_at = excluded.updated_at,
-                        position = excluded.position,
-                        modifiers_json = excluded.modifiers_json,
-                        versions_json = excluded.versions_json,
-                        active_version_id = excluded.active_version_id,
-                        processing_config_json = excluded.processing_config_json,
-                        references_json = excluded.references_json,
-                        block_name = excluded.block_name,
-                        source_app = excluded.source_app
-                """,
-                arguments: [
-                    cell.id.uuidString,
-                    cell.streamId.uuidString,
-                    cell.type.rawValue,
-                    cell.content,
-                    cell.originalPrompt,
-                    "idle",
-                    bindingJson,
-                    metadataJson,
-                    cell.createdAt.timeIntervalSince1970,
-                    cell.updatedAt.timeIntervalSince1970,
-                    cell.order,
-                    modifiersJson,
-                    versionsJson,
-                    activeVersionIdStr,
-                    processingConfigJson,
-                    referencesJson,
-                    cell.blockName,
-                    cell.sourceApp
-                ]
-            )
+        let referencesJson: String?
+        if let references = cell.references {
+            referencesJson = String(data: try JSONEncoder().encode(references), encoding: .utf8)
+        } else {
+            referencesJson = nil
+        }
 
+        try db.execute(
+            sql: """
+                INSERT INTO cells (id, stream_id, type, content, original_prompt, state, source_binding_json, metadata_json, created_at, updated_at, position, modifiers_json, versions_json, active_version_id, processing_config_json, references_json, block_name, source_app)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    content = excluded.content,
+                    original_prompt = CASE
+                        WHEN excluded.type = 'aiResponse' AND excluded.original_prompt IS NULL
+                        THEN cells.original_prompt
+                        ELSE excluded.original_prompt
+                    END,
+                    type = excluded.type,
+                    state = excluded.state,
+                    source_binding_json = excluded.source_binding_json,
+                    updated_at = excluded.updated_at,
+                    position = excluded.position,
+                    modifiers_json = excluded.modifiers_json,
+                    versions_json = excluded.versions_json,
+                    active_version_id = excluded.active_version_id,
+                    processing_config_json = excluded.processing_config_json,
+                    references_json = excluded.references_json,
+                    block_name = excluded.block_name,
+                    source_app = excluded.source_app
+            """,
+            arguments: [
+                cell.id.uuidString,
+                cell.streamId.uuidString,
+                cell.type.rawValue,
+                cell.content,
+                cell.originalPrompt,
+                "idle",
+                bindingJson,
+                metadataJson,
+                cell.createdAt.timeIntervalSince1970,
+                cell.updatedAt.timeIntervalSince1970,
+                cell.order,
+                modifiersJson,
+                versionsJson,
+                activeVersionIdStr,
+                processingConfigJson,
+                referencesJson,
+                cell.blockName,
+                cell.sourceApp
+            ]
+        )
+
+        if updateStreamTimestamp {
             // Update stream's updated_at
             try db.execute(
                 sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
                 arguments: [Date().timeIntervalSince1970, cell.streamId.uuidString]
             )
         }
+    }
+
+    private func getInsertionOrderForQuickPanel(
+        streamId: UUID,
+        insertionCount: Int,
+        db: Database
+    ) throws -> Int {
+        precondition(insertionCount > 0)
+
+        struct LastQuickPanelCell: FetchableRecord, Decodable {
+            let id: String
+            let position: Int
+            let content: String
+        }
+
+        // Find the last cell - check if it's empty.
+        let lastCell = try LastQuickPanelCell.fetchOne(db, sql: """
+            SELECT id, position, content
+            FROM cells
+            WHERE stream_id = ?
+            ORDER BY position DESC
+            LIMIT 1
+        """, arguments: [streamId.uuidString])
+
+        guard let lastCell else {
+            // No cells - start at 0.
+            return 0
+        }
+
+        if isQuickPanelEmptyCellContent(lastCell.content) {
+            // Keep a trailing empty cell at the end by shifting it exactly by the insertion batch size.
+            try db.execute(
+                sql: "UPDATE cells SET position = position + ? WHERE id = ?",
+                arguments: [insertionCount, lastCell.id]
+            )
+            return lastCell.position
+        }
+
+        // Last cell has meaningful content - append after it.
+        return lastCell.position + 1
+    }
+
+    private func isQuickPanelEmptyCellContent(_ html: String) -> Bool {
+        // Images and other embedded media count as meaningful content even if text is empty.
+        let lowered = html.lowercased()
+        if lowered.contains("<img") || lowered.contains("<video") || lowered.contains("<audio")
+            || lowered.contains("<iframe") || lowered.contains("<object") || lowered.contains("<embed") {
+            return false
+        }
+
+        let textOnly = lowered
+            .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return textOnly.isEmpty
     }
 
     /// Fetch a single cell's content by ID (used for asset cleanup)

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -105,3 +105,134 @@ final class DeviceKeyServiceTests: XCTestCase {
     }
 }
 
+final class PersistenceServiceQuickPanelTests: XCTestCase {
+    func test_insertQuickPanelCells_insertsAdjacentPairBeforeTrailingEmptyCell() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Test Stream")
+            try service.saveStream(stream)
+
+            let leading = Cell(
+                streamId: stream.id,
+                content: "<p>Existing note</p>",
+                type: .text,
+                order: 0
+            )
+            let trailingEmpty = Cell(
+                streamId: stream.id,
+                content: "<p></p>",
+                type: .text,
+                order: 1
+            )
+
+            try service.saveCell(leading)
+            try service.saveCell(trailingEmpty)
+
+            let context = Cell(
+                streamId: stream.id,
+                content: "<p><img src=\"ticker-asset:///stream/s1.png\" alt=\"Screenshot\"></p>",
+                type: .quote,
+                order: 0
+            )
+            let note = Cell(
+                streamId: stream.id,
+                content: "<p>A quick note</p>",
+                type: .text,
+                order: 0
+            )
+
+            let inserted = try service.insertQuickPanelCells(streamId: stream.id, cells: [context, note])
+            XCTAssertEqual(inserted.count, 2)
+            XCTAssertEqual(inserted[0].order, 1)
+            XCTAssertEqual(inserted[1].order, 2)
+
+            guard let loaded = try service.loadStream(id: stream.id) else {
+                XCTFail("Expected stream to load")
+                return
+            }
+
+            let sorted = loaded.cells.sorted { $0.order < $1.order }
+            XCTAssertEqual(sorted.map(\.id), [leading.id, context.id, note.id, trailingEmpty.id])
+            XCTAssertEqual(sorted.map(\.order), [0, 1, 2, 3])
+        }
+    }
+
+    func test_insertQuickPanelCells_repeatedCapturesKeepEachPairAdjacent() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Repeated Captures")
+            try service.saveStream(stream)
+
+            let base = Cell(
+                streamId: stream.id,
+                content: "<p>Start</p>",
+                type: .text,
+                order: 0
+            )
+            let trailingEmpty = Cell(
+                streamId: stream.id,
+                content: "<p></p>",
+                type: .text,
+                order: 1
+            )
+            try service.saveCell(base)
+            try service.saveCell(trailingEmpty)
+
+            var capturePairs: [(quoteId: UUID, noteId: UUID)] = []
+
+            for idx in 0..<3 {
+                let quote = Cell(
+                    streamId: stream.id,
+                    content: "<p><img src=\"ticker-asset:///stream/capture-\(idx).png\" alt=\"Screenshot\"></p>",
+                    type: .quote,
+                    order: 0
+                )
+                let note = Cell(
+                    streamId: stream.id,
+                    content: "<p>Capture \(idx)</p>",
+                    type: .text,
+                    order: 0
+                )
+                let inserted = try service.insertQuickPanelCells(streamId: stream.id, cells: [quote, note])
+                XCTAssertEqual(inserted[0].order + 1, inserted[1].order)
+                capturePairs.append((quoteId: quote.id, noteId: note.id))
+            }
+
+            guard let loaded = try service.loadStream(id: stream.id) else {
+                XCTFail("Expected stream to load")
+                return
+            }
+
+            let sorted = loaded.cells.sorted { $0.order < $1.order }
+            let ordersById = Dictionary(uniqueKeysWithValues: sorted.map { ($0.id, $0.order) })
+
+            for pair in capturePairs {
+                guard let quoteOrder = ordersById[pair.quoteId], let noteOrder = ordersById[pair.noteId] else {
+                    XCTFail("Missing persisted capture pair")
+                    return
+                }
+                XCTAssertEqual(quoteOrder + 1, noteOrder)
+            }
+
+            XCTAssertEqual(sorted.last?.id, trailingEmpty.id)
+        }
+    }
+
+    private func withTempPersistenceService(_ body: (PersistenceService) throws -> Void) throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let dbURL = tempDir.appendingPathComponent("ticker.db")
+
+        var service: PersistenceService? = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+        defer {
+            service = nil
+            _ = try? fileManager.removeItem(at: tempDir)
+        }
+
+        guard let service else {
+            XCTFail("Expected persistence service")
+            return
+        }
+
+        try body(service)
+    }
+}


### PR DESCRIPTION
## Summary
- insert Quick Panel context + input cells atomically so they receive contiguous positions from one insertion decision
- preserve and shift a trailing empty cell by the exact insertion batch size
- harden trailing-empty detection so image/media cells are never treated as empty
- add persistence tests covering adjacent screenshot+text insertion and repeated captures

## Root Cause
- Quick Panel was persisting context and text in separate writes when the stream view was closed, so insertion position could be recomputed against changed state.
- trailing-empty insertion logic read position via an optional cast that could fall back to 0, producing top-of-stream inserts while also moving the trailing empty cell.

## Testing
- `xcodebuild test -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath .build/xcode CODE_SIGNING_ALLOWED=NO`

Closes #114

## Manual validation requested
Please test screenshot capture with stream closed vs open before merge.
