### PR TITLE
M1: native note create/open/save scaffold

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import WebKit
 import ApplicationServices
 import Sparkle
+import UniformTypeIdentifiers
 
 // Notification for appearance changes
 extension Notification.Name {
@@ -27,6 +28,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var onboardingWindow: NSWindow?
     private var didCompleteStartup = false
     private let libraryService = LibraryService.shared
+    private var tickerNextEditorWindow: NSWindow?
+    private var tickerNextEditorTextView: NSTextView?
+    private var tickerNextCurrentNote: TickerMarkdownNote?
 
     // Menu bar (status item)
     private var statusItem: NSStatusItem?
@@ -149,6 +153,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         if SettingsService.tickerNextMode {
             appMenu.addItem(NSMenuItem.separator())
+            let openEditorItem = NSMenuItem(
+                title: "Open Ticker Next Editor",
+                action: #selector(openTickerNextEditor),
+                keyEquivalent: "0"
+            )
+            openEditorItem.target = self
+            appMenu.addItem(openEditorItem)
+
+            let newNoteItem = NSMenuItem(
+                title: "New Note",
+                action: #selector(createTickerNextNote),
+                keyEquivalent: "n"
+            )
+            newNoteItem.target = self
+            appMenu.addItem(newNoteItem)
+
+            let openNoteItem = NSMenuItem(
+                title: "Open Note...",
+                action: #selector(openTickerNextNote),
+                keyEquivalent: "o"
+            )
+            openNoteItem.target = self
+            appMenu.addItem(openNoteItem)
+
+            let saveNoteItem = NSMenuItem(
+                title: "Save Note",
+                action: #selector(saveTickerNextNote),
+                keyEquivalent: "s"
+            )
+            saveNoteItem.target = self
+            appMenu.addItem(saveNoteItem)
+
             let setLibraryFolderItem = NSMenuItem(
                 title: "Set Library Folder...",
                 action: #selector(selectLibraryFolder),
@@ -295,9 +331,86 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         do {
             if let selectedURL = try libraryService.selectLibraryRootInteractively() {
                 DebugLog.log("[TickerNext] Selected library folder at \(selectedURL.path)")
+                _ = try bootstrapTickerNextLibrary()
             }
         } catch {
             DebugLog.log("[TickerNext] Failed to select library folder (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    @objc private func openTickerNextEditor() {
+        guard SettingsService.tickerNextMode else { return }
+        _ = ensureTickerNextEditorTextView()
+    }
+
+    @objc private func createTickerNextNote() {
+        guard SettingsService.tickerNextMode else { return }
+        do {
+            _ = try ensureLibraryFolderSelected()
+            let createdNote = try libraryService.withLibraryRootAccess { rootURL in
+                try libraryService.createNote(in: rootURL, title: "Untitled")
+            }
+            if let createdNote {
+                showTickerNextNote(createdNote)
+                DebugLog.log("[TickerNext] Created note at \(createdNote.url.path)")
+            }
+        } catch {
+            DebugLog.log("[TickerNext] Failed to create note (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    @objc private func openTickerNextNote() {
+        guard SettingsService.tickerNextMode else { return }
+        do {
+            guard let rootURL = try ensureLibraryFolderSelected() else { return }
+
+            let panel = NSOpenPanel()
+            panel.canChooseDirectories = false
+            panel.canChooseFiles = true
+            if let markdownType = UTType(filenameExtension: "md") {
+                panel.allowedContentTypes = [markdownType]
+            }
+            panel.allowsMultipleSelection = false
+            panel.directoryURL = rootURL
+            panel.prompt = "Open Note"
+            panel.message = "Choose a Markdown note."
+
+            guard panel.runModal() == .OK, let selectedURL = panel.url else {
+                return
+            }
+
+            let loadedNote = try libraryService.withLibraryRootAccess { _ in
+                try libraryService.loadNote(at: selectedURL)
+            }
+            if let loadedNote {
+                showTickerNextNote(loadedNote)
+                DebugLog.log("[TickerNext] Opened note at \(loadedNote.url.path)")
+            }
+        } catch {
+            DebugLog.log("[TickerNext] Failed to open note (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    @objc private func saveTickerNextNote() {
+        guard SettingsService.tickerNextMode else { return }
+        do {
+            if tickerNextCurrentNote == nil {
+                createTickerNextNote()
+            }
+            guard var currentNote = tickerNextCurrentNote else { return }
+
+            guard let textView = tickerNextEditorTextView else { return }
+            currentNote.body = textView.string
+
+            _ = try ensureLibraryFolderSelected()
+            _ = try libraryService.withLibraryRootAccess { _ in
+                try libraryService.saveNote(currentNote)
+            }
+
+            tickerNextCurrentNote = currentNote
+            DebugLog.log("[TickerNext] Saved note at \(currentNote.url.path)")
+        } catch {
+            DebugLog.log("[TickerNext] Failed to save note (\(DebugLog.errorSummary(error)))")
         }
     }
 
@@ -318,10 +431,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         guard SettingsService.tickerNextMode else { return }
 
         do {
-            if let rootPath = try libraryService.withLibraryRootAccess({ rootURL in
-                try libraryService.ensureLibraryStructure(at: rootURL)
-                return rootURL.path
-            }) {
+            if let rootPath = try bootstrapTickerNextLibrary() {
                 DebugLog.log("[TickerNext] Library structure ready at \(rootPath)")
             }
         } catch {
@@ -411,5 +521,67 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         quickPanelManager?.showWithStatusMessage(
             "Screenshot mode is deprecated. Use macOS screenshot shortcuts, then press Cmd+L."
         )
+    }
+
+    private func ensureLibraryFolderSelected() throws -> URL? {
+        if let rootURL = try libraryService.resolveLibraryRootURL() {
+            return rootURL
+        }
+        return try libraryService.selectLibraryRootInteractively()
+    }
+
+    private func bootstrapTickerNextLibrary() throws -> String? {
+        try libraryService.withLibraryRootAccess { rootURL in
+            try libraryService.ensureLibraryStructure(at: rootURL)
+            return rootURL.path
+        }
+    }
+
+    @discardableResult
+    private func ensureTickerNextEditorTextView() -> NSTextView {
+        if let existingTextView = tickerNextEditorTextView, let existingWindow = tickerNextEditorWindow {
+            existingWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return existingTextView
+        }
+
+        let textView = NSTextView(frame: .zero)
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.allowsUndo = true
+        textView.font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+
+        let scrollView = NSScrollView(frame: .zero)
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.documentView = textView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 860, height: 640),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Ticker Next Editor"
+        window.contentView = scrollView
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+
+        tickerNextEditorWindow = window
+        tickerNextEditorTextView = textView
+        NSApp.activate(ignoringOtherApps: true)
+
+        return textView
+    }
+
+    private func showTickerNextNote(_ note: TickerMarkdownNote) {
+        let textView = ensureTickerNextEditorTextView()
+        tickerNextCurrentNote = note
+        textView.string = note.body
+        tickerNextEditorWindow?.title = note.url.lastPathComponent
     }
 }

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -326,6 +326,58 @@ final class LibraryService {
         }
     }
 
+    func createNote(
+        in rootURL: URL,
+        title: String,
+        kind: TickerNoteKind = .note,
+        tickerPDFID: UUID? = nil,
+        directoryRelativePath: String? = nil
+    ) throws -> TickerMarkdownNote {
+        try ensureLibraryStructure(at: rootURL)
+
+        let parentDirectoryURL: URL
+        if let directoryRelativePath, !directoryRelativePath.isEmpty {
+            parentDirectoryURL = rootURL.appendingPathComponent(directoryRelativePath, isDirectory: true)
+            try fileManager.createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true)
+        } else {
+            parentDirectoryURL = rootURL
+        }
+
+        let noteURL = uniqueMarkdownURL(forTitle: title, in: parentDirectoryURL)
+        let frontMatter = TickerNoteFrontMatter(
+            tickerID: UUID(),
+            tickerKind: kind,
+            tickerPDFID: tickerPDFID,
+            createdAt: Date()
+        )
+        let markdown = TickerMarkdownFrontMatterCodec.serialize(frontMatter: frontMatter, body: "")
+        try markdown.write(to: noteURL, atomically: true, encoding: .utf8)
+
+        return TickerMarkdownNote(url: noteURL, frontMatter: frontMatter, body: "")
+    }
+
+    func loadNote(at noteURL: URL) throws -> TickerMarkdownNote {
+        let markdown = try String(contentsOf: noteURL, encoding: .utf8)
+        let parsed = TickerMarkdownFrontMatterCodec.parse(markdown)
+
+        let frontMatter = parsed.frontMatter ?? TickerNoteFrontMatter(
+            tickerID: UUID(),
+            tickerKind: .note,
+            tickerPDFID: nil,
+            createdAt: Date()
+        )
+
+        return TickerMarkdownNote(url: noteURL, frontMatter: frontMatter, body: parsed.body)
+    }
+
+    func saveNote(_ note: TickerMarkdownNote) throws {
+        let markdown = TickerMarkdownFrontMatterCodec.serialize(
+            frontMatter: note.frontMatter,
+            body: note.body
+        )
+        try markdown.write(to: note.url, atomically: true, encoding: .utf8)
+    }
+
     func markdownFileURLs(in rootURL: URL) throws -> [URL] {
         guard let enumerator = fileManager.enumerator(
             at: rootURL,
@@ -376,5 +428,45 @@ final class LibraryService {
     func fixDuplicateTickerIDs(in rootURL: URL) throws -> DuplicateTickerIDFixResult {
         let notes = try scanMarkdownNotes(in: rootURL)
         return try TickerNoteDuplicateResolver.fixDuplicateTickerIDs(in: notes)
+    }
+
+    private func uniqueMarkdownURL(forTitle title: String, in directoryURL: URL) -> URL {
+        let baseSlug = slugify(title)
+        var index = 1
+
+        while true {
+            let fileName: String
+            if index == 1 {
+                fileName = "\(baseSlug).md"
+            } else {
+                fileName = "\(baseSlug)-\(index).md"
+            }
+
+            let candidateURL = directoryURL.appendingPathComponent(fileName)
+            if !fileManager.fileExists(atPath: candidateURL.path) {
+                return candidateURL
+            }
+            index += 1
+        }
+    }
+
+    private func slugify(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = trimmed.lowercased()
+
+        let mapped = lowercased.map { character -> Character in
+            if character.isLetter || character.isNumber {
+                return character
+            }
+            return "-"
+        }
+
+        var slug = String(mapped)
+        while slug.contains("--") {
+            slug = slug.replacingOccurrences(of: "--", with: "-")
+        }
+        slug = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        return slug.isEmpty ? "untitled" : slug
     }
 }

--- a/Sources/Ticker/Services/MLXClassifier.swift
+++ b/Sources/Ticker/Services/MLXClassifier.swift
@@ -21,14 +21,8 @@ final class MLXClassifier: QueryClassifier {
         guard !isLoading else { return }
         isLoading = true
 
-        do {
-            DebugLog.log("MLXClassifier: Loading model \(modelId)...")
-            DebugLog.log("MLXClassifier: Model loaded successfully")
-        } catch {
-            loadError = error
-            DebugLog.log("MLXClassifier: Failed to load model (\(DebugLog.errorSummary(error)))")
-            throw error
-        }
+        DebugLog.log("MLXClassifier: Loading model \(modelId)...")
+        DebugLog.log("MLXClassifier: Model loaded successfully")
 
         isLoading = false
     }

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -343,3 +343,58 @@ final class LibraryServiceFrontMatterTests: XCTestCase {
         try markdown.write(to: url, atomically: true, encoding: .utf8)
     }
 }
+
+final class LibraryServiceNoteFileTests: XCTestCase {
+    func test_createLoadSaveNote_roundtripPreservesFrontMatterAndBody() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let suiteName = "LibraryServiceNoteFileTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        try service.ensureLibraryStructure(at: tempDir)
+
+        let created = try service.createNote(in: tempDir, title: "Daily Draft")
+        XCTAssertEqual(created.url.lastPathComponent, "daily-draft.md")
+        XCTAssertEqual(created.frontMatter.tickerKind, .note)
+        XCTAssertTrue(fileManager.fileExists(atPath: created.url.path))
+
+        var loaded = try service.loadNote(at: created.url)
+        XCTAssertEqual(loaded.frontMatter.tickerID, created.frontMatter.tickerID)
+        XCTAssertEqual(loaded.body, "")
+
+        loaded.body = "# Daily Draft\n\nBody content."
+        try service.saveNote(loaded)
+
+        let reloaded = try service.loadNote(at: created.url)
+        XCTAssertEqual(reloaded.frontMatter.tickerID, created.frontMatter.tickerID)
+        XCTAssertEqual(reloaded.frontMatter.tickerKind, .note)
+        XCTAssertEqual(reloaded.body, "# Daily Draft\n\nBody content.")
+    }
+
+    func test_createNote_sameTitleUsesDeterministicCollisionSuffixes() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let suiteName = "LibraryServiceCollisionTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        try service.ensureLibraryStructure(at: tempDir)
+
+        let first = try service.createNote(in: tempDir, title: "Meeting Notes")
+        let second = try service.createNote(in: tempDir, title: "Meeting Notes")
+        let third = try service.createNote(in: tempDir, title: "Meeting Notes")
+
+        XCTAssertEqual(first.url.lastPathComponent, "meeting-notes.md")
+        XCTAssertEqual(second.url.lastPathComponent, "meeting-notes-2.md")
+        XCTAssertEqual(third.url.lastPathComponent, "meeting-notes-3.md")
+    }
+}


### PR DESCRIPTION
## Summary
Implements M1 native note-file scaffold: create/open/save markdown notes in the selected library with a simple native editor window.

## Changes
- Extended `LibraryService` with note IO APIs:
  - `createNote(in:title:kind:tickerPDFID:directoryRelativePath:)`
  - `loadNote(at:)`
  - `saveNote(_:)`
  - deterministic collision-safe naming (`meeting-notes.md`, `meeting-notes-2.md`, ...)
- Added native editor actions in `AppDelegate` (Ticker Next mode):
  - `Open Ticker Next Editor`
  - `New Note`
  - `Open Note...`
  - `Save Note`
- Added lightweight `NSTextView` editor window scaffold with standard undo/copy/paste behavior.
- Added tests for note-file behavior:
  - create/load/save roundtrip preserves front matter + body
  - deterministic filename collision suffixes
- Minor cleanup:
  - switched markdown open panel to `allowedContentTypes`
  - removed unreachable `catch` in heuristic `MLXClassifier.prepare()`

## Validation
- `./tickerctl.sh swift-test` passes.

## Scope notes
- This slice intentionally does not include AI action integration (M3) or PDF linking (M4).

Closes #6
