### PR TITLE
M4-D: harden PDF highlight link open UX

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -216,9 +216,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
             let openHighlightLinkItem = NSMenuItem(
                 title: "Open Highlight Link at Cursor",
                 action: #selector(openTickerNextHighlightLinkAtCursor),
-                keyEquivalent: ""
+                keyEquivalent: "j"
             )
             openHighlightLinkItem.target = self
+            openHighlightLinkItem.keyEquivalentModifierMask = [.command, .shift]
             appMenu.addItem(openHighlightLinkItem)
 
             let saveNoteItem = NSMenuItem(
@@ -570,21 +571,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
 
         let body = textView.string
         let selectionRange = textView.selectedRange()
-
-        var parsedLink: (pdfID: UUID, highlightID: UUID)?
-        if let match = TickerPDFLinkCodec.match(in: body, containingUTF16Offset: selectionRange.location) {
-            parsedLink = (match.pdfID, match.highlightID)
-        } else if selectionRange.length > 0 {
-            let selectedText = (body as NSString).substring(with: selectionRange)
-            parsedLink = TickerPDFLinkCodec.parse(urlString: selectedText.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-
-        guard let parsedLink else {
+        guard let parsedLink = resolveTickerNextHighlightLink(
+            in: body,
+            selectionRange: selectionRange,
+            preferredUTF16Offset: selectionRange.location
+        ) else {
             NSSound.beep()
             return
         }
 
         openTickerNextPDFHighlight(pdfID: parsedLink.pdfID, highlightID: parsedLink.highlightID)
+    }
+
+    private func resolveTickerNextHighlightLink(
+        in body: String,
+        selectionRange: NSRange,
+        preferredUTF16Offset: Int?
+    ) -> (pdfID: UUID, highlightID: UUID)? {
+        if let preferredUTF16Offset,
+           let match = TickerPDFLinkCodec.match(
+               in: body,
+               containingUTF16Offset: preferredUTF16Offset
+           ) {
+            return (match.pdfID, match.highlightID)
+        }
+
+        let nsBody = body as NSString
+        if selectionRange.length > 0,
+           NSMaxRange(selectionRange) <= nsBody.length {
+            let selectedText = nsBody.substring(with: selectionRange)
+            if let match = TickerPDFLinkCodec.firstMatch(in: selectedText) {
+                return (match.pdfID, match.highlightID)
+            }
+            return TickerPDFLinkCodec.parse(
+                urlString: selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+
+        return nil
     }
 
     @objc private func saveTickerNextNote() {
@@ -968,6 +992,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSTextView
     ) {
         guard textView == tickerNextEditorTextView else { return }
         runTickerNextSelectionAIAction(action)
+    }
+
+    func tickerNextEditorTextView(
+        _ textView: TickerNextEditorTextView,
+        didCommandClickAtUTF16Offset offset: Int
+    ) -> Bool {
+        guard textView == tickerNextEditorTextView else { return false }
+        guard let parsedLink = resolveTickerNextHighlightLink(
+            in: textView.string,
+            selectionRange: textView.selectedRange(),
+            preferredUTF16Offset: offset
+        ) else {
+            return false
+        }
+
+        openTickerNextPDFHighlight(pdfID: parsedLink.pdfID, highlightID: parsedLink.highlightID)
+        return true
     }
 
     private func syncTickerNextEditorStateAfterTextChange(newBody: String) {

--- a/Sources/Ticker/App/TickerNextEditorTextView.swift
+++ b/Sources/Ticker/App/TickerNextEditorTextView.swift
@@ -5,6 +5,10 @@ protocol TickerNextEditorTextViewActionHandling: AnyObject {
         _ textView: TickerNextEditorTextView,
         didRequestAction action: TickerNextSelectionAIAction
     )
+    func tickerNextEditorTextView(
+        _ textView: TickerNextEditorTextView,
+        didCommandClickAtUTF16Offset offset: Int
+    ) -> Bool
 }
 
 final class TickerNextEditorTextView: NSTextView {
@@ -12,6 +16,16 @@ final class TickerNextEditorTextView: NSTextView {
     private static let aiSeparatorTag = 31_002
 
     weak var actionHandler: TickerNextEditorTextViewActionHandling?
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command),
+           let utf16Offset = utf16OffsetForEvent(event),
+           actionHandler?.tickerNextEditorTextView(self, didCommandClickAtUTF16Offset: utf16Offset) == true {
+            return
+        }
+
+        super.mouseDown(with: event)
+    }
 
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = super.menu(for: event) ?? NSMenu(title: "Context")
@@ -69,5 +83,27 @@ final class TickerNextEditorTextView: NSTextView {
                 menu.removeItem(at: index)
             }
         }
+    }
+
+    private func utf16OffsetForEvent(_ event: NSEvent) -> Int? {
+        guard let layoutManager,
+              let textContainer else {
+            return nil
+        }
+
+        let pointInView = convert(event.locationInWindow, from: nil)
+        let pointInContainer = NSPoint(
+            x: pointInView.x - textContainerOrigin.x,
+            y: pointInView.y - textContainerOrigin.y
+        )
+        let glyphRange = layoutManager.glyphRange(for: textContainer)
+        let usedRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        guard usedRect.contains(pointInContainer) else {
+            return nil
+        }
+
+        let glyphIndex = layoutManager.glyphIndex(for: pointInContainer, in: textContainer)
+        let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        return min(max(0, charIndex), (string as NSString).length)
     }
 }

--- a/Sources/Ticker/Services/LibraryService.swift
+++ b/Sources/Ticker/Services/LibraryService.swift
@@ -174,14 +174,44 @@ enum TickerPDFLinkCodec {
         return (pdfID, highlightID)
     }
 
-    static func match(in text: String, containingUTF16Offset offset: Int) -> TickerPDFLinkMatch? {
+    static func firstMatch(in text: String) -> TickerPDFLinkMatch? {
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
+        guard let match = linkRegex.firstMatch(in: text, options: [], range: fullRange) else {
+            return nil
+        }
+
+        let range = match.range(at: 0)
+        let urlString = nsText.substring(with: range)
+        guard let parsed = parse(urlString: urlString) else {
+            return nil
+        }
+
+        return TickerPDFLinkMatch(
+            urlString: urlString,
+            range: range,
+            pdfID: parsed.pdfID,
+            highlightID: parsed.highlightID
+        )
+    }
+
+    static func match(in text: String, containingUTF16Offset offset: Int) -> TickerPDFLinkMatch? {
+        guard offset >= 0 else {
+            return nil
+        }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let clampedOffset = min(offset, nsText.length)
         let matches = linkRegex.matches(in: text, options: [], range: fullRange)
 
         for match in matches {
             let range = match.range(at: 0)
-            guard NSLocationInRange(offset, range) else { continue }
+            let lowerBound = range.location
+            let upperBound = NSMaxRange(range)
+            guard clampedOffset >= lowerBound && clampedOffset <= upperBound else {
+                continue
+            }
             let urlString = nsText.substring(with: range)
             guard let parsed = parse(urlString: urlString) else { continue }
             return TickerPDFLinkMatch(

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -620,5 +620,18 @@ final class LibraryServicePDFImportTests: XCTestCase {
         XCTAssertEqual(match?.urlString, url)
         XCTAssertEqual(match?.pdfID, pdfID)
         XCTAssertEqual(match?.highlightID, highlightID)
+
+        let matchAtStart = TickerPDFLinkCodec.match(in: text, containingUTF16Offset: linkRange.location)
+        XCTAssertEqual(matchAtStart?.urlString, url)
+
+        let matchAtEnd = TickerPDFLinkCodec.match(in: text, containingUTF16Offset: NSMaxRange(linkRange))
+        XCTAssertEqual(matchAtEnd?.urlString, url)
+
+        let markdownSnippet = "[Example](\(url))"
+        let firstMatch = TickerPDFLinkCodec.firstMatch(in: markdownSnippet)
+        XCTAssertEqual(firstMatch?.urlString, url)
+
+        let outsideMatch = TickerPDFLinkCodec.match(in: text, containingUTF16Offset: NSMaxRange(linkRange) + 1)
+        XCTAssertNil(outsideMatch)
     }
 }


### PR DESCRIPTION
## Summary
- add Cmd+Shift+J shortcut for opening a  link at cursor
- add command-click handling in the native editor to open highlight links directly
- harden link parsing around UTF-16 boundary offsets
- support extracting a highlight URL from selected markdown snippets
- extend link codec tests for boundary and snippet matching

## Validation
- ./tickerctl.sh swift-test
- ./tickerctl.sh web-typecheck

Closes #19