### PR TITLE
M3: selection AI actions with persisted authorship spans

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -22,7 +22,7 @@ struct TickerApp {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextViewDelegate, TickerNextEditorTextViewActionHandling {
     private var mainWindow: NSWindow?
     private var webViewManager: WebViewManager?
     private var onboardingWindow: NSWindow?
@@ -31,6 +31,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var tickerNextEditorWindow: NSWindow?
     private var tickerNextEditorTextView: NSTextView?
     private var tickerNextCurrentNote: TickerMarkdownNote?
+    private let tickerNextSelectionAIService = TickerNextSelectionAIService()
+    private let tickerNextDocMetadataStore = TickerNextDocMetadataStore()
+    private var tickerNextAuthorshipSpans: [TickerNextAuthorshipSpan] = []
+    private var tickerNextPreviousEditorBody = ""
+    private var tickerNextPendingAIInsertion: (range: NSRange, source: String)?
+    private var tickerNextSuppressTextDidChange = false
+    private var tickerNextAIRequestInFlight = false
 
     // Menu bar (status item)
     private var statusItem: NSStatusItem?
@@ -404,11 +411,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             currentNote.body = textView.string
 
             _ = try ensureLibraryFolderSelected()
-            _ = try libraryService.withLibraryRootAccess { _ in
+            _ = try libraryService.withLibraryRootAccess { rootURL in
                 try libraryService.saveNote(currentNote)
+                try tickerNextDocMetadataStore.saveSpans(
+                    tickerNextAuthorshipSpans,
+                    for: currentNote,
+                    libraryRootURL: rootURL
+                )
             }
 
             tickerNextCurrentNote = currentNote
+            tickerNextPreviousEditorBody = currentNote.body
             DebugLog.log("[TickerNext] Saved note at \(currentNote.url.path)")
         } catch {
             DebugLog.log("[TickerNext] Failed to save note (\(DebugLog.errorSummary(error)))")
@@ -544,8 +557,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         guard let textView = tickerNextEditorTextView else { return }
 
         let updatedBody = appendMarkdownBlock(appendedMarkdown, to: textView.string)
+        tickerNextSuppressTextDidChange = true
         textView.string = updatedBody
-        tickerNextCurrentNote?.body = updatedBody
+        tickerNextSuppressTextDidChange = false
+        syncTickerNextEditorStateAfterTextChange(newBody: updatedBody)
     }
 
     private func ensureLibraryFolderSelected() throws -> URL? {
@@ -570,13 +585,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return existingTextView
         }
 
-        let textView = NSTextView(frame: .zero)
+        let textView = TickerNextEditorTextView(frame: .zero)
         textView.isRichText = false
         textView.importsGraphics = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDataDetectionEnabled = false
         textView.allowsUndo = true
         textView.font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.delegate = self
+        textView.actionHandler = self
 
         let scrollView = NSScrollView(frame: .zero)
         scrollView.hasVerticalScroller = true
@@ -607,8 +624,261 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let textView = ensureTickerNextEditorTextView()
         tickerNextCurrentNote = note
         SettingsService.shared.tickerNextCurrentNotePath = note.url.path
+        tickerNextPendingAIInsertion = nil
+        tickerNextAIRequestInFlight = false
+        loadTickerNextAuthorshipSpans(for: note)
+        tickerNextSuppressTextDidChange = true
         textView.string = note.body
+        tickerNextSuppressTextDidChange = false
+        tickerNextPreviousEditorBody = note.body
+        applyTickerNextAuthorshipStyling()
         tickerNextEditorWindow?.title = note.url.lastPathComponent
+    }
+
+    func textDidChange(_ notification: Notification) {
+        guard !tickerNextSuppressTextDidChange else { return }
+        guard let textView = notification.object as? NSTextView,
+              textView == tickerNextEditorTextView else {
+            return
+        }
+
+        syncTickerNextEditorStateAfterTextChange(newBody: textView.string)
+    }
+
+    func tickerNextEditorTextView(
+        _ textView: TickerNextEditorTextView,
+        didRequestAction action: TickerNextSelectionAIAction
+    ) {
+        guard textView == tickerNextEditorTextView else { return }
+        runTickerNextSelectionAIAction(action)
+    }
+
+    private func syncTickerNextEditorStateAfterTextChange(newBody: String) {
+        let oldBody = tickerNextPreviousEditorBody
+
+        if oldBody != newBody,
+           let edit = TickerNextTextEditDetector.detectSingleEdit(from: oldBody, to: newBody) {
+            tickerNextAuthorshipSpans = TickerNextAuthorshipSpanTransformer.applyUserEdit(
+                spans: tickerNextAuthorshipSpans,
+                edit: edit
+            )
+        }
+
+        var shouldPersist = false
+        if let pending = tickerNextPendingAIInsertion {
+            tickerNextAuthorshipSpans = TickerNextAuthorshipSpanTransformer.addAIInsertion(
+                range: pending.range,
+                source: pending.source,
+                to: tickerNextAuthorshipSpans
+            )
+            tickerNextPendingAIInsertion = nil
+            shouldPersist = true
+        }
+
+        let textLength = (newBody as NSString).length
+        tickerNextAuthorshipSpans = TickerNextAuthorshipSpanTransformer.clamped(
+            spans: tickerNextAuthorshipSpans,
+            toUTF16Length: textLength
+        )
+
+        tickerNextPreviousEditorBody = newBody
+        tickerNextCurrentNote?.body = newBody
+        applyTickerNextAuthorshipStyling()
+
+        if shouldPersist {
+            persistTickerNextCurrentNoteAndMetadata()
+        }
+    }
+
+    private func runTickerNextSelectionAIAction(_ action: TickerNextSelectionAIAction) {
+        guard !tickerNextAIRequestInFlight else { return }
+        guard let textView = tickerNextEditorTextView else { return }
+
+        let selectedRange = textView.selectedRange()
+        guard selectedRange.length > 0 else {
+            NSSound.beep()
+            return
+        }
+
+        let buffer = textView.string as NSString
+        guard NSMaxRange(selectedRange) <= buffer.length else {
+            NSSound.beep()
+            return
+        }
+
+        let selectedText = buffer.substring(with: selectedRange)
+
+        let rewriteInstruction: String?
+        if action == .rewrite {
+            guard let instruction = promptForTickerNextRewriteInstruction() else {
+                return
+            }
+            rewriteInstruction = instruction
+        } else {
+            rewriteInstruction = nil
+        }
+
+        tickerNextAIRequestInFlight = true
+        textView.isEditable = false
+        tickerNextEditorWindow?.title = "Ticker Next Editor (AI...)"
+
+        Task {
+            do {
+                let replacement = try await tickerNextSelectionAIService.transformSelection(
+                    selectedText,
+                    action: action,
+                    customInstruction: rewriteInstruction
+                )
+
+                await MainActor.run {
+                    self.applyTickerNextAIReplacement(
+                        with: replacement,
+                        replacing: selectedRange,
+                        source: action.rawValue
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    self.presentTickerNextAIActionError(error)
+                }
+            }
+
+            await MainActor.run {
+                self.tickerNextAIRequestInFlight = false
+                self.tickerNextEditorTextView?.isEditable = true
+                self.tickerNextEditorWindow?.title = self.tickerNextCurrentNote?.url.lastPathComponent ?? "Ticker Next Editor"
+            }
+        }
+    }
+
+    private func applyTickerNextAIReplacement(
+        with replacement: String,
+        replacing range: NSRange,
+        source: String
+    ) {
+        guard let textView = tickerNextEditorTextView else { return }
+
+        let bufferLength = (textView.string as NSString).length
+        let safeLocation = min(max(0, range.location), bufferLength)
+        let safeLength = min(max(0, range.length), bufferLength - safeLocation)
+        let safeRange = NSRange(location: safeLocation, length: safeLength)
+        guard safeRange.length > 0 else { return }
+
+        let insertedLength = (replacement as NSString).length
+        let undoManager = textView.undoManager
+        undoManager?.beginUndoGrouping()
+        defer { undoManager?.endUndoGrouping() }
+
+        guard textView.shouldChangeText(in: safeRange, replacementString: replacement) else {
+            return
+        }
+
+        textView.textStorage?.replaceCharacters(in: safeRange, with: replacement)
+        textView.setSelectedRange(NSRange(location: safeRange.location + insertedLength, length: 0))
+        tickerNextPendingAIInsertion = (
+            range: NSRange(location: safeRange.location, length: insertedLength),
+            source: source
+        )
+        textView.didChangeText()
+    }
+
+    private func promptForTickerNextRewriteInstruction() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "Rewrite Selection"
+        alert.informativeText = "Describe how the selected text should be rewritten."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Rewrite")
+        alert.addButton(withTitle: "Cancel")
+
+        let promptField = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 22))
+        promptField.placeholderString = "e.g. Make this more concise and technical."
+        alert.accessoryView = promptField
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return nil }
+
+        let prompt = promptField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            NSSound.beep()
+            return nil
+        }
+        return prompt
+    }
+
+    private func presentTickerNextAIActionError(_ error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "AI action failed"
+        alert.informativeText = DebugLog.errorSummary(error)
+        alert.alertStyle = .warning
+        alert.runModal()
+    }
+
+    private func loadTickerNextAuthorshipSpans(for note: TickerMarkdownNote) {
+        do {
+            let spans = try libraryService.withLibraryRootAccess { rootURL in
+                try tickerNextDocMetadataStore.loadSpans(for: note, libraryRootURL: rootURL)
+            } ?? []
+
+            tickerNextAuthorshipSpans = TickerNextAuthorshipSpanTransformer.clamped(
+                spans: spans,
+                toUTF16Length: (note.body as NSString).length
+            )
+        } catch {
+            tickerNextAuthorshipSpans = []
+            DebugLog.log("[TickerNext] Failed to load authorship metadata (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    private func applyTickerNextAuthorshipStyling() {
+        guard let textView = tickerNextEditorTextView,
+              let layoutManager = textView.layoutManager else {
+            return
+        }
+
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        layoutManager.removeTemporaryAttribute(.font, forCharacterRange: fullRange)
+        layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
+
+        guard !tickerNextAuthorshipSpans.isEmpty else { return }
+
+        let pointSize = textView.font?.pointSize ?? 14
+        let aiFont = NSFont.monospacedSystemFont(ofSize: pointSize, weight: .medium)
+        let aiColor = NSColor.labelColor.withAlphaComponent(0.8)
+
+        for span in tickerNextAuthorshipSpans {
+            guard span.lengthUTF16 > 0 else { continue }
+            let maxLength = fullRange.length - span.startUTF16
+            guard span.startUTF16 >= 0, maxLength > 0 else { continue }
+            let appliedRange = NSRange(
+                location: span.startUTF16,
+                length: min(span.lengthUTF16, maxLength)
+            )
+            layoutManager.addTemporaryAttribute(.font, value: aiFont, forCharacterRange: appliedRange)
+            layoutManager.addTemporaryAttribute(.foregroundColor, value: aiColor, forCharacterRange: appliedRange)
+        }
+    }
+
+    private func persistTickerNextCurrentNoteAndMetadata() {
+        guard var note = tickerNextCurrentNote else { return }
+        if let textView = tickerNextEditorTextView {
+            note.body = textView.string
+        }
+
+        do {
+            _ = try ensureLibraryFolderSelected()
+            _ = try libraryService.withLibraryRootAccess { rootURL in
+                try libraryService.saveNote(note)
+                try tickerNextDocMetadataStore.saveSpans(
+                    tickerNextAuthorshipSpans,
+                    for: note,
+                    libraryRootURL: rootURL
+                )
+            }
+            tickerNextCurrentNote = note
+            tickerNextPreviousEditorBody = note.body
+        } catch {
+            DebugLog.log("[TickerNext] Failed to persist note metadata (\(DebugLog.errorSummary(error)))")
+        }
     }
 
     private func appendMarkdownBlock(_ block: String, to body: String) -> String {

--- a/Sources/Ticker/App/TickerNextEditorTextView.swift
+++ b/Sources/Ticker/App/TickerNextEditorTextView.swift
@@ -1,0 +1,73 @@
+import AppKit
+
+protocol TickerNextEditorTextViewActionHandling: AnyObject {
+    func tickerNextEditorTextView(
+        _ textView: TickerNextEditorTextView,
+        didRequestAction action: TickerNextSelectionAIAction
+    )
+}
+
+final class TickerNextEditorTextView: NSTextView {
+    private static let aiMenuTag = 31_001
+    private static let aiSeparatorTag = 31_002
+
+    weak var actionHandler: TickerNextEditorTextViewActionHandling?
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = super.menu(for: event) ?? NSMenu(title: "Context")
+        removeTickerNextAIMenuItems(from: menu)
+
+        let hasSelection = selectedRange().length > 0
+
+        let aiMenuItem = NSMenuItem(title: "AI", action: nil, keyEquivalent: "")
+        aiMenuItem.tag = Self.aiMenuTag
+        let aiSubmenu = NSMenu(title: "AI")
+
+        let rewrite = NSMenuItem(title: "Rewrite...", action: #selector(handleRewrite), keyEquivalent: "")
+        rewrite.target = self
+        rewrite.isEnabled = hasSelection
+        aiSubmenu.addItem(rewrite)
+
+        let proofread = NSMenuItem(title: "Proofread", action: #selector(handleProofread), keyEquivalent: "")
+        proofread.target = self
+        proofread.isEnabled = hasSelection
+        aiSubmenu.addItem(proofread)
+
+        let summarize = NSMenuItem(title: "Summarize", action: #selector(handleSummarize), keyEquivalent: "")
+        summarize.target = self
+        summarize.isEnabled = hasSelection
+        aiSubmenu.addItem(summarize)
+
+        aiMenuItem.submenu = aiSubmenu
+
+        if !menu.items.isEmpty {
+            let separator = NSMenuItem.separator()
+            separator.tag = Self.aiSeparatorTag
+            menu.addItem(separator)
+        }
+        menu.addItem(aiMenuItem)
+
+        return menu
+    }
+
+    @objc private func handleRewrite() {
+        actionHandler?.tickerNextEditorTextView(self, didRequestAction: .rewrite)
+    }
+
+    @objc private func handleProofread() {
+        actionHandler?.tickerNextEditorTextView(self, didRequestAction: .proofread)
+    }
+
+    @objc private func handleSummarize() {
+        actionHandler?.tickerNextEditorTextView(self, didRequestAction: .summarize)
+    }
+
+    private func removeTickerNextAIMenuItems(from menu: NSMenu) {
+        for index in stride(from: menu.items.count - 1, through: 0, by: -1) {
+            let item = menu.items[index]
+            if item.tag == Self.aiMenuTag || item.tag == Self.aiSeparatorTag {
+                menu.removeItem(at: index)
+            }
+        }
+    }
+}

--- a/Sources/Ticker/Services/DeviceKeyService.swift
+++ b/Sources/Ticker/Services/DeviceKeyService.swift
@@ -266,12 +266,13 @@ actor DeviceKeyService {
         return "https://ticker-proxy.fly.dev"
     }
 
-    init(fileURL: URL? = nil, fileManager: FileManager = .default) {
-        self.fileManager = fileManager
-        self.fileURL = fileURL ?? Self.defaultFileURL(fileManager: fileManager)
+    init(fileURL: URL? = nil) {
+        self.fileManager = .default
+        self.fileURL = fileURL ?? Self.defaultFileURL()
     }
 
-    private static func defaultFileURL(fileManager: FileManager) -> URL {
+    private static func defaultFileURL() -> URL {
+        let fileManager = FileManager.default
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
         let tickerDir = appSupport.appendingPathComponent("Ticker", isDirectory: true)

--- a/Sources/Ticker/Services/TickerNextAuthorshipService.swift
+++ b/Sources/Ticker/Services/TickerNextAuthorshipService.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+struct TickerNextAuthorshipSpan: Codable, Equatable {
+    var startUTF16: Int
+    var lengthUTF16: Int
+    var source: String
+    var createdAt: Date
+
+    var endUTF16: Int {
+        startUTF16 + lengthUTF16
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case startUTF16 = "start_utf16"
+        case lengthUTF16 = "length_utf16"
+        case source
+        case createdAt = "created_at"
+    }
+}
+
+struct TickerNextTextEdit: Equatable {
+    var replacedRange: NSRange
+    var insertedLength: Int
+
+    var delta: Int {
+        insertedLength - replacedRange.length
+    }
+}
+
+enum TickerNextTextEditDetector {
+    static func detectSingleEdit(from oldText: String, to newText: String) -> TickerNextTextEdit? {
+        let oldUnits = Array(oldText.utf16)
+        let newUnits = Array(newText.utf16)
+
+        let oldLength = oldUnits.count
+        let newLength = newUnits.count
+        let minimumLength = min(oldLength, newLength)
+
+        var commonPrefix = 0
+        while commonPrefix < minimumLength, oldUnits[commonPrefix] == newUnits[commonPrefix] {
+            commonPrefix += 1
+        }
+
+        var commonSuffix = 0
+        while commonSuffix < (oldLength - commonPrefix),
+              commonSuffix < (newLength - commonPrefix),
+              oldUnits[oldLength - 1 - commonSuffix] == newUnits[newLength - 1 - commonSuffix] {
+            commonSuffix += 1
+        }
+
+        let replacedLength = oldLength - commonPrefix - commonSuffix
+        let insertedLength = newLength - commonPrefix - commonSuffix
+
+        guard replacedLength > 0 || insertedLength > 0 else {
+            return nil
+        }
+
+        return TickerNextTextEdit(
+            replacedRange: NSRange(location: commonPrefix, length: replacedLength),
+            insertedLength: insertedLength
+        )
+    }
+}
+
+enum TickerNextAuthorshipSpanTransformer {
+    static func applyUserEdit(
+        spans: [TickerNextAuthorshipSpan],
+        edit: TickerNextTextEdit
+    ) -> [TickerNextAuthorshipSpan] {
+        guard !spans.isEmpty else { return [] }
+
+        let editStart = edit.replacedRange.location
+        let editEnd = edit.replacedRange.location + edit.replacedRange.length
+
+        var updated: [TickerNextAuthorshipSpan] = []
+        updated.reserveCapacity(spans.count + 1)
+
+        for span in spans {
+            let spanStart = span.startUTF16
+            let spanEnd = span.endUTF16
+
+            if spanEnd <= editStart {
+                updated.append(span)
+                continue
+            }
+
+            if spanStart >= editEnd {
+                var shifted = span
+                shifted.startUTF16 += edit.delta
+                updated.append(shifted)
+                continue
+            }
+
+            let leftLength = max(0, editStart - spanStart)
+            if leftLength > 0 {
+                var left = span
+                left.lengthUTF16 = leftLength
+                updated.append(left)
+            }
+
+            let rightLength = max(0, spanEnd - editEnd)
+            if rightLength > 0 {
+                var right = span
+                right.startUTF16 = edit.replacedRange.location + edit.insertedLength
+                right.lengthUTF16 = rightLength
+                updated.append(right)
+            }
+        }
+
+        return normalize(updated)
+    }
+
+    static func addAIInsertion(
+        range: NSRange,
+        source: String,
+        to spans: [TickerNextAuthorshipSpan],
+        createdAt: Date = Date()
+    ) -> [TickerNextAuthorshipSpan] {
+        guard range.length > 0 else {
+            return normalize(spans)
+        }
+
+        var updated = spans
+        updated.append(
+            TickerNextAuthorshipSpan(
+                startUTF16: range.location,
+                lengthUTF16: range.length,
+                source: source,
+                createdAt: createdAt
+            )
+        )
+
+        return normalize(updated)
+    }
+
+    static func clamped(
+        spans: [TickerNextAuthorshipSpan],
+        toUTF16Length textLength: Int
+    ) -> [TickerNextAuthorshipSpan] {
+        guard textLength >= 0 else { return [] }
+
+        let clampedSpans: [TickerNextAuthorshipSpan] = spans.compactMap { span in
+            guard span.lengthUTF16 > 0, span.startUTF16 < textLength else {
+                return nil
+            }
+
+            let clampedStart = max(0, span.startUTF16)
+            let clampedEnd = min(textLength, span.endUTF16)
+            guard clampedEnd > clampedStart else {
+                return nil
+            }
+
+            var updated = span
+            updated.startUTF16 = clampedStart
+            updated.lengthUTF16 = clampedEnd - clampedStart
+            return updated
+        }
+
+        return normalize(clampedSpans)
+    }
+
+    static func normalize(_ spans: [TickerNextAuthorshipSpan]) -> [TickerNextAuthorshipSpan] {
+        let sorted = spans
+            .filter { $0.lengthUTF16 > 0 }
+            .sorted {
+                if $0.startUTF16 == $1.startUTF16 {
+                    return $0.endUTF16 < $1.endUTF16
+                }
+                return $0.startUTF16 < $1.startUTF16
+            }
+
+        guard !sorted.isEmpty else { return [] }
+
+        var merged: [TickerNextAuthorshipSpan] = []
+        merged.reserveCapacity(sorted.count)
+
+        for span in sorted {
+            guard var last = merged.last else {
+                merged.append(span)
+                continue
+            }
+
+            if span.startUTF16 <= last.endUTF16, span.source == last.source {
+                let mergedEnd = max(last.endUTF16, span.endUTF16)
+                last.lengthUTF16 = mergedEnd - last.startUTF16
+                last.createdAt = min(last.createdAt, span.createdAt)
+                merged[merged.count - 1] = last
+                continue
+            }
+
+            merged.append(span)
+        }
+
+        return merged
+    }
+}
+
+struct TickerNextDocMetadata: Codable, Equatable {
+    var schemaVersion: Int
+    var aiSpans: [TickerNextAuthorshipSpan]
+
+    init(schemaVersion: Int = 1, aiSpans: [TickerNextAuthorshipSpan]) {
+        self.schemaVersion = schemaVersion
+        self.aiSpans = aiSpans
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case aiSpans = "ai_spans"
+    }
+}
+
+final class TickerNextDocMetadataStore {
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    func loadSpans(
+        for note: TickerMarkdownNote,
+        libraryRootURL: URL
+    ) throws -> [TickerNextAuthorshipSpan] {
+        let metadataURL = metadataFileURL(for: note, libraryRootURL: libraryRootURL)
+        guard fileManager.fileExists(atPath: metadataURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: metadataURL)
+        let metadata = try decoder.decode(TickerNextDocMetadata.self, from: data)
+        return TickerNextAuthorshipSpanTransformer.normalize(metadata.aiSpans)
+    }
+
+    func saveSpans(
+        _ spans: [TickerNextAuthorshipSpan],
+        for note: TickerMarkdownNote,
+        libraryRootURL: URL
+    ) throws {
+        let metadataURL = metadataFileURL(for: note, libraryRootURL: libraryRootURL)
+        let parentDirectory = metadataURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+
+        let metadata = TickerNextDocMetadata(
+            schemaVersion: 1,
+            aiSpans: TickerNextAuthorshipSpanTransformer.normalize(spans)
+        )
+        let data = try encoder.encode(metadata)
+        try data.write(to: metadataURL, options: [.atomic])
+    }
+
+    private func metadataFileURL(
+        for note: TickerMarkdownNote,
+        libraryRootURL: URL
+    ) -> URL {
+        libraryRootURL
+            .appendingPathComponent(".ticker", isDirectory: true)
+            .appendingPathComponent("meta", isDirectory: true)
+            .appendingPathComponent("docs", isDirectory: true)
+            .appendingPathComponent("\(note.frontMatter.tickerID.uuidString.lowercased()).json")
+    }
+}

--- a/Sources/Ticker/Services/TickerNextSelectionAIService.swift
+++ b/Sources/Ticker/Services/TickerNextSelectionAIService.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+enum TickerNextSelectionAIAction: String {
+    case rewrite
+    case proofread
+    case summarize
+
+    func modifierPrompt(customInstruction: String?) throws -> String {
+        switch self {
+        case .rewrite:
+            guard let customInstruction = customInstruction?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !customInstruction.isEmpty else {
+                throw TickerNextSelectionAIServiceError.missingRewriteInstruction
+            }
+
+            return """
+            Rewrite the text to satisfy this instruction:
+            \(customInstruction)
+
+            Preserve factual meaning unless the instruction explicitly requests a change.
+            Return only the rewritten text.
+            """
+
+        case .proofread:
+            return """
+            Proofread the text.
+            Fix grammar, punctuation, spelling, and obvious clarity issues.
+            Preserve meaning and tone. Return only the corrected text.
+            """
+
+        case .summarize:
+            return """
+            Summarize the text while preserving the key facts and conclusions.
+            Keep it concise and readable. Return only the summary.
+            """
+        }
+    }
+}
+
+enum TickerNextSelectionAIServiceError: LocalizedError {
+    case missingRewriteInstruction
+    case emptyModelResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRewriteInstruction:
+            return "Rewrite requires an instruction."
+        case .emptyModelResponse:
+            return "AI returned an empty response."
+        }
+    }
+}
+
+final class TickerNextSelectionAIService {
+    private let proxyService: ProxyLLMService
+
+    init(proxyService: ProxyLLMService = ProxyLLMService()) {
+        self.proxyService = proxyService
+    }
+
+    func transformSelection(
+        _ selection: String,
+        action: TickerNextSelectionAIAction,
+        customInstruction: String? = nil
+    ) async throws -> String {
+        let modifierPrompt = try action.modifierPrompt(customInstruction: customInstruction)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var responseBuffer = ""
+            var didResume = false
+
+            Task {
+                await proxyService.applyModifier(
+                    currentContent: selection,
+                    modifierPrompt: modifierPrompt,
+                    onChunk: { chunk in
+                        responseBuffer += chunk
+                    },
+                    onComplete: {
+                        guard !didResume else { return }
+                        didResume = true
+
+                        let output = responseBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !output.isEmpty else {
+                            continuation.resume(throwing: TickerNextSelectionAIServiceError.emptyModelResponse)
+                            return
+                        }
+
+                        continuation.resume(returning: output)
+                    },
+                    onError: { error in
+                        guard !didResume else { return }
+                        didResume = true
+                        continuation.resume(throwing: error)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/Tests/TickerTests/TickerNextAuthorshipServiceTests.swift
+++ b/Tests/TickerTests/TickerNextAuthorshipServiceTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+@testable import Ticker
+
+final class TickerNextAuthorshipSpanTransformerTests: XCTestCase {
+    func test_applyUserEdit_splitSpanWhenEditingInsideAIText() {
+        let original = TickerNextAuthorshipSpan(
+            startUTF16: 10,
+            lengthUTF16: 10,
+            source: "rewrite",
+            createdAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let edit = TickerNextTextEdit(
+            replacedRange: NSRange(location: 14, length: 2),
+            insertedLength: 1
+        )
+
+        let updated = TickerNextAuthorshipSpanTransformer.applyUserEdit(spans: [original], edit: edit)
+
+        XCTAssertEqual(updated.count, 2)
+        XCTAssertEqual(updated[0].startUTF16, 10)
+        XCTAssertEqual(updated[0].lengthUTF16, 4)
+        XCTAssertEqual(updated[1].startUTF16, 15)
+        XCTAssertEqual(updated[1].lengthUTF16, 4)
+    }
+
+    func test_applyUserEdit_shrinkSpanWhenEditingAcrossLeadingEdge() {
+        let original = TickerNextAuthorshipSpan(
+            startUTF16: 10,
+            lengthUTF16: 10,
+            source: "proofread",
+            createdAt: Date(timeIntervalSince1970: 2_000)
+        )
+        let edit = TickerNextTextEdit(
+            replacedRange: NSRange(location: 8, length: 5),
+            insertedLength: 2
+        )
+
+        let updated = TickerNextAuthorshipSpanTransformer.applyUserEdit(spans: [original], edit: edit)
+
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertEqual(updated[0].startUTF16, 10)
+        XCTAssertEqual(updated[0].lengthUTF16, 7)
+    }
+
+    func test_applyUserEdit_shiftsSpansAfterEditedRange() {
+        let original = TickerNextAuthorshipSpan(
+            startUTF16: 20,
+            lengthUTF16: 5,
+            source: "summarize",
+            createdAt: Date(timeIntervalSince1970: 3_000)
+        )
+        let edit = TickerNextTextEdit(
+            replacedRange: NSRange(location: 5, length: 2),
+            insertedLength: 6
+        )
+
+        let updated = TickerNextAuthorshipSpanTransformer.applyUserEdit(spans: [original], edit: edit)
+
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertEqual(updated[0].startUTF16, 24)
+        XCTAssertEqual(updated[0].lengthUTF16, 5)
+    }
+}
+
+final class TickerNextDocMetadataStoreTests: XCTestCase {
+    func test_saveAndLoadSpans_roundtrip() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let noteURL = tempDir.appendingPathComponent("test-note.md")
+        let note = TickerMarkdownNote(
+            url: noteURL,
+            frontMatter: TickerNoteFrontMatter(
+                tickerID: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!,
+                tickerKind: .note,
+                tickerPDFID: nil,
+                createdAt: nil
+            ),
+            body: "Body"
+        )
+
+        let spans = [
+            TickerNextAuthorshipSpan(
+                startUTF16: 0,
+                lengthUTF16: 4,
+                source: "rewrite",
+                createdAt: Date(timeIntervalSince1970: 1_000)
+            ),
+            TickerNextAuthorshipSpan(
+                startUTF16: 8,
+                lengthUTF16: 3,
+                source: "proofread",
+                createdAt: Date(timeIntervalSince1970: 2_000)
+            )
+        ]
+
+        let store = TickerNextDocMetadataStore(fileManager: fileManager)
+        try store.saveSpans(spans, for: note, libraryRootURL: tempDir)
+        let loaded = try store.loadSpans(for: note, libraryRootURL: tempDir)
+
+        XCTAssertEqual(loaded, spans)
+    }
+}

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -55,10 +55,14 @@
 		A1000001000000000029 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000029 /* KeychainService.swift */; };
 		A100000100000000002A /* SelectionReaderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002A /* SelectionReaderService.swift */; };
 			A100000100000000002C /* DeviceKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002C /* DeviceKeyService.swift */; };
-			A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
-			A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
-			A1000001000000000030 /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* LibraryService.swift */; };
-			A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
+		A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
+		A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
+		A1000001000000000030 /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* LibraryService.swift */; };
+		A1000001000000000031 /* TickerNextEditorTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000031 /* TickerNextEditorTextView.swift */; };
+		A1000001000000000032 /* TickerNextAuthorshipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000032 /* TickerNextAuthorshipService.swift */; };
+		A1000001000000000033 /* TickerNextSelectionAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000033 /* TickerNextSelectionAIService.swift */; };
+		A1000001000000000034 /* TickerNextAuthorshipServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000034 /* TickerNextAuthorshipServiceTests.swift */; };
+		A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
 		/* End PBXBuildFile section */
 
 		/* Begin PBXContainerItemProxy section */
@@ -120,10 +124,14 @@
 		B1000001000000000029 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B100000100000000002A /* SelectionReaderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionReaderService.swift; sourceTree = "<group>"; };
 			B100000100000000002C /* DeviceKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyService.swift; sourceTree = "<group>"; };
-			B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
-			B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
-			B1000001000000000030 /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
-				B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
+		B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
+		B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
+		B1000001000000000030 /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
+		B1000001000000000031 /* TickerNextEditorTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerNextEditorTextView.swift; sourceTree = "<group>"; };
+		B1000001000000000032 /* TickerNextAuthorshipService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerNextAuthorshipService.swift; sourceTree = "<group>"; };
+		B1000001000000000033 /* TickerNextSelectionAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerNextSelectionAIService.swift; sourceTree = "<group>"; };
+		B1000001000000000034 /* TickerNextAuthorshipServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerNextAuthorshipServiceTests.swift; sourceTree = "<group>"; };
+		B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
 				F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 				F1000001000000000002 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
@@ -193,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				B1000001000000000001 /* AppDelegate.swift */,
+				B1000001000000000031 /* TickerNextEditorTextView.swift */,
 				B1000001000000000002 /* AssetSchemeHandler.swift */,
 				B100000100000000002B /* BundleSchemeHandler.swift */,
 				B1000001000000000003 /* BridgeService.swift */,
@@ -246,6 +255,8 @@
 				B100000100000000002D /* ProxyLLMService.swift */,
 				B100000100000000002E /* DebugLog.swift */,
 				B1000001000000000030 /* LibraryService.swift */,
+				B1000001000000000032 /* TickerNextAuthorshipService.swift */,
+				B1000001000000000033 /* TickerNextSelectionAIService.swift */,
 				B1000001000000000020 /* QueryClassifier.swift */,
 				B1000001000000000021 /* RAGMigrationService.swift */,
 				B1000001000000000022 /* RetrievalService.swift */,
@@ -304,14 +315,15 @@
 				path = Tests;
 				sourceTree = "<group>";
 			};
-			G100000100000000000A /* TickerTests */ = {
-				isa = PBXGroup;
-				children = (
-					B100000100000000002F /* DeviceKeyServiceTests.swift */,
-				);
-				path = TickerTests;
-				sourceTree = "<group>";
-			};
+		G100000100000000000A /* TickerTests */ = {
+			isa = PBXGroup;
+			children = (
+				B100000100000000002F /* DeviceKeyServiceTests.swift */,
+				B1000001000000000034 /* TickerNextAuthorshipServiceTests.swift */,
+			);
+			path = TickerTests;
+			sourceTree = "<group>";
+		};
 		/* End PBXGroup section */
 
 		/* Begin PBXNativeTarget section */
@@ -447,6 +459,7 @@
 				A1000001000000000007 /* QuickPanelManager.swift in Sources */,
 				A1000001000000000008 /* QuickPanelView.swift in Sources */,
 				A1000001000000000009 /* QuickPanelWindow.swift in Sources */,
+				A1000001000000000031 /* TickerNextEditorTextView.swift in Sources */,
 				A100000100000000000A /* Colors.swift in Sources */,
 				A100000100000000000B /* Spacing.swift in Sources */,
 				A100000100000000000C /* BridgePayloads.swift in Sources */,
@@ -484,6 +497,8 @@
 				A100000100000000002D /* ProxyLLMService.swift in Sources */,
 				A100000100000000002E /* DebugLog.swift in Sources */,
 				A1000001000000000030 /* LibraryService.swift in Sources */,
+				A1000001000000000032 /* TickerNextAuthorshipService.swift in Sources */,
+				A1000001000000000033 /* TickerNextSelectionAIService.swift in Sources */,
 			);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
@@ -492,6 +507,7 @@
 				buildActionMask = 2147483647;
 				files = (
 					A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */,
+					A1000001000000000034 /* TickerNextAuthorshipServiceTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};


### PR DESCRIPTION
## Summary
- add native selection-based AI actions in Ticker Next editor context menu (`Rewrite`, `Proofread`, `Summarize`)
- route selected text transforms through existing proxy-backed modifier flow
- apply replacements as normal text edits with undo grouping (single undo returns pre-AI text)
- persist AI authorship spans in `.ticker/meta/docs/<ticker_id>.json` and reapply subtle styling on note load
- include Swift unit tests for span edit transforms and metadata roundtrip
- include warning-hardening fix for `DeviceKeyService` actor init sendability warning

## Files
- `Sources/Ticker/App/AppDelegate.swift`
- `Sources/Ticker/App/TickerNextEditorTextView.swift`
- `Sources/Ticker/Services/TickerNextAuthorshipService.swift`
- `Sources/Ticker/Services/TickerNextSelectionAIService.swift`
- `Tests/TickerTests/TickerNextAuthorshipServiceTests.swift`
- `Ticker.xcodeproj/project.pbxproj`

## Verification
- `./tickerctl.sh swift-test`

Closes #11
Closes #10
