### PR TITLE
M4-C: add native PDF highlight links

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import WebKit
 import ApplicationServices
+import PDFKit
 import Sparkle
 import UniformTypeIdentifiers
 
@@ -38,6 +39,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
     private var tickerNextPendingAIInsertion: (range: NSRange, source: String)?
     private var tickerNextSuppressTextDidChange = false
     private var tickerNextAIRequestInFlight = false
+    private var tickerNextPDFWindow: NSWindow?
+    private var tickerNextPDFView: PDFView?
+    private var tickerNextCurrentPDFID: UUID?
 
     // Menu bar (status item)
     private var statusItem: NSStatusItem?
@@ -193,6 +197,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
             importPDFItem.target = self
             appMenu.addItem(importPDFItem)
 
+            let showLinkedPDFItem = NSMenuItem(
+                title: "Show Linked PDF",
+                action: #selector(showTickerNextLinkedPDF),
+                keyEquivalent: ""
+            )
+            showLinkedPDFItem.target = self
+            appMenu.addItem(showLinkedPDFItem)
+
+            let linkPDFSelectionItem = NSMenuItem(
+                title: "Link PDF Selection to Note",
+                action: #selector(linkTickerNextPDFSelectionToNote),
+                keyEquivalent: ""
+            )
+            linkPDFSelectionItem.target = self
+            appMenu.addItem(linkPDFSelectionItem)
+
+            let openHighlightLinkItem = NSMenuItem(
+                title: "Open Highlight Link at Cursor",
+                action: #selector(openTickerNextHighlightLinkAtCursor),
+                keyEquivalent: ""
+            )
+            openHighlightLinkItem.target = self
+            appMenu.addItem(openHighlightLinkItem)
+
             let saveNoteItem = NSMenuItem(
                 title: "Save Note",
                 action: #selector(saveTickerNextNote),
@@ -275,6 +303,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
 
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
+        if window == tickerNextPDFWindow {
+            tickerNextPDFWindow = nil
+            tickerNextPDFView = nil
+            tickerNextCurrentPDFID = nil
+            return
+        }
         guard window == onboardingWindow else { return }
 
         // If the user closes onboarding without completing, proceed anyway and don't show again.
@@ -442,6 +476,115 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
         } catch {
             DebugLog.log("[TickerNext] Failed to import PDF (\(DebugLog.errorSummary(error)))")
         }
+    }
+
+    @objc private func showTickerNextLinkedPDF() {
+        guard let note = tickerNextCurrentNote else { return }
+        openTickerNextPDF(for: note)
+    }
+
+    @objc private func linkTickerNextPDFSelectionToNote() {
+        guard let note = tickerNextCurrentNote,
+              note.frontMatter.tickerKind == .pdfNote,
+              let pdfID = note.frontMatter.tickerPDFID else {
+            NSSound.beep()
+            return
+        }
+        guard tickerNextCurrentPDFID == pdfID else {
+            openTickerNextPDF(for: note)
+            NSSound.beep()
+            return
+        }
+        guard let pdfView = tickerNextPDFView,
+              let selection = pdfView.currentSelection,
+              let document = pdfView.document else {
+            NSSound.beep()
+            return
+        }
+
+        let pages = selection.pages
+        guard pages.count == 1, let page = pages.first else {
+            presentTickerNextPDFDriftWarning(
+                title: "Selection Not Supported",
+                message: "Select text within a single PDF page to create a note link."
+            )
+            return
+        }
+
+        let selectedText = (selection.string ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !selectedText.isEmpty else {
+            NSSound.beep()
+            return
+        }
+
+        let pageIndex = document.index(for: page)
+        let selectionRect = selection.bounds(for: page)
+        let rects = [TickerPDFHighlightRect(selectionRect)]
+        let highlightID = UUID()
+        let highlight = TickerPDFHighlightAnchor(
+            id: highlightID,
+            pageIndex: pageIndex,
+            selectedText: selectedText,
+            rects: rects,
+            createdAt: Date()
+        )
+
+        do {
+            _ = try ensureLibraryFolderSelected()
+            _ = try libraryService.withLibraryRootAccess { rootURL in
+                try libraryService.appendPDFHighlight(
+                    pdfID: pdfID,
+                    highlight: highlight,
+                    in: rootURL
+                )
+            }
+        } catch {
+            DebugLog.log("[TickerNext] Failed to persist PDF highlight (\(DebugLog.errorSummary(error)))")
+            return
+        }
+
+        guard let textView = tickerNextEditorTextView else { return }
+        let linkURL = TickerPDFLinkCodec.makeURLString(pdfID: pdfID, highlightID: highlightID)
+        let normalizedText = selectedText.replacingOccurrences(of: "\n", with: " ")
+        let label = String(normalizedText.prefix(72)).replacingOccurrences(of: "]", with: "")
+        let markdownLink = "[\(label)](\(linkURL))"
+        let insertion = "\(markdownLink)\n"
+
+        let selectedRange = textView.selectedRange()
+        guard textView.shouldChangeText(in: selectedRange, replacementString: insertion) else {
+            return
+        }
+        textView.textStorage?.replaceCharacters(in: selectedRange, with: insertion)
+        textView.setSelectedRange(NSRange(location: selectedRange.location + (insertion as NSString).length, length: 0))
+        textView.didChangeText()
+
+        persistTickerNextCurrentNoteAndMetadata()
+    }
+
+    @objc private func openTickerNextHighlightLinkAtCursor() {
+        guard let textView = tickerNextEditorTextView else {
+            NSSound.beep()
+            return
+        }
+
+        let body = textView.string
+        let selectionRange = textView.selectedRange()
+
+        var parsedLink: (pdfID: UUID, highlightID: UUID)?
+        if let match = TickerPDFLinkCodec.match(in: body, containingUTF16Offset: selectionRange.location) {
+            parsedLink = (match.pdfID, match.highlightID)
+        } else if selectionRange.length > 0 {
+            let selectedText = (body as NSString).substring(with: selectionRange)
+            parsedLink = TickerPDFLinkCodec.parse(urlString: selectedText.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        guard let parsedLink else {
+            NSSound.beep()
+            return
+        }
+
+        openTickerNextPDFHighlight(pdfID: parsedLink.pdfID, highlightID: parsedLink.highlightID)
     }
 
     @objc private func saveTickerNextNote() {
@@ -679,6 +822,134 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
         applyTickerNextAuthorshipStyling()
         tickerNextEditorWindow?.title = note.url.lastPathComponent
         checkTickerNextPDFDriftIfNeeded(for: note)
+        if note.frontMatter.tickerKind == .pdfNote {
+            openTickerNextPDF(for: note)
+        }
+    }
+
+    private func ensureTickerNextPDFView() -> PDFView {
+        if let existingPDFView = tickerNextPDFView, let existingWindow = tickerNextPDFWindow {
+            existingWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return existingPDFView
+        }
+
+        let pdfView = PDFView(frame: .zero)
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displaysPageBreaks = true
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 860),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Ticker Next PDF"
+        window.contentView = pdfView
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        window.delegate = self
+
+        tickerNextPDFWindow = window
+        tickerNextPDFView = pdfView
+        NSApp.activate(ignoringOtherApps: true)
+
+        return pdfView
+    }
+
+    private func openTickerNextPDF(for note: TickerMarkdownNote) {
+        guard note.frontMatter.tickerKind == .pdfNote,
+              let pdfID = note.frontMatter.tickerPDFID else {
+            return
+        }
+
+        do {
+            _ = try ensureLibraryFolderSelected()
+            let payload = try libraryService.withLibraryRootAccess { rootURL -> (URL, PDFDocument)? in
+                let pdfURL = libraryService.importedPDFURL(for: pdfID, in: rootURL)
+                guard FileManager.default.fileExists(atPath: pdfURL.path) else {
+                    return nil
+                }
+                let pdfData = try Data(contentsOf: pdfURL, options: [.mappedIfSafe])
+                guard let document = PDFDocument(data: pdfData) else {
+                    return nil
+                }
+                return (pdfURL, document)
+            } ?? nil
+
+            guard let payload else {
+                return
+            }
+
+            let pdfView = ensureTickerNextPDFView()
+            pdfView.document = payload.1
+            tickerNextCurrentPDFID = pdfID
+            tickerNextPDFWindow?.title = payload.0.lastPathComponent
+        } catch {
+            DebugLog.log("[TickerNext] Failed to open linked PDF (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    private func openTickerNextPDFHighlight(pdfID: UUID, highlightID: UUID) {
+        do {
+            _ = try ensureLibraryFolderSelected()
+
+            let payload = try libraryService.withLibraryRootAccess { rootURL -> (URL, PDFDocument, TickerPDFHighlightAnchor)? in
+                let pdfURL = libraryService.importedPDFURL(for: pdfID, in: rootURL)
+                guard FileManager.default.fileExists(atPath: pdfURL.path) else {
+                    return nil
+                }
+                guard let highlight = try libraryService.loadPDFHighlight(
+                    pdfID: pdfID,
+                    highlightID: highlightID,
+                    in: rootURL
+                ) else {
+                    return nil
+                }
+                let pdfData = try Data(contentsOf: pdfURL, options: [.mappedIfSafe])
+                guard let document = PDFDocument(data: pdfData) else {
+                    return nil
+                }
+                return (pdfURL, document, highlight)
+            } ?? nil
+
+            guard let payload else {
+                NSSound.beep()
+                return
+            }
+
+            let pdfView = ensureTickerNextPDFView()
+            pdfView.document = payload.1
+            tickerNextCurrentPDFID = pdfID
+            tickerNextPDFWindow?.title = payload.0.lastPathComponent
+            jumpTickerNextPDFView(pdfView, to: payload.2)
+        } catch {
+            DebugLog.log("[TickerNext] Failed to open PDF highlight (\(DebugLog.errorSummary(error)))")
+            NSSound.beep()
+        }
+    }
+
+    private func jumpTickerNextPDFView(_ pdfView: PDFView, to highlight: TickerPDFHighlightAnchor) {
+        guard let document = pdfView.document,
+              let page = document.page(at: highlight.pageIndex) else {
+            return
+        }
+
+        let destinationPoint: CGPoint
+        if let firstRect = highlight.rects.first?.cgRect {
+            destinationPoint = CGPoint(x: firstRect.midX, y: firstRect.maxY)
+        } else {
+            destinationPoint = CGPoint(x: 0, y: page.bounds(for: .mediaBox).maxY)
+        }
+
+        let destination = PDFDestination(page: page, at: destinationPoint)
+        pdfView.go(to: destination)
+
+        if let firstRect = highlight.rects.first?.cgRect,
+           let selection = page.selection(for: firstRect) {
+            pdfView.setCurrentSelection(selection, animate: true)
+        }
     }
 
     func textDidChange(_ notification: Notification) {

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -49,13 +49,47 @@ struct TickerPDFMetadata: Codable, Equatable {
     var schemaVersion: Int
     var pdfID: UUID
     var fingerprint: TickerPDFFingerprint
+    var highlights: [TickerPDFHighlightAnchor]
     var updatedAt: Date
 
     private enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
         case pdfID = "pdf_id"
         case fingerprint
+        case highlights
         case updatedAt = "updated_at"
+    }
+
+    init(
+        schemaVersion: Int,
+        pdfID: UUID,
+        fingerprint: TickerPDFFingerprint,
+        highlights: [TickerPDFHighlightAnchor],
+        updatedAt: Date
+    ) {
+        self.schemaVersion = schemaVersion
+        self.pdfID = pdfID
+        self.fingerprint = fingerprint
+        self.highlights = highlights
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        pdfID = try container.decode(UUID.self, forKey: .pdfID)
+        fingerprint = try container.decode(TickerPDFFingerprint.self, forKey: .fingerprint)
+        highlights = try container.decodeIfPresent([TickerPDFHighlightAnchor].self, forKey: .highlights) ?? []
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(pdfID, forKey: .pdfID)
+        try container.encode(fingerprint, forKey: .fingerprint)
+        try container.encode(highlights, forKey: .highlights)
+        try container.encode(updatedAt, forKey: .updatedAt)
     }
 }
 
@@ -64,6 +98,102 @@ enum TickerPDFDriftStatus: Equatable {
     case missingFile
     case missingMetadata(current: TickerPDFFingerprint)
     case drifted(expected: TickerPDFFingerprint, current: TickerPDFFingerprint)
+}
+
+struct TickerPDFHighlightRect: Codable, Equatable {
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+
+    init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    init(_ rect: CGRect) {
+        self.x = rect.origin.x
+        self.y = rect.origin.y
+        self.width = rect.size.width
+        self.height = rect.size.height
+    }
+
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+
+struct TickerPDFHighlightAnchor: Codable, Equatable {
+    var id: UUID
+    var pageIndex: Int
+    var selectedText: String
+    var rects: [TickerPDFHighlightRect]
+    var createdAt: Date
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case pageIndex = "page_index"
+        case selectedText = "selected_text"
+        case rects
+        case createdAt = "created_at"
+    }
+}
+
+struct TickerPDFLinkMatch: Equatable {
+    var urlString: String
+    var range: NSRange
+    var pdfID: UUID
+    var highlightID: UUID
+}
+
+enum TickerPDFLinkCodec {
+    private static let linkPattern = #"ticker-pdf://([0-9a-fA-F-]{36})#hl=([0-9a-fA-F-]{36})"#
+    private static let linkRegex = try! NSRegularExpression(pattern: linkPattern, options: [])
+
+    static func makeURLString(pdfID: UUID, highlightID: UUID) -> String {
+        "ticker-pdf://\(pdfID.uuidString.lowercased())#hl=\(highlightID.uuidString.lowercased())"
+    }
+
+    static func parse(urlString: String) -> (pdfID: UUID, highlightID: UUID)? {
+        let nsString = urlString as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        guard let match = linkRegex.firstMatch(in: urlString, options: [], range: fullRange),
+              match.range.location == 0,
+              match.range.length == fullRange.length else {
+            return nil
+        }
+
+        let pdfIDString = nsString.substring(with: match.range(at: 1))
+        let highlightIDString = nsString.substring(with: match.range(at: 2))
+        guard let pdfID = UUID(uuidString: pdfIDString),
+              let highlightID = UUID(uuidString: highlightIDString) else {
+            return nil
+        }
+        return (pdfID, highlightID)
+    }
+
+    static func match(in text: String, containingUTF16Offset offset: Int) -> TickerPDFLinkMatch? {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let matches = linkRegex.matches(in: text, options: [], range: fullRange)
+
+        for match in matches {
+            let range = match.range(at: 0)
+            guard NSLocationInRange(offset, range) else { continue }
+            let urlString = nsText.substring(with: range)
+            guard let parsed = parse(urlString: urlString) else { continue }
+            return TickerPDFLinkMatch(
+                urlString: urlString,
+                range: range,
+                pdfID: parsed.pdfID,
+                highlightID: parsed.highlightID
+            )
+        }
+
+        return nil
+    }
 }
 
 struct DuplicateTickerIDGroup: Equatable {
@@ -454,13 +584,68 @@ final class LibraryService {
         fingerprint: TickerPDFFingerprint,
         in rootURL: URL
     ) throws {
+        let existingHighlights = try loadPDFMetadata(pdfID: pdfID, in: rootURL)?.highlights ?? []
         let metadata = TickerPDFMetadata(
             schemaVersion: 1,
             pdfID: pdfID,
             fingerprint: fingerprint,
+            highlights: existingHighlights,
             updatedAt: Date()
         )
-        let metadataURL = pdfMetadataURL(for: pdfID, in: rootURL)
+        try writePDFMetadata(metadata, in: rootURL)
+    }
+
+    func appendPDFHighlight(
+        pdfID: UUID,
+        highlight: TickerPDFHighlightAnchor,
+        in rootURL: URL
+    ) throws {
+        var metadata: TickerPDFMetadata
+        if let existing = try loadPDFMetadata(pdfID: pdfID, in: rootURL) {
+            metadata = existing
+        } else {
+            let pdfURL = importedPDFURL(for: pdfID, in: rootURL)
+            let fingerprint = try computePDFFingerprint(at: pdfURL)
+            metadata = TickerPDFMetadata(
+                schemaVersion: 1,
+                pdfID: pdfID,
+                fingerprint: fingerprint,
+                highlights: [],
+                updatedAt: Date()
+            )
+        }
+
+        metadata.highlights.removeAll { $0.id == highlight.id }
+        metadata.highlights.append(highlight)
+        metadata.highlights.sort { $0.createdAt < $1.createdAt }
+        metadata.updatedAt = Date()
+
+        try writePDFMetadata(metadata, in: rootURL)
+    }
+
+    func loadPDFHighlight(
+        pdfID: UUID,
+        highlightID: UUID,
+        in rootURL: URL
+    ) throws -> TickerPDFHighlightAnchor? {
+        guard let metadata = try loadPDFMetadata(pdfID: pdfID, in: rootURL) else {
+            return nil
+        }
+        return metadata.highlights.first { $0.id == highlightID }
+    }
+
+    func loadPDFHighlights(
+        pdfID: UUID,
+        in rootURL: URL
+    ) throws -> [TickerPDFHighlightAnchor] {
+        guard let metadata = try loadPDFMetadata(pdfID: pdfID, in: rootURL) else {
+            return []
+        }
+        return metadata.highlights
+    }
+
+    private func writePDFMetadata(_ metadata: TickerPDFMetadata, in rootURL: URL) throws {
+        let metadataURL = pdfMetadataURL(for: metadata.pdfID, in: rootURL)
         try fileManager.createDirectory(at: metadataURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         let encoder = JSONEncoder()

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -559,4 +559,66 @@ final class LibraryServicePDFImportTests: XCTestCase {
             XCTFail("Expected .drifted, got \(driftStatus)")
         }
     }
+
+    func test_appendPDFHighlight_persistsAndCanReloadByID() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let libraryRoot = tempDir.appendingPathComponent("Library", isDirectory: true)
+        let sourceRoot = tempDir.appendingPathComponent("Source", isDirectory: true)
+        try fileManager.createDirectory(at: libraryRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+
+        let sourcePDFURL = sourceRoot.appendingPathComponent("annotate.pdf")
+        let basePDF = Data("%PDF-1.4\n1 0 obj\n<< /Type /Page >>\nendobj\ntrailer\n<<>>\n%%EOF\n".utf8)
+        try basePDF.write(to: sourcePDFURL, options: [.atomic])
+
+        let suiteName = "LibraryServicePDFHighlightTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let service = LibraryService(defaults: defaults, fileManager: fileManager)
+        let imported = try service.importPDF(at: sourcePDFURL, in: libraryRoot)
+
+        let highlightID = UUID()
+        let highlight = TickerPDFHighlightAnchor(
+            id: highlightID,
+            pageIndex: 0,
+            selectedText: "Example quote",
+            rects: [TickerPDFHighlightRect(x: 12, y: 24, width: 120, height: 18)],
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        try service.appendPDFHighlight(pdfID: imported.pdfID, highlight: highlight, in: libraryRoot)
+
+        let loaded = try service.loadPDFHighlight(pdfID: imported.pdfID, highlightID: highlightID, in: libraryRoot)
+        XCTAssertEqual(loaded, highlight)
+
+        let allHighlights = try service.loadPDFHighlights(pdfID: imported.pdfID, in: libraryRoot)
+        XCTAssertEqual(allHighlights.count, 1)
+        XCTAssertEqual(allHighlights.first, highlight)
+    }
+
+    func test_pdfLinkCodec_roundtripAndOffsetMatching() {
+        let pdfID = UUID()
+        let highlightID = UUID()
+        let url = TickerPDFLinkCodec.makeURLString(pdfID: pdfID, highlightID: highlightID)
+
+        let parsed = TickerPDFLinkCodec.parse(urlString: url)
+        XCTAssertEqual(parsed?.pdfID, pdfID)
+        XCTAssertEqual(parsed?.highlightID, highlightID)
+
+        let text = "Before \(url) after"
+        let nsText = text as NSString
+        let linkRange = nsText.range(of: url)
+        XCTAssertNotEqual(linkRange.location, NSNotFound)
+
+        let offsetInsideLink = linkRange.location + 4
+        let match = TickerPDFLinkCodec.match(in: text, containingUTF16Offset: offsetInsideLink)
+        XCTAssertEqual(match?.urlString, url)
+        XCTAssertEqual(match?.pdfID, pdfID)
+        XCTAssertEqual(match?.highlightID, highlightID)
+    }
 }


### PR DESCRIPTION
## Summary
- add persisted PDF highlight anchors to library metadata
- add ticker-pdf link codec for markdown links in notes
- add native PDF window actions to create and open highlight links
- auto-open linked PDFs for pdf notes in Ticker Next editor
- add tests for highlight persistence and link parsing/matching

## Validation
- ./tickerctl.sh swift-test
- xcodebuild test -project Ticker.xcodeproj -scheme Ticker -destination 'platform=macOS' -derivedDataPath ./.build/xcode CODE_SIGNING_ALLOWED=NO -only-testing:TickerTests/LibraryServicePDFImportTests -quiet
- ./tickerctl.sh web-typecheck

Closes #17