### PR TITLE
fix: deprecate app-initiated screenshots and remove screen recording onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ Global capture panel accessible via **Cmd+L** from any app. Captures selected te
 
 **Hotkeys:**
 - `Cmd+L` — Toggle Quick Panel (captures selection before opening)
-- `Cmd+;` — Screenshot mode (triggers screencapture, then opens panel)
+- `Cmd+;` — Deprecated screenshot hotkey (shows guidance to use macOS screenshot-to-clipboard + `Cmd+L`)
 
 **Input Modes:**
 | Context | Action | Result |

--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -33,7 +33,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // Quick Panel services
     private var hotkeyService: HotkeyService?
     private var quickPanelManager: QuickPanelManager?
-    private var didOpenScreenRecordingSettingsThisLaunch = false
 
     // Sparkle updater (lives for app lifetime)
     private let updaterController = SPUStandardUpdaterController(
@@ -350,10 +349,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self?.triggerQuickPanelToggle()
         }
 
-        // Register Screenshot hotkey (Cmd+;)
+        // Register deprecated screenshot hotkey (Cmd+;).
+        // We keep the binding for discoverability while app-initiated capture is disabled.
         hotkeyService?.register(config: .screenshot) { [weak self] in
             Task { @MainActor in
-                self?.captureScreenshot()
+                self?.handleDeprecatedScreenshotHotkey()
             }
         }
 
@@ -365,78 +365,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    private func openScreenRecordingSystemSettings() {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") else {
-            return
-        }
-        _ = NSWorkspace.shared.open(url)
-    }
-
-    /// Capture screenshot using system tool, then show Quick Panel
+    /// Deprecated until we migrate to a Sequoia-style picker flow.
+    /// Users can still attach screenshots by capturing to clipboard with macOS, then pressing Cmd+L.
     @MainActor
-    private func captureScreenshot() {
-        // Screen recording permission is required for capturing other apps' windows.
-        // Without it, macOS may redact capture output (e.g., Desktop only).
-        if !CGPreflightScreenCaptureAccess() {
-            DebugLog.log("[Screenshot] Screen recording permission missing")
-
-            // Requesting access registers Ticker with macOS so it appears in the Screen Recording list.
-            let granted = CGRequestScreenCaptureAccess()
-            if granted {
-                quickPanelManager?.showWithStatusMessage("Screen Recording enabled. Restart Ticker.")
-                return
-            }
-
-            // If access is denied/already denied, deep-link once per launch so users land in the right pane.
-            if !didOpenScreenRecordingSettingsThisLaunch {
-                didOpenScreenRecordingSettingsThisLaunch = true
-                openScreenRecordingSystemSettings()
-            }
-            quickPanelManager?.showWithStatusMessage("Enable Screen Recording in System Settings, then restart Ticker")
-            return
-        }
-
-        let pasteboardChangeCountBefore = ClipboardService.changeCount()
-
-        // Use screencapture to capture to clipboard
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-        process.arguments = ["-ic"]  // Interactive, clipboard
-
-        process.terminationHandler = { [weak self] terminatedProcess in
-            Task { @MainActor in
-                // Only show panel if capture succeeded (exit code 0)
-                // User cancellation (ESC) returns exit code 1
-                guard terminatedProcess.terminationStatus == 0 else {
-                    DebugLog.log("[Screenshot] Capture cancelled or failed (exit code: \(terminatedProcess.terminationStatus))")
-                    return
-                }
-
-                // Short delay to allow clipboard to update
-                try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1s
-
-                // Ensure the clipboard actually changed; otherwise we may be reading a stale image.
-                let pasteboardChangeCountAfter = ClipboardService.changeCount()
-                guard pasteboardChangeCountAfter != pasteboardChangeCountBefore else {
-                    DebugLog.log("[Screenshot] Clipboard did not change after capture; aborting attach")
-                    self?.quickPanelManager?.showWithStatusMessage("Screenshot didn't reach clipboard")
-                    return
-                }
-
-                // Verify clipboard actually has an image before showing panel
-                guard ClipboardService.hasImage() else {
-                    DebugLog.log("[Screenshot] No image in clipboard after capture")
-                    return
-                }
-
-                self?.quickPanelManager?.showAfterScreenshot()
-            }
-        }
-
-        do {
-            try process.run()
-        } catch {
-            DebugLog.log("[Screenshot] Failed to run screencapture (\(DebugLog.errorSummary(error)))")
-        }
+    private func handleDeprecatedScreenshotHotkey() {
+        quickPanelManager?.showWithStatusMessage(
+            "Screenshot mode is deprecated. Use macOS screenshot shortcuts, then press Cmd+L."
+        )
     }
 }

--- a/Sources/Ticker/App/Onboarding/OnboardingView.swift
+++ b/Sources/Ticker/App/Onboarding/OnboardingView.swift
@@ -1,22 +1,18 @@
 import SwiftUI
 import AppKit
 import ApplicationServices
-import CoreGraphics
 
 /// Onboarding view shown on first launch
 struct OnboardingView: View {
     @State private var step: OnboardingStep = .welcome
     @State private var hasAccessibility = false
     @State private var isPromptingAccessibility = false
-    @State private var hasScreenRecording = false
-    @State private var isPromptingScreenRecording = false
 
     var onComplete: () -> Void
 
     enum OnboardingStep {
         case welcome
         case accessibility
-        case screenRecording
         case complete
     }
 
@@ -24,7 +20,7 @@ struct OnboardingView: View {
         VStack(spacing: 0) {
             // Progress indicator
             HStack(spacing: 8) {
-                ForEach(0..<4, id: \.self) { index in
+                ForEach(0..<3, id: \.self) { index in
                     Circle()
                         .fill(stepIndex >= index ? Color.accentColor : Color.gray.opacity(0.3))
                         .frame(width: 8, height: 8)
@@ -40,8 +36,6 @@ struct OnboardingView: View {
                     welcomeStep
                 case .accessibility:
                     accessibilityStep
-                case .screenRecording:
-                    screenRecordingStep
                 case .complete:
                     completeStep
                 }
@@ -62,8 +56,7 @@ struct OnboardingView: View {
         switch step {
         case .welcome: return 0
         case .accessibility: return 1
-        case .screenRecording: return 2
-        case .complete: return 3
+        case .complete: return 2
         }
     }
 
@@ -142,80 +135,6 @@ struct OnboardingView: View {
 
             HStack(spacing: 12) {
                 Button("Skip for now") {
-                    withAnimation { step = .screenRecording }
-                }
-                .buttonStyle(.plain)
-                .foregroundColor(.secondary)
-
-                Button(hasAccessibility ? "Continue" : "Continue") {
-                    withAnimation { step = .screenRecording }
-                }
-                .buttonStyle(.borderedProminent)
-            }
-        }
-        .onAppear { checkAccessibility() }
-    }
-
-    // MARK: - Screen Recording Step
-
-    private var screenRecordingStep: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "rectangle.inset.filled.and.cursorarrow")
-                .font(.system(size: 48))
-                .foregroundColor(.accentColor)
-
-            Text("Screen Recording Permission")
-                .font(.system(size: 20, weight: .semibold))
-
-            Text("Ticker needs Screen Recording permission to capture screenshots when you press Cmd+;.")
-                .font(.system(size: 13))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-
-            Text("After enabling, you may need to restart Ticker for it to take effect.")
-                .font(.system(size: 12))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-
-            Text("If Ticker isn’t listed, click “+” and add Ticker manually.")
-                .font(.system(size: 12))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-
-            if hasScreenRecording {
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Permission granted")
-                        .foregroundColor(.green)
-                }
-                .font(.system(size: 14, weight: .medium))
-            } else {
-                Button("Grant Access") {
-                    guard !isPromptingScreenRecording else { return }
-                    isPromptingScreenRecording = true
-                    grantScreenRecordingAccess()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                        isPromptingScreenRecording = false
-                    }
-                }
-                .buttonStyle(.bordered)
-                .disabled(isPromptingScreenRecording)
-
-                Button("Open System Settings") {
-                    _ = openSystemSettingsPrivacyPane(.screenRecording)
-                }
-                .buttonStyle(.plain)
-                .foregroundColor(.secondary)
-            }
-
-            Spacer()
-
-            HStack(spacing: 12) {
-                Button("Skip for now") {
                     withAnimation { step = .complete }
                 }
                 .buttonStyle(.plain)
@@ -227,7 +146,7 @@ struct OnboardingView: View {
                 .buttonStyle(.borderedProminent)
             }
         }
-        .onAppear { checkScreenRecording() }
+        .onAppear { checkAccessibility() }
     }
 
     // MARK: - Complete Step
@@ -251,14 +170,8 @@ struct OnboardingView: View {
                         .foregroundColor(.secondary)
                 }
 
-                HStack(spacing: 8) {
-                    Image(systemName: "command")
-                        .frame(width: 20)
-                    Text("Cmd+;")
-                        .fontWeight(.medium)
-                    Text("Capture a screenshot")
-                        .foregroundColor(.secondary)
-                }
+                Text("Use macOS screenshot shortcuts to copy an image, then open Quick Panel to attach it.")
+                    .foregroundColor(.secondary)
             }
             .font(.system(size: 13))
             .padding()
@@ -299,33 +212,12 @@ struct OnboardingView: View {
         }
     }
 
-    private func checkScreenRecording() {
-        hasScreenRecording = CGPreflightScreenCaptureAccess()
-    }
-
-    @discardableResult
-    private func requestScreenRecording() -> Bool {
-        let granted = CGRequestScreenCaptureAccess()
-
-        // Poll for permission change (may still require restart, but this keeps UI honest when it updates).
-        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
-            if CGPreflightScreenCaptureAccess() {
-                hasScreenRecording = true
-                timer.invalidate()
-            }
-        }
-
-        return granted
-    }
-
     private func refreshPermissionState() {
         hasAccessibility = AXIsProcessTrusted()
-        hasScreenRecording = CGPreflightScreenCaptureAccess()
     }
 
     private enum SystemSettingsPrivacyPane: String {
         case accessibility = "Privacy_Accessibility"
-        case screenRecording = "Privacy_ScreenCapture"
     }
 
     /// Open System Settings directly to avoid cross-talk/ordering issues between permission prompts.
@@ -350,19 +242,4 @@ struct OnboardingView: View {
             }
         }
     }
-
-    private func grantScreenRecordingAccess() {
-        // Calling CGRequestScreenCaptureAccess is what registers Ticker with macOS so it
-        // shows up in the Screen Recording list. Deep-linking alone is not sufficient.
-        if CGPreflightScreenCaptureAccess() {
-            hasScreenRecording = true
-            return
-        }
-
-        // Important: don't open System Settings ourselves here. macOS will show a system
-        // prompt with an "Open System Settings" button; opening both simultaneously is
-        // confusing and can make it look like Ticker isn't listed yet.
-        _ = requestScreenRecording()
-    }
-
 }

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -281,8 +281,8 @@ struct QuickPanelContext {
     let panelPosition: CGPoint
     /// Clipboard image data (if no text selection and clipboard has image)
     let clipboardImage: Data?
-    /// True only when the image was captured via Ticker's screenshot hotkey (Cmd+;).
-    /// Used for UI styling (avoid transient "toast" messages).
+    /// True only for explicit app-initiated screenshot mode (currently deprecated).
+    /// Clipboard-derived images should keep this false.
     let isScreenshot: Bool
 
     var hasSelection: Bool {

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -59,8 +59,8 @@ Permission debugging note:
 - Stable lane uses bundle ID `io.ticker.app` (default).
 - QA lane uses bundle ID `io.ticker.app.qa` (default) so TCC resets don't disrupt stable daily-dev permissions.
 - Reset only the lane you are testing:
-  - `./tickerctl.sh reset-accessibility` / `./tickerctl.sh reset-screen-recording`
-  - `./tickerctl.sh reset-accessibility-qa` / `./tickerctl.sh reset-screen-recording-qa`
+  - `./tickerctl.sh reset-accessibility`
+  - `./tickerctl.sh reset-accessibility-qa`
 
 Legacy runner (still supported):
 - Dev: `./run.sh --dev`


### PR DESCRIPTION
## Summary
- deprecates app-initiated screenshot capture from `Cmd+;` and removes all Screen Recording permission request/deep-link logic from runtime app paths
- removes the Screen Recording step from onboarding and simplifies onboarding to welcome -> accessibility -> complete
- updates onboarding completion copy to direct users to native macOS screenshot-to-clipboard flow + `Cmd+L`
- updates in-repo docs/comments to reflect the deprecated `Cmd+;` behavior

## Why
Users are alarmed by Screen Recording permission prompts, and screenshot capture is secondary for current alpha workflows.

## Behavior change
- `Cmd+;` now shows a deprecation guidance message instead of invoking `screencapture`.
- Onboarding no longer asks for Screen Recording permission.
- Clipboard-based screenshot attach flow remains available (manual macOS screenshot, then Quick Panel).

Closes #125

## Validation
- `./tickerctl.sh swift-test`
  - passes
  - existing pre-existing warnings remain in `DeviceKeyService` sendability (no new warnings from this change)
