### PR TITLE
M4 slice A: import PDF and create linked companion note

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -185,6 +185,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
             openNoteItem.target = self
             appMenu.addItem(openNoteItem)
 
+            let importPDFItem = NSMenuItem(
+                title: "Import PDF...",
+                action: #selector(importTickerNextPDF),
+                keyEquivalent: "i"
+            )
+            importPDFItem.target = self
+            appMenu.addItem(importPDFItem)
+
             let saveNoteItem = NSMenuItem(
                 title: "Save Note",
                 action: #selector(saveTickerNextNote),
@@ -396,6 +404,43 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
             }
         } catch {
             DebugLog.log("[TickerNext] Failed to open note (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    @objc private func importTickerNextPDF() {
+        guard SettingsService.tickerNextMode else { return }
+        do {
+            _ = try ensureLibraryFolderSelected()
+
+            let panel = NSOpenPanel()
+            panel.canChooseDirectories = false
+            panel.canChooseFiles = true
+            panel.allowsMultipleSelection = false
+            panel.allowedContentTypes = [.pdf]
+            panel.prompt = "Import PDF"
+            panel.message = "Choose a PDF to copy into the Ticker Next library."
+
+            guard panel.runModal() == .OK, let selectedURL = panel.url else {
+                return
+            }
+
+            let didAccessSelectedPDF = selectedURL.startAccessingSecurityScopedResource()
+            defer {
+                if didAccessSelectedPDF {
+                    selectedURL.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            let imported = try libraryService.withLibraryRootAccess { rootURL in
+                try libraryService.importPDF(at: selectedURL, in: rootURL)
+            }
+
+            if let imported {
+                showTickerNextNote(imported.note)
+                DebugLog.log("[TickerNext] Imported PDF at \(imported.importedURL.path)")
+            }
+        } catch {
+            DebugLog.log("[TickerNext] Failed to import PDF (\(DebugLog.errorSummary(error)))")
         }
     }
 

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -25,6 +25,13 @@ struct TickerMarkdownNote: Equatable {
     var body: String
 }
 
+struct TickerImportedPDF: Equatable {
+    var pdfID: UUID
+    var sourceURL: URL
+    var importedURL: URL
+    var note: TickerMarkdownNote
+}
+
 struct DuplicateTickerIDGroup: Equatable {
     var tickerID: UUID
     var fileURLs: [URL]
@@ -345,6 +352,43 @@ final class LibraryService {
             .appendingPathComponent(fileName)
         try data.write(to: imageURL, options: [.atomic])
         return imageURL
+    }
+
+    func importPDF(
+        at sourceURL: URL,
+        in rootURL: URL,
+        companionDirectoryRelativePath: String? = nil
+    ) throws -> TickerImportedPDF {
+        try ensureLibraryStructure(at: rootURL)
+
+        let pdfID = UUID()
+        let destinationURL = rootURL
+            .appendingPathComponent("Assets", isDirectory: true)
+            .appendingPathComponent("PDFs", isDirectory: true)
+            .appendingPathComponent("\(pdfID.uuidString.lowercased()).pdf")
+
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+
+        do {
+            let title = sourceURL.deletingPathExtension().lastPathComponent
+            let note = try createNote(
+                in: rootURL,
+                title: title.isEmpty ? "Imported PDF" : title,
+                kind: .pdfNote,
+                tickerPDFID: pdfID,
+                directoryRelativePath: companionDirectoryRelativePath
+            )
+
+            return TickerImportedPDF(
+                pdfID: pdfID,
+                sourceURL: sourceURL,
+                importedURL: destinationURL,
+                note: note
+            )
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
     }
 
     func relativePath(from baseURL: URL, to targetURL: URL) -> String {

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -439,3 +439,38 @@ final class LibraryServiceCaptureAssetTests: XCTestCase {
         XCTAssertTrue(relativePath.hasPrefix("../Assets/Images/"))
     }
 }
+
+final class LibraryServicePDFImportTests: XCTestCase {
+    func test_importPDF_copiesAssetAndCreatesLinkedPDFNote() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let libraryRoot = tempDir.appendingPathComponent("Library", isDirectory: true)
+        let sourceRoot = tempDir.appendingPathComponent("Source", isDirectory: true)
+        try fileManager.createDirectory(at: libraryRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+
+        let sourcePDFURL = sourceRoot.appendingPathComponent("paper.pdf")
+        let samplePDF = Data("%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n".utf8)
+        try samplePDF.write(to: sourcePDFURL, options: [.atomic])
+
+        let suiteName = "LibraryServicePDFImportTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        let imported = try service.importPDF(at: sourcePDFURL, in: libraryRoot)
+
+        XCTAssertTrue(fileManager.fileExists(atPath: imported.importedURL.path))
+        XCTAssertEqual(imported.importedURL.pathExtension.lowercased(), "pdf")
+        XCTAssertTrue(imported.importedURL.path.contains("/Assets/PDFs/"))
+        XCTAssertEqual(imported.note.frontMatter.tickerKind, .pdfNote)
+        XCTAssertEqual(imported.note.frontMatter.tickerPDFID, imported.pdfID)
+
+        let loaded = try service.loadNote(at: imported.note.url)
+        XCTAssertEqual(loaded.frontMatter.tickerKind, .pdfNote)
+        XCTAssertEqual(loaded.frontMatter.tickerPDFID, imported.pdfID)
+    }
+}


### PR DESCRIPTION
## Summary
- add `Import PDF...` action in Ticker Next app menu
- copy imported PDFs into library-managed `Assets/PDFs/<pdfId>.pdf`
- create companion markdown note as `ticker_kind: pdf_note` with `ticker_pdf_id` linkage
- open the companion note in editor immediately after import
- add unit test coverage for import path and note linkage

## Files
- `Sources/Ticker/App/AppDelegate.swift`
- `Sources/Ticker/Services/LibraryService.swift`
- `Tests/TickerTests/DeviceKeyServiceTests.swift`

## Validation
- `./tickerctl.sh swift-test`

Closes #13
