### PR TITLE
Fix assistant-role image replay in multimodal stream history

### DIFF
--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -753,11 +753,15 @@ final class WebViewManager: NSObject {
                         // Resolve references in prior cell content
                         cellDict["content"] = DependencyService.resolveReferencesInContent(content, cells: streamCells)
                     }
-                    if let type = cell["type"] as? String {
+                    let type = cell["type"] as? String
+                    if let type {
                         cellDict["type"] = type
                     }
-                    // Convert prior cell images to data URLs
-                    if let imageURLs = cell["imageURLs"] as? [String], !imageURLs.isEmpty {
+                    // Only user-role history should carry images to the model.
+                    // aiResponse maps to assistant role and OpenAI rejects assistant image parts.
+                    if type != "aiResponse",
+                       let imageURLs = cell["imageURLs"] as? [String],
+                       !imageURLs.isEmpty {
                         cellDict["imageURLs"] = assetService.assetsToDataURLs(imageURLs)
                     }
                     priorCells.append(cellDict)

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -168,15 +168,24 @@ final class AIOrchestrator {
         // Add prior cells as conversation history
         // Note: priorCells already excludes the current cell (filtered upstream)
         for cell in priorCells {
-            let role = (cell["type"] as? String) == "aiResponse" ? "assistant" : "user"
+            let role = roleForCellType(cell["type"] as? String)
             if let content = cell["content"] as? String, !content.isEmpty {
-                let imageURLs = cell["imageURLs"] as? [String] ?? []
+                let imageURLs = sanitizeImageURLs(
+                    cell["imageURLs"] as? [String] ?? [],
+                    forRole: role
+                )
                 messages.append(LLMMessage(role: role, content: content, imageURLs: imageURLs))
             }
         }
 
         // Add current query with any attached images
-        messages.append(LLMMessage(role: "user", content: query, imageURLs: queryImages))
+        messages.append(
+            LLMMessage(
+                role: "user",
+                content: query,
+                imageURLs: sanitizeImageURLs(queryImages, forRole: "user")
+            )
+        )
 
         // Build intent for proxy if classification result available
         let llmIntent = classificationResult.map { LLMIntent(from: $0) }
@@ -188,6 +197,15 @@ final class AIOrchestrator {
             maxTokens: 2048,
             intent: llmIntent
         )
+    }
+
+    private func roleForCellType(_ type: String?) -> String {
+        type == "aiResponse" ? "assistant" : "user"
+    }
+
+    private func sanitizeImageURLs(_ imageURLs: [String], forRole role: String) -> [String] {
+        guard role == "user" else { return [] }
+        return imageURLs.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     }
 }
 

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -507,13 +507,14 @@ final class ProxyLLMService: LLMProvider {
         ]
 
         for msg in request.messages {
-            if msg.hasImages {
+            let imageURLs = sanitizeImageURLs(msg.imageURLs, forRole: msg.role)
+            if !imageURLs.isEmpty {
                 // Multimodal message
                 var content: [[String: Any]] = [
                     ["type": "text", "text": msg.content]
                 ]
 
-                for imageURL in msg.imageURLs {
+                for imageURL in imageURLs {
                     if imageURL.starts(with: "data:") {
                         // Parse data URL and convert to proxy format
                         if let (mediaType, base64Data) = parseDataURL(imageURL) {
@@ -541,6 +542,17 @@ final class ProxyLLMService: LLMProvider {
         }
 
         return messages
+    }
+
+    private func sanitizeImageURLs(_ imageURLs: [String], forRole role: String) -> [String] {
+        guard role == "user" else {
+            if !imageURLs.isEmpty {
+                debugLog("Dropping \(imageURLs.count) image(s) from non-user role=\(role)")
+            }
+            return []
+        }
+
+        return imageURLs.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
     }
 
     /// Parse a data URL into media type and base64 data


### PR DESCRIPTION
## Summary
This fixes a multimodal replay bug where prior `aiResponse` cells could replay preserved image URLs as `assistant` messages, causing OpenAI to reject the request (`image_url` is only valid on `user` role messages).

## Changes
- `AIOrchestrator`: sanitize history image attachments so only `user` role messages can include images.
- `ProxyLLMService`: add a final payload guard to drop image URLs on non-`user` roles before proxy JSON build.
- `WebViewManager`: skip converting prior `aiResponse` image URLs to data URLs.

## Why this bug appeared on second run
First multimodal request succeeds because the current prompt is `user` with image content. On the next request, the previous AI cell (now `assistant`) was replayed with extracted `<img src>` URLs, producing an invalid OpenAI message.

## Validation
- Ran `./tickerctl.sh swift-test` (passes; existing unrelated warnings remain).

Closes #116

## Manual validation requested
Please manually verify in-app:
1. Run `Cmd+Enter` on a text+image cell (success).
2. Run `Cmd+Enter` again on a new text+image cell in the same stream.
3. Confirm no proxy streaming error and no `assistant` image-role rejection upstream.
