### PR TITLE
M2: Inbox-first Quick Panel routing for ticker-next mode

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         setupStatusItem()
         setupMenuBar()
         setupAppearanceObserver()
+        setupTickerNextObservers()
 
         // Alpha: proxy-only onboarding (no vendor API keys).
         if SettingsService.shared.needsOnboarding {
@@ -523,6 +524,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         )
     }
 
+    private func setupTickerNextObservers() {
+        guard SettingsService.tickerNextMode else { return }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleTickerNextCaptureAppend(_:)),
+            name: .tickerNextDidAppendCaptureToNote,
+            object: nil
+        )
+    }
+
+    @objc private func handleTickerNextCaptureAppend(_ notification: Notification) {
+        guard let notePath = notification.userInfo?[TickerNextQuickCaptureUserInfoKey.notePath] as? String,
+              let appendedMarkdown = notification.userInfo?[TickerNextQuickCaptureUserInfoKey.appendedMarkdown] as? String else {
+            return
+        }
+
+        guard tickerNextCurrentNote?.url.path == notePath else { return }
+        guard let textView = tickerNextEditorTextView else { return }
+
+        let updatedBody = appendMarkdownBlock(appendedMarkdown, to: textView.string)
+        textView.string = updatedBody
+        tickerNextCurrentNote?.body = updatedBody
+    }
+
     private func ensureLibraryFolderSelected() throws -> URL? {
         if let rootURL = try libraryService.resolveLibraryRootURL() {
             return rootURL
@@ -581,7 +606,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func showTickerNextNote(_ note: TickerMarkdownNote) {
         let textView = ensureTickerNextEditorTextView()
         tickerNextCurrentNote = note
+        SettingsService.shared.tickerNextCurrentNotePath = note.url.path
         textView.string = note.body
         tickerNextEditorWindow?.title = note.url.lastPathComponent
+    }
+
+    private func appendMarkdownBlock(_ block: String, to body: String) -> String {
+        if body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return block
+        }
+
+        var updatedBody = body
+        if !updatedBody.hasSuffix("\n") {
+            updatedBody += "\n"
+        }
+        if !updatedBody.hasSuffix("\n\n") {
+            updatedBody += "\n"
+        }
+        updatedBody += block
+        return updatedBody
     }
 }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -32,6 +32,16 @@ struct EphemeralConversation: Equatable {
     }
 }
 
+enum TickerNextCaptureDestination: String, Equatable {
+    case inbox
+    case currentNote
+}
+
+enum TickerNextQuickCaptureUserInfoKey {
+    static let notePath = "notePath"
+    static let appendedMarkdown = "appendedMarkdown"
+}
+
 /// Manages the Quick Panel lifecycle, positioning, and state
 /// Coordinates between services (cursor, selection) and the panel window
 @MainActor
@@ -46,6 +56,9 @@ final class QuickPanelManager: ObservableObject {
     @Published var error: String?
     @Published var statusMessage: String?  // Temporary feedback (success/info messages)
     @Published var ephemeralConversation = EphemeralConversation()
+    @Published var tickerNextCaptureDestination: TickerNextCaptureDestination = .inbox
+    @Published private(set) var tickerNextCurrentNotePath: String?
+    @Published private(set) var tickerNextCurrentNoteName: String?
 
     // Stream selection
     @Published private(set) var availableStreams: [StreamSummary] = []
@@ -59,6 +72,7 @@ final class QuickPanelManager: ObservableObject {
     private weak var bridgeService: BridgeService?
     private var assetService: AssetService?
     private weak var orchestrator: AIOrchestrator?
+    private let libraryService: LibraryService
 
     // MARK: - Streaming Task
 
@@ -82,13 +96,15 @@ final class QuickPanelManager: ObservableObject {
 
     init(
         persistence: PersistenceService? = nil,
-        bridgeService: BridgeService? = nil
+        bridgeService: BridgeService? = nil,
+        libraryService: LibraryService = .shared
     ) {
         let cursor = CursorPositionService()
         self.cursorService = cursor
         self.selectionService = SelectionReaderService(cursorService: cursor)
         self.persistence = persistence
         self.bridgeService = bridgeService
+        self.libraryService = libraryService
     }
 
     /// Configure services after initialization (for dependency injection)
@@ -191,8 +207,13 @@ final class QuickPanelManager: ObservableObject {
         self.context = capturedContext
         resetState()
 
-        // Load available streams for picker
-        loadAvailableStreams()
+        if SettingsService.tickerNextMode {
+            tickerNextCaptureDestination = .inbox
+            refreshTickerNextCurrentNoteState()
+        } else {
+            // Load available streams for picker
+            loadAvailableStreams()
+        }
 
         // If Accessibility isn't granted, just show a soft warning (don't prompt).
         // Onboarding is responsible for prompting; repeated system prompts here are jarring.
@@ -253,6 +274,18 @@ final class QuickPanelManager: ObservableObject {
     func updateAppearance(_ appearance: NSAppearance?) {
         currentAppearance = appearance
         panel?.appearance = appearance
+    }
+
+    func selectTickerNextCaptureDestination(_ destination: TickerNextCaptureDestination) {
+        refreshTickerNextCurrentNoteState()
+
+        if destination == .currentNote, tickerNextCurrentNotePath == nil {
+            tickerNextCaptureDestination = .inbox
+            statusMessage = "No current note. Saving to Inbox."
+            return
+        }
+
+        tickerNextCaptureDestination = destination
     }
 
     // MARK: - Input Handling
@@ -406,11 +439,6 @@ final class QuickPanelManager: ObservableObject {
 
     /// Add captured content and/or input to the active stream
     private func addToStream(triggerAI: Bool) async {
-        guard let persistence = persistence else {
-            error = "Persistence not configured"
-            return
-        }
-
         let hasContext = context?.hasContent == true
         let hasInput = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
@@ -422,6 +450,25 @@ final class QuickPanelManager: ObservableObject {
 
         isLoading = true
         error = nil
+        defer { isLoading = false }
+
+        if SettingsService.tickerNextMode {
+            do {
+                let shouldHide = try addToTickerNextNote(triggerAI: triggerAI)
+                if shouldHide {
+                    hide()
+                }
+            } catch {
+                self.error = error.localizedDescription
+                DebugLog.log("[QuickPanel] TickerNext save failed (\(DebugLog.errorSummary(error)))")
+            }
+            return
+        }
+
+        guard let persistence = persistence else {
+            error = "Persistence not configured"
+            return
+        }
 
         do {
             // Get target stream (may create new one)
@@ -476,8 +523,149 @@ final class QuickPanelManager: ObservableObject {
             self.error = error.localizedDescription
             DebugLog.log("[QuickPanel] Error adding to stream (\(DebugLog.errorSummary(error)))")
         }
+    }
 
-        isLoading = false
+    private func refreshTickerNextCurrentNoteState() {
+        guard SettingsService.tickerNextMode else {
+            tickerNextCurrentNotePath = nil
+            tickerNextCurrentNoteName = nil
+            return
+        }
+
+        guard let notePath = SettingsService.shared.tickerNextCurrentNotePath,
+              FileManager.default.fileExists(atPath: notePath) else {
+            tickerNextCurrentNotePath = nil
+            tickerNextCurrentNoteName = nil
+            return
+        }
+
+        tickerNextCurrentNotePath = notePath
+        tickerNextCurrentNoteName = URL(fileURLWithPath: notePath).lastPathComponent
+    }
+
+    /// Saves capture text/image to Ticker Next markdown notes.
+    /// Returns whether the panel should hide on completion.
+    private func addToTickerNextNote(triggerAI: Bool) throws -> Bool {
+        refreshTickerNextCurrentNoteState()
+
+        if try libraryService.resolveLibraryRootURL() == nil {
+            guard try libraryService.selectLibraryRootInteractively() != nil else {
+                throw QuickPanelError.tickerNextLibraryNotConfigured
+            }
+        }
+
+        if triggerAI {
+            statusMessage = "AI+save for Ticker Next is not implemented yet. Saved as note."
+        }
+
+        let saveResult = try libraryService.withLibraryRootAccess { rootURL in
+            try libraryService.ensureLibraryStructure(at: rootURL)
+
+            let selectedDestination = tickerNextCaptureDestination
+            var usedInboxFallback = false
+            let targetURL: URL
+
+            if selectedDestination == .currentNote {
+                let rootPath = rootURL.standardizedFileURL.path
+                if let currentPath = tickerNextCurrentNotePath,
+                   currentPath.hasPrefix(rootPath),
+                   FileManager.default.fileExists(atPath: currentPath) {
+                    targetURL = URL(fileURLWithPath: currentPath)
+                } else {
+                    targetURL = libraryService.inboxNoteURL(in: rootURL)
+                    usedInboxFallback = true
+                }
+            } else {
+                targetURL = libraryService.inboxNoteURL(in: rootURL)
+            }
+
+            var note: TickerMarkdownNote
+            if targetURL.lastPathComponent == "Inbox.md" {
+                note = try libraryService.ensureInboxNote(in: rootURL)
+            } else {
+                note = try libraryService.loadNote(at: targetURL)
+            }
+
+            let appendedBlock = try buildTickerNextCaptureBlock(rootURL: rootURL, noteURL: note.url)
+            note.body = appendMarkdownBlock(appendedBlock, to: note.body)
+            try libraryService.saveNote(note)
+
+            NotificationCenter.default.post(
+                name: .tickerNextDidAppendCaptureToNote,
+                object: nil,
+                userInfo: [
+                    TickerNextQuickCaptureUserInfoKey.notePath: note.url.path,
+                    TickerNextQuickCaptureUserInfoKey.appendedMarkdown: appendedBlock
+                ]
+            )
+
+            return (note, usedInboxFallback)
+        }
+
+        guard let (savedNote, usedInboxFallback) = saveResult else {
+            throw QuickPanelError.tickerNextLibraryNotConfigured
+        }
+
+        if usedInboxFallback {
+            statusMessage = "Current note unavailable. Saved to Inbox."
+            return false
+        }
+
+        DebugLog.log("[QuickPanel] Saved capture to \(savedNote.url.path)")
+        return triggerAI ? false : true
+    }
+
+    private func buildTickerNextCaptureBlock(rootURL: URL, noteURL: URL) throws -> String {
+        var sections: [String] = []
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        sections.append("_Captured \(timestamp)_")
+
+        if let ctx = context {
+            if let selectedText = ctx.selectedText, !selectedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                sections.append(markdownQuote(selectedText))
+            } else if let imageData = ctx.clipboardImage {
+                let imageURL = try libraryService.saveImageAsset(data: imageData, in: rootURL)
+                let imagePath = libraryService.relativePath(
+                    from: noteURL.deletingLastPathComponent(),
+                    to: imageURL
+                )
+                sections.append("![](\(imagePath))")
+            }
+
+            if let source = buildPlainSourceAttribution(app: ctx.activeApp, windowTitle: ctx.windowTitle) {
+                sections.append("_Source: \(source)_")
+            }
+        }
+
+        let trimmedInput = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedInput.isEmpty {
+            sections.append(trimmedInput)
+        }
+
+        return sections.joined(separator: "\n\n")
+    }
+
+    private func appendMarkdownBlock(_ block: String, to body: String) -> String {
+        if body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return block
+        }
+
+        var updatedBody = body
+        if !updatedBody.hasSuffix("\n") {
+            updatedBody += "\n"
+        }
+        if !updatedBody.hasSuffix("\n\n") {
+            updatedBody += "\n"
+        }
+        updatedBody += block
+        return updatedBody
+    }
+
+    private func markdownQuote(_ text: String) -> String {
+        text
+            .split(whereSeparator: \.isNewline)
+            .map { "> \($0)" }
+            .joined(separator: "\n")
     }
 
     /// Load available streams for the picker
@@ -593,6 +781,24 @@ final class QuickPanelManager: ObservableObject {
         case let (app?, _):
             return app
         case let (nil, title?) where !title.isEmpty:
+            return title
+        default:
+            return nil
+        }
+    }
+
+    /// Build source attribution in plain text for markdown note captures.
+    private func buildPlainSourceAttribution(app: String?, windowTitle: String?) -> String? {
+        let trimmedApp = app?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTitle = windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch (trimmedApp, trimmedTitle) {
+        case let (app?, title?) where !app.isEmpty && !title.isEmpty:
+            let truncatedTitle = title.count > 60 ? String(title.prefix(57)) + "..." : title
+            return "\(app) - \(truncatedTitle)"
+        case let (app?, _ ) where !app.isEmpty:
+            return app
+        case let (_, title?) where !title.isEmpty:
             return title
         default:
             return nil
@@ -728,6 +934,7 @@ final class QuickPanelManager: ObservableObject {
 enum QuickPanelError: Error, LocalizedError {
     case persistenceNotConfigured
     case noActiveStream
+    case tickerNextLibraryNotConfigured
 
     var errorDescription: String? {
         switch self {
@@ -735,6 +942,8 @@ enum QuickPanelError: Error, LocalizedError {
             return "Database not configured"
         case .noActiveStream:
             return "No active stream"
+        case .tickerNextLibraryNotConfigured:
+            return "Set a Ticker Next library folder before saving captures"
         }
     }
 }
@@ -744,4 +953,5 @@ enum QuickPanelError: Error, LocalizedError {
 extension Notification.Name {
     static let quickPanelDidShow = Notification.Name("QuickPanelDidShow")
     static let quickPanelDidHide = Notification.Name("QuickPanelDidHide")
+    static let tickerNextDidAppendCaptureToNote = Notification.Name("TickerNextDidAppendCaptureToNote")
 }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -34,8 +34,12 @@ struct QuickPanelView: View {
                 statusView(status)
             }
 
-            // Stream destination picker
-            streamDestinationPicker
+            // Destination picker
+            if SettingsService.tickerNextMode {
+                tickerNextDestinationPicker
+            } else {
+                streamDestinationPicker
+            }
 
             // Context badge (if text/image was captured)
             if let context = manager.context, context.hasContent {
@@ -194,6 +198,66 @@ struct QuickPanelView: View {
         return "Select stream..."
     }
 
+    private var tickerNextDestinationPicker: some View {
+        Menu {
+            Button(action: { manager.selectTickerNextCaptureDestination(.inbox) }) {
+                HStack {
+                    Text("Inbox")
+                    if manager.tickerNextCaptureDestination == .inbox {
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            Button(action: { manager.selectTickerNextCaptureDestination(.currentNote) }) {
+                HStack {
+                    Text(tickerNextCurrentNoteLabel)
+                    if manager.tickerNextCaptureDestination == .currentNote {
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+            .disabled(manager.tickerNextCurrentNoteName == nil)
+        } label: {
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "tray.and.arrow.down")
+                    .font(.system(size: 11))
+                    .foregroundColor(Colors.secondaryText)
+                Text(tickerNextDestinationTitle)
+                    .font(.system(size: 11))
+                    .foregroundColor(Colors.secondaryText)
+                    .lineLimit(1)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 9))
+                    .foregroundColor(Colors.tertiaryText)
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+            .background(Colors.hoverBackground)
+            .cornerRadius(Spacing.radiusSm)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var tickerNextCurrentNoteLabel: String {
+        if let name = manager.tickerNextCurrentNoteName {
+            return "Current note (\(name))"
+        }
+        return "Current note unavailable"
+    }
+
+    private var tickerNextDestinationTitle: String {
+        switch manager.tickerNextCaptureDestination {
+        case .inbox:
+            return "Inbox"
+        case .currentNote:
+            return manager.tickerNextCurrentNoteName ?? "Inbox"
+        }
+    }
+
     // MARK: - Ephemeral Conversation Response Area
 
     private var responseArea: some View {
@@ -335,7 +399,7 @@ struct QuickPanelView: View {
                 .font(.system(size: 9))
                 .foregroundColor(Colors.secondaryText.opacity(0.6))
 
-            Text("⌘↵ AI+save")
+            Text(SettingsService.tickerNextMode ? "⌘↵ save+AI soon" : "⌘↵ AI+save")
                 .font(.system(size: 9))
                 .foregroundColor(Colors.secondaryText.opacity(0.6))
 

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -326,6 +326,48 @@ final class LibraryService {
         }
     }
 
+    func inboxNoteURL(in rootURL: URL) -> URL {
+        rootURL.appendingPathComponent("Inbox.md")
+    }
+
+    func ensureInboxNote(in rootURL: URL) throws -> TickerMarkdownNote {
+        try ensureLibraryStructure(at: rootURL)
+        let inboxURL = inboxNoteURL(in: rootURL)
+        return try loadNote(at: inboxURL)
+    }
+
+    func saveImageAsset(data: Data, in rootURL: URL, fileExtension: String = "png") throws -> URL {
+        try ensureLibraryStructure(at: rootURL)
+        let fileName = "\(UUID().uuidString.lowercased()).\(fileExtension)"
+        let imageURL = rootURL
+            .appendingPathComponent("Assets", isDirectory: true)
+            .appendingPathComponent("Images", isDirectory: true)
+            .appendingPathComponent(fileName)
+        try data.write(to: imageURL, options: [.atomic])
+        return imageURL
+    }
+
+    func relativePath(from baseURL: URL, to targetURL: URL) -> String {
+        let baseComponents = baseURL.standardizedFileURL.pathComponents
+        let targetComponents = targetURL.standardizedFileURL.pathComponents
+
+        var sharedPrefixCount = 0
+        while sharedPrefixCount < baseComponents.count &&
+                sharedPrefixCount < targetComponents.count &&
+                baseComponents[sharedPrefixCount] == targetComponents[sharedPrefixCount] {
+            sharedPrefixCount += 1
+        }
+
+        let upwardTraversal = Array(repeating: "..", count: baseComponents.count - sharedPrefixCount)
+        let targetRemainder = Array(targetComponents.dropFirst(sharedPrefixCount))
+        let relativeComponents = upwardTraversal + targetRemainder
+
+        if relativeComponents.isEmpty {
+            return "."
+        }
+        return relativeComponents.joined(separator: "/")
+    }
+
     func createNote(
         in rootURL: URL,
         title: String,

--- a/Sources/Ticker/Services/SettingsService.swift
+++ b/Sources/Ticker/Services/SettingsService.swift
@@ -27,6 +27,7 @@ final class SettingsService {
         static let hasCompletedKeychainMigration = "has_completed_keychain_migration"
         static let hasCompletedOnboarding = "has_completed_onboarding"
         static let diagnosticsEnabled = "diagnostics_enabled"
+        static let tickerNextCurrentNotePath = "ticker_next_current_note_path"
         // Legacy keys (for migration)
         static let legacyOpenaiAPIKey = "openai_api_key"
         static let legacyAnthropicAPIKey = "anthropic_api_key"
@@ -236,6 +237,14 @@ final class SettingsService {
             return defaults.bool(forKey: Keys.diagnosticsEnabled)
         }
         set { defaults.set(newValue, forKey: Keys.diagnosticsEnabled) }
+    }
+
+    // MARK: - Ticker Next Session
+
+    /// Path of the currently open Ticker Next note (if any).
+    var tickerNextCurrentNotePath: String? {
+        get { defaults.string(forKey: Keys.tickerNextCurrentNotePath) }
+        set { defaults.set(newValue, forKey: Keys.tickerNextCurrentNotePath) }
     }
 
     // MARK: - Settings Dictionary (for bridge)

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -398,3 +398,44 @@ final class LibraryServiceNoteFileTests: XCTestCase {
         XCTAssertEqual(third.url.lastPathComponent, "meeting-notes-3.md")
     }
 }
+
+final class LibraryServiceCaptureAssetTests: XCTestCase {
+    func test_ensureInboxNote_returnsInboxFrontMatterAndPersistsFile() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let suiteName = "LibraryServiceCaptureAssetTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        let inbox = try service.ensureInboxNote(in: tempDir)
+
+        XCTAssertEqual(inbox.frontMatter.tickerKind, .inbox)
+        XCTAssertEqual(inbox.url.lastPathComponent, "Inbox.md")
+        XCTAssertTrue(fileManager.fileExists(atPath: inbox.url.path))
+    }
+
+    func test_saveImageAsset_and_relativePath_forNestedNote() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let suiteName = "LibraryServiceCaptureAssetPathTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        try service.ensureLibraryStructure(at: tempDir)
+
+        let note = try service.createNote(in: tempDir, title: "Research", directoryRelativePath: "ProjectA")
+        let imageURL = try service.saveImageAsset(data: Data([0x01, 0x02, 0x03]), in: tempDir)
+        let relativePath = service.relativePath(from: note.url.deletingLastPathComponent(), to: imageURL)
+
+        XCTAssertTrue(fileManager.fileExists(atPath: imageURL.path))
+        XCTAssertTrue(relativePath.hasPrefix("../Assets/Images/"))
+    }
+}


### PR DESCRIPTION
## Summary
Implements M2: Inbox-first Quick Panel routing in Ticker Next mode.

## Changes
- Added Ticker Next Quick Panel destination model:
  - default destination is Inbox
  - explicit destination option for current note
- Routed Quick Panel save flow in `tickerNextMode` away from stream/cell persistence to markdown note files.
- Added fallback behavior:
  - if current note is unavailable, capture is saved to Inbox with user-visible status.
- Added current-note session sync:
  - AppDelegate persists current note path in Settings
  - Quick Panel uses that path for explicit current-note routing
  - editor updates in-memory text when Quick Panel appends to the same open note
- Added markdown capture helpers:
  - append formatting for captured text/image/input
  - image asset save to `Assets/Images`
  - relative path generation for markdown image links
- Added tests for new capture primitives in `LibraryService`:
  - inbox note availability
  - image asset save + nested relative path behavior

## Validation
- `./tickerctl.sh swift-test` passes.

## Scope note
- Option+Enter ephemeral chat remains unchanged.
- AI+save transforms remain deferred to M3.

Closes #8
