### PR TITLE
M4 slice B: PDF fingerprint metadata and drift detection

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -678,6 +678,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
         tickerNextPreviousEditorBody = note.body
         applyTickerNextAuthorshipStyling()
         tickerNextEditorWindow?.title = note.url.lastPathComponent
+        checkTickerNextPDFDriftIfNeeded(for: note)
     }
 
     func textDidChange(_ notification: Notification) {
@@ -924,6 +925,60 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
         } catch {
             DebugLog.log("[TickerNext] Failed to persist note metadata (\(DebugLog.errorSummary(error)))")
         }
+    }
+
+    private func checkTickerNextPDFDriftIfNeeded(for note: TickerMarkdownNote) {
+        guard note.frontMatter.tickerKind == .pdfNote,
+              let pdfID = note.frontMatter.tickerPDFID else {
+            return
+        }
+
+        do {
+            let status = try libraryService.withLibraryRootAccess { rootURL in
+                try libraryService.inspectPDFDrift(for: pdfID, in: rootURL)
+            }
+
+            guard let status else { return }
+
+            switch status {
+            case .matches:
+                return
+
+            case .missingFile:
+                presentTickerNextPDFDriftWarning(
+                    title: "Linked PDF Missing",
+                    message: "Ticker Next cannot find the imported PDF file linked to this note."
+                )
+
+            case .missingMetadata(let current):
+                _ = try libraryService.withLibraryRootAccess { rootURL in
+                    try libraryService.savePDFMetadata(pdfID: pdfID, fingerprint: current, in: rootURL)
+                }
+                DebugLog.log("[TickerNext] Bootstrapped missing PDF metadata for \(pdfID.uuidString.lowercased())")
+
+            case .drifted(let expected, let current):
+                let message = """
+                The linked PDF has changed since import.
+
+                Stored: \(expected.fileSize) bytes
+                Current: \(current.fileSize) bytes
+                """
+                presentTickerNextPDFDriftWarning(
+                    title: "Linked PDF Has Changed",
+                    message: message
+                )
+            }
+        } catch {
+            DebugLog.log("[TickerNext] PDF drift check failed (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    private func presentTickerNextPDFDriftWarning(title: String, message: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = title
+        alert.informativeText = message
+        alert.runModal()
     }
 
     private func appendMarkdownBlock(_ block: String, to body: String) -> String {

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import CryptoKit
 
 enum TickerNoteKind: String, Equatable {
     case note
@@ -30,6 +31,39 @@ struct TickerImportedPDF: Equatable {
     var sourceURL: URL
     var importedURL: URL
     var note: TickerMarkdownNote
+}
+
+struct TickerPDFFingerprint: Codable, Equatable {
+    var fileSize: Int64
+    var modificationTimestamp: TimeInterval
+    var sha256Hex: String
+
+    private enum CodingKeys: String, CodingKey {
+        case fileSize = "file_size"
+        case modificationTimestamp = "modification_timestamp"
+        case sha256Hex = "sha256_hex"
+    }
+}
+
+struct TickerPDFMetadata: Codable, Equatable {
+    var schemaVersion: Int
+    var pdfID: UUID
+    var fingerprint: TickerPDFFingerprint
+    var updatedAt: Date
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case pdfID = "pdf_id"
+        case fingerprint
+        case updatedAt = "updated_at"
+    }
+}
+
+enum TickerPDFDriftStatus: Equatable {
+    case matches
+    case missingFile
+    case missingMetadata(current: TickerPDFFingerprint)
+    case drifted(expected: TickerPDFFingerprint, current: TickerPDFFingerprint)
 }
 
 struct DuplicateTickerIDGroup: Equatable {
@@ -362,14 +396,14 @@ final class LibraryService {
         try ensureLibraryStructure(at: rootURL)
 
         let pdfID = UUID()
-        let destinationURL = rootURL
-            .appendingPathComponent("Assets", isDirectory: true)
-            .appendingPathComponent("PDFs", isDirectory: true)
-            .appendingPathComponent("\(pdfID.uuidString.lowercased()).pdf")
+        let destinationURL = importedPDFURL(for: pdfID, in: rootURL)
 
         try fileManager.copyItem(at: sourceURL, to: destinationURL)
 
         do {
+            let fingerprint = try computePDFFingerprint(at: destinationURL)
+            try savePDFMetadata(pdfID: pdfID, fingerprint: fingerprint, in: rootURL)
+
             let title = sourceURL.deletingPathExtension().lastPathComponent
             let note = try createNote(
                 in: rootURL,
@@ -387,8 +421,94 @@ final class LibraryService {
             )
         } catch {
             try? fileManager.removeItem(at: destinationURL)
+            try? fileManager.removeItem(at: pdfMetadataURL(for: pdfID, in: rootURL))
             throw error
         }
+    }
+
+    func importedPDFURL(for pdfID: UUID, in rootURL: URL) -> URL {
+        rootURL
+            .appendingPathComponent("Assets", isDirectory: true)
+            .appendingPathComponent("PDFs", isDirectory: true)
+            .appendingPathComponent("\(pdfID.uuidString.lowercased()).pdf")
+    }
+
+    func computePDFFingerprint(at pdfURL: URL) throws -> TickerPDFFingerprint {
+        let fileData = try Data(contentsOf: pdfURL, options: [.mappedIfSafe])
+        let digest = SHA256.hash(data: fileData)
+        let sha256Hex = digest.map { String(format: "%02x", $0) }.joined()
+
+        let resourceValues = try pdfURL.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        let fileSize = Int64(resourceValues.fileSize ?? fileData.count)
+        let modificationTimestamp = (resourceValues.contentModificationDate ?? Date.distantPast).timeIntervalSince1970
+
+        return TickerPDFFingerprint(
+            fileSize: fileSize,
+            modificationTimestamp: modificationTimestamp,
+            sha256Hex: sha256Hex
+        )
+    }
+
+    func savePDFMetadata(
+        pdfID: UUID,
+        fingerprint: TickerPDFFingerprint,
+        in rootURL: URL
+    ) throws {
+        let metadata = TickerPDFMetadata(
+            schemaVersion: 1,
+            pdfID: pdfID,
+            fingerprint: fingerprint,
+            updatedAt: Date()
+        )
+        let metadataURL = pdfMetadataURL(for: pdfID, in: rootURL)
+        try fileManager.createDirectory(at: metadataURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(metadata)
+        try data.write(to: metadataURL, options: [.atomic])
+    }
+
+    func loadPDFMetadata(pdfID: UUID, in rootURL: URL) throws -> TickerPDFMetadata? {
+        let metadataURL = pdfMetadataURL(for: pdfID, in: rootURL)
+        guard fileManager.fileExists(atPath: metadataURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: metadataURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(TickerPDFMetadata.self, from: data)
+    }
+
+    func inspectPDFDrift(
+        for pdfID: UUID,
+        in rootURL: URL
+    ) throws -> TickerPDFDriftStatus {
+        let importedURL = importedPDFURL(for: pdfID, in: rootURL)
+        guard fileManager.fileExists(atPath: importedURL.path) else {
+            return .missingFile
+        }
+
+        let currentFingerprint = try computePDFFingerprint(at: importedURL)
+        guard let metadata = try loadPDFMetadata(pdfID: pdfID, in: rootURL) else {
+            return .missingMetadata(current: currentFingerprint)
+        }
+
+        if metadata.fingerprint == currentFingerprint {
+            return .matches
+        }
+
+        return .drifted(expected: metadata.fingerprint, current: currentFingerprint)
+    }
+
+    private func pdfMetadataURL(for pdfID: UUID, in rootURL: URL) -> URL {
+        rootURL
+            .appendingPathComponent(".ticker", isDirectory: true)
+            .appendingPathComponent("meta", isDirectory: true)
+            .appendingPathComponent("pdfs", isDirectory: true)
+            .appendingPathComponent("\(pdfID.uuidString.lowercased()).json")
     }
 
     func relativePath(from baseURL: URL, to targetURL: URL) -> String {

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -473,4 +473,90 @@ final class LibraryServicePDFImportTests: XCTestCase {
         XCTAssertEqual(loaded.frontMatter.tickerKind, .pdfNote)
         XCTAssertEqual(loaded.frontMatter.tickerPDFID, imported.pdfID)
     }
+
+    func test_importPDF_persistsPDFMetadataAndMatchesInitialFingerprint() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let libraryRoot = tempDir.appendingPathComponent("Library", isDirectory: true)
+        let sourceRoot = tempDir.appendingPathComponent("Source", isDirectory: true)
+        try fileManager.createDirectory(at: libraryRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+
+        let sourcePDFURL = sourceRoot.appendingPathComponent("whitepaper.pdf")
+        let samplePDF = Data("%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<<>>\n%%EOF\n".utf8)
+        try samplePDF.write(to: sourcePDFURL, options: [.atomic])
+
+        let suiteName = "LibraryServicePDFMetadataTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        let imported = try service.importPDF(at: sourcePDFURL, in: libraryRoot)
+
+        let metadata = try service.loadPDFMetadata(pdfID: imported.pdfID, in: libraryRoot)
+        XCTAssertNotNil(metadata)
+
+        let driftStatus = try service.inspectPDFDrift(for: imported.pdfID, in: libraryRoot)
+        if case .matches = driftStatus {
+            XCTAssertTrue(true)
+        } else {
+            XCTFail("Expected .matches after import, got \(driftStatus)")
+        }
+    }
+
+    func test_inspectPDFDrift_reportsMissingMetadataAndDriftAfterMutation() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let libraryRoot = tempDir.appendingPathComponent("Library", isDirectory: true)
+        let sourceRoot = tempDir.appendingPathComponent("Source", isDirectory: true)
+        try fileManager.createDirectory(at: libraryRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+
+        let sourcePDFURL = sourceRoot.appendingPathComponent("spec.pdf")
+        let originalPDF = Data("%PDF-1.4\n1 0 obj\n<< /Type /Page >>\nendobj\ntrailer\n<<>>\n%%EOF\n".utf8)
+        try originalPDF.write(to: sourcePDFURL, options: [.atomic])
+
+        let suiteName = "LibraryServicePDFDriftTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        let imported = try service.importPDF(at: sourcePDFURL, in: libraryRoot)
+
+        let metadataURL = libraryRoot
+            .appendingPathComponent(".ticker", isDirectory: true)
+            .appendingPathComponent("meta", isDirectory: true)
+            .appendingPathComponent("pdfs", isDirectory: true)
+            .appendingPathComponent("\(imported.pdfID.uuidString.lowercased()).json")
+
+        try fileManager.removeItem(at: metadataURL)
+
+        let missingMetadataStatus = try service.inspectPDFDrift(for: imported.pdfID, in: libraryRoot)
+        switch missingMetadataStatus {
+        case .missingMetadata(let current):
+            XCTAssertGreaterThan(current.fileSize, 0)
+        default:
+            XCTFail("Expected .missingMetadata, got \(missingMetadataStatus)")
+        }
+
+        let reloadedFingerprint = try service.computePDFFingerprint(at: imported.importedURL)
+        try service.savePDFMetadata(pdfID: imported.pdfID, fingerprint: reloadedFingerprint, in: libraryRoot)
+
+        let mutatedPDF = Data("%PDF-1.4\n1 0 obj\n<< /Type /Page /Rotate 90 >>\nendobj\ntrailer\n<<>>\n%%EOF\n".utf8)
+        try mutatedPDF.write(to: imported.importedURL, options: [.atomic])
+
+        let driftStatus = try service.inspectPDFDrift(for: imported.pdfID, in: libraryRoot)
+        switch driftStatus {
+        case .drifted(let expected, let current):
+            XCTAssertNotEqual(expected.sha256Hex, current.sha256Hex)
+        default:
+            XCTFail("Expected .drifted, got \(driftStatus)")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add PDF fingerprint and metadata models (`size`, `mtime`, `sha256`) and persist under `.ticker/meta/pdfs/<pdfId>.json`
- write metadata at import time as part of PDF ingest flow
- add drift inspection API for linked imported PDFs
- on opening a `pdf_note`, detect missing file / drift and show warning
- bootstrap metadata silently for legacy imports that predate metadata files
- add unit tests for metadata persistence, missing-metadata detection, and drift-after-mutation

## Files
- `Sources/Ticker/Services/LibraryService.swift`
- `Sources/Ticker/App/AppDelegate.swift`
- `Tests/TickerTests/DeviceKeyServiceTests.swift`

## Testing Matrix
- `./tickerctl.sh swift-test`
- `xcodebuild test -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath ./.build/xcode CODE_SIGNING_ALLOWED=NO -only-testing:TickerTests/LibraryServicePDFImportTests -quiet`
- `./tickerctl.sh web-typecheck`

Closes #15
