### PR TITLE
Phase 1: fix quick-capture persistence (document-model append pipeline)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: verify
+description: Build, launch, and drive Ticker-Next end-to-end on this Mac (GUI app + Vite dev lane) to verify changes at the user surface.
+---
+
+# Verifying Ticker-Next changes
+
+## Build & launch
+- Build gate: `./tickerctl.sh build-dev` (xcodebuild). Plain `swift build` is broken (mlx-swift-lm/sandbox) — don't fight it.
+- Stale Sparkle artifact error → `./tickerctl.sh clean-derived-data -y` then rebuild.
+- Run: `./tickerctl.sh run-dev` in background (starts Vite on :5173 + launches `~/Applications/Ticker Next.app`). Wait ~20s; check `curl localhost:5173` and `pgrep -fl "Ticker Next"`.
+- **Check for stale instances first**: `pgrep -fl "Ticker Next"` — kill old PIDs (`kill -TERM`) or two processes share one SQLite DB and the old code confounds results.
+- A Sparkle "Check for updates?" dialog may block on launch. Dismiss: `osascript -e 'tell application "System Events" to tell process "TickerNext" to click button "Don’t Check" of window 2'` (note curly apostrophe; process name is `TickerNext`, app name is `Ticker Next`).
+
+## Data safety
+- DB: `~/Library/Application Support/Ticker-Next/ticker.db` (real user data, lane-independent!). ALWAYS `cp` it to scratchpad before driving, restore/clean afterwards (quit app first so the editor doesn't re-save over your cleanup).
+- Inspect: `sqlite3 ... "SELECT markdown FROM stream_documents WHERE ..."`.
+
+## Driving the GUI
+- Quick Panel: global hotkey ⌘L → `osascript`: activate "Ticker Next", `keystroke "l" using command down`, then `keystroke "<text>"`, `key code 36` (↵). ⌘↵ = `key code 36 using command down`; ⌥↵ = `using option down`.
+- Web content (stream list, editor) has no usable AX tree — click by coordinates with CGEvent:
+  `swift -e 'import CoreGraphics; let pt=CGPoint(x:X,y:Y); for t in [CGEventType.leftMouseDown, .leftMouseUp] { CGEvent(mouseEventSource:nil,mouseType:t,mouseCursorPosition:pt,mouseButton:.left)!.post(tap:.cghidEventTap); usleep(60000) }'`
+  Coordinates are screen POINTS = screenshot-pixels ÷ 2 (Retina). Take `screencapture -x <path>` first, Read it, compute.
+- Observe: `screencapture -x` (silent, full screen) + Read the PNG.
+
+## Flows worth driving
+- Capture → closed stream: ⌘L, type, ↵; check `stream_documents.markdown` in sqlite; open stream and confirm visible.
+- Capture → open stream (live append): open stream first, ⌘L, type, ↵; text must appear in editor within ~1s without reload.
+- Race: click into editor, type, immediately ⌘L-capture; both must persist after autosave (350ms debounce).
+- Cleanup: quit app, restore the touched stream's markdown from the backup DB (ATTACH + UPDATE), kill the run-dev background task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable user-facing changes to Ticker are documented here.
 - TBD
 
 ### Fixed
-- TBD
+- Recovered quick-capture notes that previously didn't appear in streams.
 
 ### Removed
 - TBD
@@ -19,4 +19,3 @@ All notable user-facing changes to Ticker are documented here.
 ## Versioning
 
 Ticker uses `YYYY.MM.patch` (alpha), e.g. `2026.01.3`.
-

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -259,12 +259,13 @@ final class QuickPanelManager: ObservableObject {
 
     /// Handle Enter key - add content to stream
     func handleEnter() async {
-        await addToStream(triggerAI: false)
+        await addToStream()
     }
 
     /// Handle Cmd+Enter - add content and trigger AI
     func handleCmdEnter() async {
-        await addToStream(triggerAI: true)
+        // TODO(task-1.4): Restore Quick Panel AI handling on the document model.
+        await addToStream()
     }
 
     /// Handle Option+Enter - ephemeral AI conversation (not saved)
@@ -402,16 +403,16 @@ final class QuickPanelManager: ObservableObject {
         )
     }
 
-    // MARK: - Cell Creation
+    // MARK: - Markdown Capture
 
     /// Add captured content and/or input to the active stream
-    private func addToStream(triggerAI: Bool) async {
+    private func addToStream() async {
         guard let persistence = persistence else {
             error = "Persistence not configured"
             return
         }
 
-        let hasContext = context?.hasContent == true
+        let hasContext = nonEmptyTrimmed(context?.selectedText) != nil || context?.clipboardImage != nil
         let hasInput = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
         // Must have something to add
@@ -427,47 +428,9 @@ final class QuickPanelManager: ObservableObject {
             // Get target stream (may create new one)
             let (streamId, isNewStream) = try getTargetStreamId()
 
-            var pendingCells: [Cell] = []
-            var contextCellId: UUID?
-            var triggerAICellId: UUID?
-
-            // 1. If we have context (selection or image), create a quote cell
-            if let ctx = context, ctx.hasContent {
-                let contextCell = createContextCell(from: ctx, streamId: streamId)
-                pendingCells.append(contextCell)
-                contextCellId = contextCell.id
-            }
-
-            // 2. If we have input text
-            if hasInput {
-                let trimmedInput = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if triggerAI {
-                    // Create AI response cell that references context
-                    let aiCell = Cell(
-                        streamId: streamId,
-                        content: "",  // Will be filled by AI
-                        originalPrompt: trimmedInput,
-                        type: .aiResponse,
-                        order: 0,  // Final order assigned atomically at persistence time.
-                        references: contextCellId.map { [$0] }
-                    )
-                    pendingCells.append(aiCell)
-                    triggerAICellId = aiCell.id
-                } else {
-                    // Create plain text cell
-                    let textCell = Cell(
-                        streamId: streamId,
-                        content: "<p>\(escapeHtml(trimmedInput))</p>",
-                        type: .text,
-                        order: 0  // Final order assigned atomically at persistence time.
-                    )
-                    pendingCells.append(textCell)
-                }
-            }
-
-            let persistedCells = try persistence.insertQuickPanelCells(streamId: streamId, cells: pendingCells)
-            notifyFrontend(streamId: streamId, cells: persistedCells, triggerAI: triggerAICellId, isNewStream: isNewStream)
+            let fragment = try buildMarkdownFragment(streamId: streamId)
+            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
+            notifyFrontend(streamId: streamId, fragment: result.fragment, isNewStream: isNewStream)
 
             // Success - hide panel
             hide()
@@ -538,115 +501,70 @@ final class QuickPanelManager: ObservableObject {
         return (newStream.id, true)
     }
 
-    /// Create a quote cell from captured context
-    private func createContextCell(from ctx: QuickPanelContext, streamId: UUID) -> Cell {
-        var content = ""
+    private func buildMarkdownFragment(streamId: UUID) throws -> String {
+        var blocks: [String] = []
 
-        // Build source attribution: "App — Window Title" or just "App"
-        let sourceAttribution = buildSourceAttribution(app: ctx.activeApp, windowTitle: ctx.windowTitle)
+        if let ctx = context {
+            if let selectedText = nonEmptyTrimmed(ctx.selectedText) {
+                blocks.append(markdownBlockquote(selectedText))
 
-        if let text = ctx.selectedText {
-            // Format as italicized quote with source info
-            let escapedText = escapeHtml(text)
-            content = "<p><em>\(escapedText)</em></p>"
-
-            if let source = sourceAttribution {
-                content += "<p class=\"source-info\">— \(source)</p>"
-            }
-        } else if let imageData = ctx.clipboardImage, let assetService = assetService {
-            // Save image via AssetService and embed as img tag
-            do {
-                let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
-                // Use relative path for portability - AssetSchemeHandler resolves at render time
-                // Note: ticker-asset:/// (three slashes) ensures the path isn't parsed as host
-                let assetUrl = "ticker-asset:///\(relativePath)"
-                content = "<p><img src=\"\(assetUrl)\" alt=\"Screenshot\" style=\"max-width: 100%;\"></p>"
-
-                if let source = sourceAttribution {
-                    content += "<p class=\"source-info\">— Screenshot from \(source)</p>"
+                if let sourceApp = nonEmptyTrimmed(ctx.activeApp) {
+                    blocks.append("*— \(escapeMarkdownEmphasis(sourceApp))*")
                 }
-            } catch {
-                DebugLog.log("[QuickPanel] Failed to save screenshot (\(DebugLog.errorSummary(error)))")
-                content = "<p>[Screenshot failed to save]</p>"
+            }
+
+            if let imageData = ctx.clipboardImage {
+                guard let assetService = assetService else {
+                    throw QuickPanelError.assetServiceNotConfigured
+                }
+
+                let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
+                blocks.append("![capture](ticker-asset:///\(relativePath))")
             }
         }
 
-        return Cell(
-            streamId: streamId,
-            content: content,
-            type: .quote,
-            order: 0,  // Final order assigned atomically at persistence time.
-            sourceApp: ctx.activeApp
-        )
+        if let input = nonEmptyTrimmed(inputText) {
+            blocks.append(input)
+        }
+
+        return blocks.joined(separator: "\n\n")
     }
 
-    /// Build source attribution string from app name and window title
-    private func buildSourceAttribution(app: String?, windowTitle: String?) -> String? {
-        let escapedApp = app.map { escapeHtml($0) }
-        let escapedTitle = windowTitle.map { escapeHtml($0) }
+    private func markdownBlockquote(_ text: String) -> String {
+        text.components(separatedBy: CharacterSet.newlines)
+            .map { line in
+                line.isEmpty ? ">" : "> \(line)"
+            }
+            .joined(separator: "\n")
+    }
 
-        switch (escapedApp, escapedTitle) {
-        case let (app?, title?) where !title.isEmpty:
-            // Truncate long titles
-            let truncatedTitle = title.count > 60 ? String(title.prefix(57)) + "..." : title
-            return "\(app) — \(truncatedTitle)"
-        case let (app?, _):
-            return app
-        case let (nil, title?) where !title.isEmpty:
-            return title
-        default:
+    private func nonEmptyTrimmed(_ text: String?) -> String? {
+        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
             return nil
         }
+        return trimmed
     }
 
-    /// Notify the React frontend about new cells
-    /// When isNewStream is true, includes stream metadata so frontend can add it without creating a blank cell
-    private func notifyFrontend(streamId: UUID, cells: [Cell], triggerAI: UUID?, isNewStream: Bool = false) {
+    private func escapeMarkdownEmphasis(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "*", with: "\\*")
+            .replacingOccurrences(of: "_", with: "\\_")
+    }
+
+    /// Notify the React frontend about document appends.
+    private func notifyFrontend(streamId: UUID, fragment: String, isNewStream: Bool = false) {
         guard let bridgeService = bridgeService else { return }
 
-        var payload: [String: AnyCodable] = [
+        let payload: [String: AnyCodable] = [
             "streamId": AnyCodable(streamId.uuidString),
-            "cells": AnyCodable(cells.map { cellToDict($0) }),
-            "isNewStream": AnyCodable(isNewStream)
+            "fragment": AnyCodable(fragment),
+            "isNewStream": AnyCodable(isNewStream),
+            "source": AnyCodable("quickPanel")
         ]
 
-        if let aiCellId = triggerAI {
-            payload["triggerAI"] = AnyCodable(aiCellId.uuidString)
-        }
-
-        bridgeService.send(BridgeMessage(type: "quickPanelCellsAdded", payload: payload))
-    }
-
-    /// Convert Cell to dictionary for bridge
-    private func cellToDict(_ cell: Cell) -> [String: Any] {
-        var dict: [String: Any] = [
-            "id": cell.id.uuidString,
-            "streamId": cell.streamId.uuidString,
-            "content": cell.content,
-            "type": cell.type.rawValue,
-            "order": cell.order,
-            "createdAt": ISO8601DateFormatter().string(from: cell.createdAt),
-            "updatedAt": ISO8601DateFormatter().string(from: cell.updatedAt)
-        ]
-        if let sourceApp = cell.sourceApp {
-            dict["sourceApp"] = sourceApp
-        }
-        if let originalPrompt = cell.originalPrompt {
-            dict["originalPrompt"] = originalPrompt
-        }
-        if let references = cell.references {
-            dict["references"] = references.map { $0.uuidString }
-        }
-        return dict
-    }
-
-    /// Simple HTML escaping
-    private func escapeHtml(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
+        bridgeService.send(BridgeMessage(type: "streamDocumentAppended", payload: payload))
     }
 
     // MARK: - Panel Creation
@@ -727,12 +645,15 @@ final class QuickPanelManager: ObservableObject {
 
 enum QuickPanelError: Error, LocalizedError {
     case persistenceNotConfigured
+    case assetServiceNotConfigured
     case noActiveStream
 
     var errorDescription: String? {
         switch self {
         case .persistenceNotConfigured:
             return "Database not configured"
+        case .assetServiceNotConfigured:
+            return "Asset storage not configured"
         case .noActiveStream:
             return "No active stream"
         }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -63,6 +63,7 @@ final class QuickPanelManager: ObservableObject {
     // MARK: - Streaming Task
 
     private var streamingTask: Task<Void, Never>?
+    private var documentAITasks: [UUID: Task<Void, Never>] = [:]
     private var isStreamingCancelled = false  // Explicit flag since nested Tasks don't inherit cancellation
 
     // MARK: - Height Management
@@ -89,6 +90,11 @@ final class QuickPanelManager: ObservableObject {
         self.selectionService = SelectionReaderService(cursorService: cursor)
         self.persistence = persistence
         self.bridgeService = bridgeService
+    }
+
+    deinit {
+        streamingTask?.cancel()
+        documentAITasks.values.forEach { $0.cancel() }
     }
 
     /// Configure services after initialization (for dependency injection)
@@ -264,8 +270,7 @@ final class QuickPanelManager: ObservableObject {
 
     /// Handle Cmd+Enter - add content and trigger AI
     func handleCmdEnter() async {
-        // TODO(task-1.4): Restore Quick Panel AI handling on the document model.
-        await addToStream()
+        await addToStream(triggerDocumentAI: true)
     }
 
     /// Handle Option+Enter - ephemeral AI conversation (not saved)
@@ -406,14 +411,15 @@ final class QuickPanelManager: ObservableObject {
     // MARK: - Markdown Capture
 
     /// Add captured content and/or input to the active stream
-    private func addToStream() async {
+    private func addToStream(triggerDocumentAI: Bool = false) async {
         guard let persistence = persistence else {
             error = "Persistence not configured"
             return
         }
 
         let hasContext = nonEmptyTrimmed(context?.selectedText) != nil || context?.clipboardImage != nil
-        let hasInput = !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let prompt = nonEmptyTrimmed(inputText)
+        let hasInput = prompt != nil
 
         // Must have something to add
         guard hasContext || hasInput else {
@@ -432,8 +438,44 @@ final class QuickPanelManager: ObservableObject {
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
             notifyFrontend(streamId: streamId, fragment: result.fragment, isNewStream: isNewStream)
 
+            let aiPrompt = triggerDocumentAI ? prompt : nil
+            let orchestratorForAI = orchestrator
+            var documentMarkdownForAI: String?
+            var aiStartupError: String?
+
+            if aiPrompt != nil {
+                if orchestratorForAI == nil {
+                    aiStartupError = "AI is not configured"
+                } else {
+                    do {
+                        documentMarkdownForAI = try persistence.loadOrCreateStreamDocument(streamId: streamId).markdown
+                    } catch {
+                        aiStartupError = "Could not load document context"
+                        DebugLog.log("[QuickPanel] Failed to load document context for AI (\(DebugLog.errorSummary(error)))")
+                    }
+                }
+            }
+
             // Success - hide panel
             hide()
+
+            if let aiPrompt {
+                if let orchestratorForAI, let documentMarkdownForAI {
+                    startDocumentAI(
+                        streamId: streamId,
+                        prompt: aiPrompt,
+                        documentMarkdown: documentMarkdownForAI,
+                        persistence: persistence,
+                        orchestrator: orchestratorForAI
+                    )
+                } else {
+                    appendQuickPanelAIError(
+                        streamId: streamId,
+                        summary: aiStartupError ?? "AI request could not start",
+                        persistence: persistence
+                    )
+                }
+            }
 
         } catch {
             self.error = error.localizedDescription
@@ -553,15 +595,104 @@ final class QuickPanelManager: ObservableObject {
             .replacingOccurrences(of: "_", with: "\\_")
     }
 
+    private func startDocumentAI(
+        streamId: UUID,
+        prompt: String,
+        documentMarkdown: String,
+        persistence: PersistenceService,
+        orchestrator: AIOrchestrator
+    ) {
+        let taskId = UUID()
+        var responseMarkdown = ""
+
+        documentAITasks[taskId] = Task { [weak self] in
+            await orchestrator.route(
+                query: prompt,
+                streamId: nil,
+                priorCells: [],
+                sourceContext: documentMarkdown,
+                includeHeading: false,
+                onChunk: { chunk in
+                    responseMarkdown += chunk
+                },
+                onComplete: { [weak self] in
+                    Task { @MainActor in
+                        guard let self else { return }
+
+                        let fragment = responseMarkdown.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if fragment.isEmpty {
+                            self.appendQuickPanelAIError(
+                                streamId: streamId,
+                                summary: "AI returned an empty response",
+                                persistence: persistence
+                            )
+                        } else {
+                            self.appendQuickPanelAIFragment(
+                                streamId: streamId,
+                                fragment: fragment,
+                                persistence: persistence
+                            )
+                        }
+
+                        self.documentAITasks[taskId] = nil
+                    }
+                },
+                onError: { [weak self] error in
+                    Task { @MainActor in
+                        guard let self else { return }
+
+                        self.appendQuickPanelAIError(
+                            streamId: streamId,
+                            summary: error.localizedDescription,
+                            persistence: persistence
+                        )
+                        self.documentAITasks[taskId] = nil
+                    }
+                }
+            )
+        }
+    }
+
+    private func appendQuickPanelAIFragment(streamId: UUID, fragment: String, persistence: PersistenceService) {
+        do {
+            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
+            notifyFrontend(streamId: streamId, fragment: result.fragment, source: "quickPanelAI")
+        } catch {
+            DebugLog.log("[QuickPanel] Failed to append AI response (\(DebugLog.errorSummary(error)))")
+        }
+    }
+
+    private func appendQuickPanelAIError(streamId: UUID, summary: String, persistence: PersistenceService) {
+        appendQuickPanelAIFragment(
+            streamId: streamId,
+            fragment: quickPanelAIErrorFragment(summary: summary),
+            persistence: persistence
+        )
+    }
+
+    private func quickPanelAIErrorFragment(summary: String) -> String {
+        let compact = summary
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = compact.isEmpty ? "Unknown error" : compact
+        let shortened = fallback.count > 180 ? "\(fallback.prefix(177))..." : fallback
+        return "*AI request failed: \(escapeMarkdownEmphasis(shortened))*"
+    }
+
     /// Notify the React frontend about document appends.
-    private func notifyFrontend(streamId: UUID, fragment: String, isNewStream: Bool = false) {
+    private func notifyFrontend(
+        streamId: UUID,
+        fragment: String,
+        isNewStream: Bool = false,
+        source: String = "quickPanel"
+    ) {
         guard let bridgeService = bridgeService else { return }
 
         let payload: [String: AnyCodable] = [
             "streamId": AnyCodable(streamId.uuidString),
             "fragment": AnyCodable(fragment),
             "isNewStream": AnyCodable(isNewStream),
-            "source": AnyCodable("quickPanel")
+            "source": AnyCodable(source)
         ]
 
         bridgeService.send(BridgeMessage(type: "streamDocumentAppended", payload: payload))

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -222,6 +222,60 @@ final class PersistenceService {
             }
         }
 
+        migrator.registerMigration("v11_recover_orphaned_quickpanel_cells") { db in
+            let documentRows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT stream_id, markdown, created_at
+                    FROM stream_documents
+                """
+            )
+
+            for documentRow in documentRows {
+                let streamId: String = documentRow["stream_id"]
+                let documentMarkdown: String = documentRow["markdown"]
+                let documentCreatedAt: Double = documentRow["created_at"]
+
+                let cellRows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT content
+                        FROM cells
+                        WHERE stream_id = ?
+                          AND created_at > ?
+                        ORDER BY created_at ASC, position ASC
+                    """,
+                    arguments: [streamId, documentCreatedAt]
+                )
+
+                let recoveredFragments: [String] = cellRows.compactMap { row in
+                    let content: String = row["content"]
+                    let markdown = Self.markdownishTextFromLegacyCellHTML(content)
+                    return markdown.isEmpty ? nil : markdown
+                }
+
+                guard !recoveredFragments.isEmpty else { continue }
+
+                let recoveryBlock = (["## Recovered captures"] + recoveredFragments)
+                    .joined(separator: "\n\n")
+                let recoveredMarkdown = documentMarkdown.isEmpty
+                    ? recoveryBlock
+                    : "\(documentMarkdown)\n\n\(recoveryBlock)"
+                let now = Date().timeIntervalSince1970
+
+                try db.execute(
+                    sql: """
+                        UPDATE stream_documents
+                        SET markdown = ?, updated_at = ?
+                        WHERE stream_id = ?
+                    """,
+                    arguments: [recoveredMarkdown, now, streamId]
+                )
+            }
+
+            // ponytail: Retain legacy cells until Phase 2+ drops the cells table in a future migration.
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -953,6 +1007,32 @@ final class PersistenceService {
         }
 
         return attributed.string.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func markdownishTextFromLegacyCellHTML(_ html: String) -> String {
+        let rewrittenHTML = rewriteImageTagsToMarkdown(html)
+        return htmlToPlainText(rewrittenHTML).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func rewriteImageTagsToMarkdown(_ html: String) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"<img\b[^>]*\bsrc\s*=\s*(['"])(.*?)\1[^>]*>"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return html
+        }
+
+        let original = html as NSString
+        let result = NSMutableString(string: html)
+        let fullRange = NSRange(location: 0, length: original.length)
+
+        for match in regex.matches(in: html, range: fullRange).reversed() {
+            guard match.numberOfRanges >= 3 else { continue }
+            let src = original.substring(with: match.range(at: 2))
+            result.replaceCharacters(in: match.range, with: "![capture](\(src))")
+        }
+
+        return result as String
     }
 
     // MARK: - Chunk Operations (RAG Pipeline)

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -1,6 +1,11 @@
 import Foundation
 import GRDB
 
+struct AppendResult {
+    let fragment: String
+    let isNewDocument: Bool
+}
+
 /// Manages SQLite persistence for streams, cells, and sources
 final class PersistenceService {
     private let dbQueue: DatabaseQueue
@@ -552,6 +557,48 @@ final class PersistenceService {
                 sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
                 arguments: [now, streamId.uuidString]
             )
+        }
+    }
+
+    func appendToStreamDocument(streamId: UUID, fragment: String) throws -> AppendResult {
+        try dbQueue.write { db in
+            let now = Date().timeIntervalSince1970
+            let existingMarkdown: String
+            let isNewDocument: Bool
+
+            if let row = try Row.fetchOne(
+                db,
+                sql: "SELECT markdown FROM stream_documents WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            ) {
+                existingMarkdown = row["markdown"]
+                isNewDocument = false
+            } else {
+                existingMarkdown = try initialMarkdownFromLegacyCells(streamId: streamId, db: db)
+                isNewDocument = true
+            }
+
+            let markdown = existingMarkdown.isEmpty
+                ? fragment
+                : "\(existingMarkdown)\n\n\(fragment)"
+
+            try db.execute(
+                sql: """
+                    INSERT INTO stream_documents (stream_id, markdown, created_at, updated_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(stream_id) DO UPDATE SET
+                        markdown = excluded.markdown,
+                        updated_at = excluded.updated_at
+                """,
+                arguments: [streamId.uuidString, markdown, now, now]
+            )
+
+            try db.execute(
+                sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
+                arguments: [now, streamId.uuidString]
+            )
+
+            return AppendResult(fragment: fragment, isNewDocument: isNewDocument)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import XCTest
 
 @testable import Ticker
@@ -132,6 +133,129 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_v11MigrationRecoversPostDocumentQuickPanelCellsInOrder() throws {
+        let streamId = UUID()
+        let documentCreatedAt = 1_000.0
+
+        try withSeededV10Database { db in
+            try insertStream(db, id: streamId, title: "Recover Later Cells", createdAt: 900)
+            try insertStreamDocument(
+                db,
+                streamId: streamId,
+                markdown: "Existing document",
+                createdAt: documentCreatedAt
+            )
+            try insertCell(
+                db,
+                streamId: streamId,
+                content: "<p>First recovered note</p>",
+                createdAt: documentCreatedAt + 1,
+                position: 0
+            )
+            try insertCell(
+                db,
+                streamId: streamId,
+                content: #"<p><img src="ticker-asset:///abc/img.png" alt="Screenshot"></p>"#,
+                createdAt: documentCreatedAt + 2,
+                position: 1
+            )
+        } body: { dbURL, fileManager in
+            let service = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+
+            try assertPreMigrationBackupExists(nextTo: dbURL, fileManager: fileManager)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: streamId))
+            XCTAssertTrue(document.markdown.hasSuffix("""
+            ## Recovered captures
+
+            First recovered note
+
+            ![capture](ticker-asset:///abc/img.png)
+            """))
+        }
+    }
+
+    func test_v11MigrationDoesNotRecoverCellsCreatedBeforeDocumentRow() throws {
+        let streamId = UUID()
+        let documentCreatedAt = 1_000.0
+
+        try withSeededV10Database { db in
+            try insertStream(db, id: streamId, title: "Already Seeded", createdAt: 900)
+            try insertStreamDocument(
+                db,
+                streamId: streamId,
+                markdown: "Already folded legacy note",
+                createdAt: documentCreatedAt
+            )
+            try insertCell(
+                db,
+                streamId: streamId,
+                content: "<p>Already folded legacy note</p>",
+                createdAt: documentCreatedAt - 1,
+                position: 0
+            )
+        } body: { dbURL, fileManager in
+            let service = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: streamId))
+            XCTAssertEqual(document.markdown, "Already folded legacy note")
+        }
+    }
+
+    func test_v11MigrationDoesNotCreateDocumentForStreamsWithoutDocumentRow() throws {
+        let streamId = UUID()
+
+        try withSeededV10Database { db in
+            try insertStream(db, id: streamId, title: "No Document", createdAt: 900)
+            try insertCell(
+                db,
+                streamId: streamId,
+                content: "<p>Invisible capture</p>",
+                createdAt: 1_001,
+                position: 0
+            )
+        } body: { dbURL, fileManager in
+            let service = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+
+            XCTAssertNil(try service.loadStreamDocument(streamId: streamId))
+        }
+    }
+
+    func test_v11MigrationIsNoOpAfterAlreadyApplied() throws {
+        let streamId = UUID()
+        let documentCreatedAt = 1_000.0
+
+        try withSeededV10Database { db in
+            try insertStream(db, id: streamId, title: "No-op", createdAt: 900)
+            try insertStreamDocument(
+                db,
+                streamId: streamId,
+                markdown: "Existing document",
+                createdAt: documentCreatedAt
+            )
+            try insertCell(
+                db,
+                streamId: streamId,
+                content: "<p>Recovered once</p>",
+                createdAt: documentCreatedAt + 1,
+                position: 0
+            )
+        } body: { dbURL, fileManager in
+            var firstService: PersistenceService? = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+            let firstMarkdown = try XCTUnwrap(firstService?.loadStreamDocument(streamId: streamId)).markdown
+            firstService = nil
+
+            let secondService = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+            let secondMarkdown = try XCTUnwrap(secondService.loadStreamDocument(streamId: streamId)).markdown
+
+            XCTAssertEqual(secondMarkdown, firstMarkdown)
+            XCTAssertEqual(
+                secondMarkdown,
+                "Existing document\n\n## Recovered captures\n\nRecovered once"
+            )
+        }
+    }
+
     private func withTempPersistenceService(_ body: (PersistenceService) throws -> Void) throws {
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -150,5 +274,168 @@ final class StreamDocumentTests: XCTestCase {
         }
 
         try body(service)
+    }
+
+    private func withSeededV10Database(
+        seed: (Database) throws -> Void,
+        body: (URL, FileManager) throws -> Void
+    ) throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let dbURL = tempDir.appendingPathComponent("ticker.db")
+
+        var dbQueue: DatabaseQueue? = try DatabaseQueue(path: dbURL.path)
+        try dbQueue?.write { db in
+            try createV10Schema(db)
+            try seed(db)
+            try markV10MigrationsApplied(db)
+        }
+        dbQueue = nil
+
+        defer {
+            _ = try? fileManager.removeItem(at: tempDir)
+        }
+
+        try body(dbURL, fileManager)
+    }
+
+    private func createV10Schema(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE streams (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                created_at DOUBLE NOT NULL,
+                updated_at DOUBLE NOT NULL
+            )
+            """)
+        try db.execute(sql: """
+            CREATE TABLE cells (
+                id TEXT PRIMARY KEY,
+                stream_id TEXT NOT NULL REFERENCES streams(id) ON DELETE CASCADE,
+                type TEXT NOT NULL,
+                content TEXT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'idle',
+                source_binding_json TEXT,
+                metadata_json TEXT NOT NULL,
+                created_at DOUBLE NOT NULL,
+                updated_at DOUBLE NOT NULL,
+                position INTEGER NOT NULL,
+                restatement TEXT,
+                original_prompt TEXT,
+                modifiers_json TEXT,
+                versions_json TEXT,
+                active_version_id TEXT,
+                processing_config_json TEXT,
+                references_json TEXT,
+                block_name TEXT,
+                source_app TEXT
+            )
+            """)
+        try db.execute(sql: "CREATE INDEX idx_cells_stream ON cells(stream_id)")
+        try db.execute(sql: "CREATE INDEX idx_cells_position ON cells(stream_id, position)")
+        try db.execute(sql: """
+            CREATE TABLE stream_documents (
+                stream_id TEXT PRIMARY KEY REFERENCES streams(id) ON DELETE CASCADE,
+                markdown TEXT NOT NULL DEFAULT '',
+                created_at DOUBLE NOT NULL,
+                updated_at DOUBLE NOT NULL
+            )
+            """)
+        try db.execute(sql: "CREATE TABLE grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+    }
+
+    private func markV10MigrationsApplied(_ db: Database) throws {
+        for identifier in [
+            "v1_initial",
+            "v2_cell_restatement",
+            "v3_cell_original_prompt",
+            "v4_modifier_stack",
+            "v5_processing",
+            "v6_fix_source_status",
+            "v7_rag_pipeline",
+            "v8_quick_panel",
+            "v9_heading_in_content_titles",
+            "v10_stream_documents"
+        ] {
+            try db.execute(
+                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                arguments: [identifier]
+            )
+        }
+    }
+
+    private func insertStream(_ db: Database, id: UUID, title: String, createdAt: Double) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO streams (id, title, created_at, updated_at)
+                VALUES (?, ?, ?, ?)
+            """,
+            arguments: [id.uuidString, title, createdAt, createdAt]
+        )
+    }
+
+    private func insertStreamDocument(
+        _ db: Database,
+        streamId: UUID,
+        markdown: String,
+        createdAt: Double
+    ) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO stream_documents (stream_id, markdown, created_at, updated_at)
+                VALUES (?, ?, ?, ?)
+            """,
+            arguments: [streamId.uuidString, markdown, createdAt, createdAt]
+        )
+    }
+
+    private func insertCell(
+        _ db: Database,
+        streamId: UUID,
+        content: String,
+        createdAt: Double,
+        position: Int
+    ) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO cells (
+                    id,
+                    stream_id,
+                    type,
+                    content,
+                    state,
+                    metadata_json,
+                    created_at,
+                    updated_at,
+                    position
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            arguments: [
+                UUID().uuidString,
+                streamId.uuidString,
+                "quote",
+                content,
+                "idle",
+                "{}",
+                createdAt,
+                createdAt,
+                position
+            ]
+        )
+    }
+
+    private func assertPreMigrationBackupExists(nextTo dbURL: URL, fileManager: FileManager) throws {
+        let backupsDirectory = dbURL.deletingLastPathComponent().appendingPathComponent("backups", isDirectory: true)
+        let backups = try fileManager.contentsOfDirectory(
+            at: backupsDirectory,
+            includingPropertiesForKeys: nil
+        )
+
+        XCTAssertTrue(
+            backups.contains { $0.pathExtension.lowercased() == "db" },
+            "Expected pre-migration backup for existing DB with pending v11 migration"
+        )
     }
 }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import XCTest
+
+@testable import Ticker
+
+final class StreamDocumentTests: XCTestCase {
+    func test_appendToStreamDocument_createsDocumentWithExactlyFragmentWhenMissing() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "New Document")
+            try service.saveStream(stream)
+
+            let result = try service.appendToStreamDocument(streamId: stream.id, fragment: "Captured note")
+
+            XCTAssertEqual(result.fragment, "Captured note")
+            XCTAssertTrue(result.isNewDocument)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "Captured note")
+        }
+    }
+
+    func test_appendToStreamDocument_appendsWithBlankLineSeparatorWhenDocumentExists() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Existing Document")
+            try service.saveStream(stream)
+            try service.saveStreamDocument(streamId: stream.id, markdown: "Existing markdown")
+
+            let result = try service.appendToStreamDocument(streamId: stream.id, fragment: "New fragment")
+
+            XCTAssertEqual(result.fragment, "New fragment")
+            XCTAssertFalse(result.isNewDocument)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "Existing markdown\n\nNew fragment")
+        }
+    }
+
+    func test_appendToStreamDocument_skipsSeparatorWhenExistingDocumentIsEmpty() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Empty Existing Document")
+            try service.saveStream(stream)
+            try service.saveStreamDocument(streamId: stream.id, markdown: "")
+
+            let result = try service.appendToStreamDocument(streamId: stream.id, fragment: "Only fragment")
+
+            XCTAssertEqual(result.fragment, "Only fragment")
+            XCTAssertFalse(result.isNewDocument)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "Only fragment")
+        }
+    }
+
+    func test_appendToStreamDocument_twoSequentialAppendsPreserveOrder() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Sequential Appends")
+            try service.saveStream(stream)
+
+            let first = try service.appendToStreamDocument(streamId: stream.id, fragment: "First fragment")
+            let second = try service.appendToStreamDocument(streamId: stream.id, fragment: "Second fragment")
+
+            XCTAssertTrue(first.isNewDocument)
+            XCTAssertFalse(second.isNewDocument)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "First fragment\n\nSecond fragment")
+        }
+    }
+
+    func test_loadOrCreateStreamDocumentAfterAppendReturnsMarkdownContainingFragment() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Load After Append")
+            try service.saveStream(stream)
+
+            _ = try service.appendToStreamDocument(streamId: stream.id, fragment: "Visible capture")
+
+            let document = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            XCTAssertTrue(document.markdown.contains("Visible capture"))
+        }
+    }
+
+    func test_appendToStreamDocument_bumpsDocumentAndStreamUpdatedAt() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Timestamp Bump")
+            try service.saveStream(stream)
+            try service.saveStreamDocument(streamId: stream.id, markdown: "Before")
+
+            let beforeDocument = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            let beforeStream = try XCTUnwrap(service.loadStream(id: stream.id))
+
+            Thread.sleep(forTimeInterval: 0.01)
+
+            _ = try service.appendToStreamDocument(streamId: stream.id, fragment: "After")
+
+            let afterDocument = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            let afterStream = try XCTUnwrap(service.loadStream(id: stream.id))
+
+            XCTAssertGreaterThan(
+                afterDocument.updatedAt.timeIntervalSince1970,
+                beforeDocument.updatedAt.timeIntervalSince1970
+            )
+            XCTAssertGreaterThan(
+                afterStream.updatedAt.timeIntervalSince1970,
+                beforeStream.updatedAt.timeIntervalSince1970
+            )
+        }
+    }
+
+    func test_appendToStreamDocumentSeedsLegacyCellsBeforeAppendingWhenDocumentMissing() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Legacy Seed")
+            try service.saveStream(stream)
+
+            let legacyCell = Cell(
+                streamId: stream.id,
+                content: "<p>Legacy note</p>",
+                type: .text,
+                order: 0
+            )
+            try service.saveCell(legacyCell)
+
+            let result = try service.appendToStreamDocument(streamId: stream.id, fragment: "New capture")
+
+            XCTAssertEqual(result.fragment, "New capture")
+            XCTAssertTrue(result.isNewDocument)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "Legacy note\n\nNew capture")
+
+            let loaded = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            XCTAssertEqual(loaded.markdown, "Legacy note\n\nNew capture")
+        }
+    }
+
+    private func withTempPersistenceService(_ body: (PersistenceService) throws -> Void) throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let dbURL = tempDir.appendingPathComponent("ticker.db")
+
+        var service: PersistenceService? = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+        defer {
+            service = nil
+            _ = try? fileManager.removeItem(at: tempDir)
+        }
+
+        guard let service else {
+            XCTFail("Expected persistence service")
+            return
+        }
+
+        try body(service)
+    }
+}

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 			A100000100000000002D /* ProxyLLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002D /* ProxyLLMService.swift */; };
 			A100000100000000002E /* DebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002E /* DebugLog.swift */; };
 			A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002F /* DeviceKeyServiceTests.swift */; };
+			A1000001000000000031 /* StreamDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000031 /* StreamDocumentTests.swift */; };
 		/* End PBXBuildFile section */
 
 		/* Begin PBXContainerItemProxy section */
@@ -125,6 +126,7 @@
 			B100000100000000002D /* ProxyLLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyLLMService.swift; sourceTree = "<group>"; };
 			B100000100000000002E /* DebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLog.swift; sourceTree = "<group>"; };
 			B100000100000000002F /* DeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyServiceTests.swift; sourceTree = "<group>"; };
+			B1000001000000000031 /* StreamDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamDocumentTests.swift; sourceTree = "<group>"; };
 				F1000001000000000001 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 				F1000001000000000002 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
@@ -318,6 +320,7 @@
 				isa = PBXGroup;
 				children = (
 					B100000100000000002F /* DeviceKeyServiceTests.swift */,
+					B1000001000000000031 /* StreamDocumentTests.swift */,
 				);
 				path = TickerTests;
 				sourceTree = "<group>";
@@ -504,6 +507,7 @@
 				buildActionMask = 2147483647;
 				files = (
 					A100000100000000002F /* DeviceKeyServiceTests.swift in Sources */,
+					A1000001000000000031 /* StreamDocumentTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
@@ -656,6 +660,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				MARKETING_VERSION = 2025.12.1;
 					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.next;
+					PRODUCT_MODULE_NAME = Ticker;
 					PRODUCT_NAME = TickerNext;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -682,6 +687,7 @@
 				);
 				MARKETING_VERSION = 2025.12.1;
 					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.next;
+					PRODUCT_MODULE_NAME = Ticker;
 					PRODUCT_NAME = TickerNext;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { bridge, Stream, StreamSummary } from './types';
 import { StreamEditor } from './components/StreamEditor';
 import { Settings } from './components/Settings';
@@ -75,6 +75,8 @@ export function App() {
   const [currentStream, setCurrentStream] = useState<Stream | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingStream, setIsLoadingStream] = useState(false);
+  const viewRef = useRef(view);
+  const currentStreamIdRef = useRef<string | null>(currentStream?.id ?? null);
   const clearStream = useBlockStore((state) => state.clearStream);
 
   // Proxy auth state - gates main UI until key is validated
@@ -96,6 +98,11 @@ export function App() {
   useEffect(() => {
     bridge.send({ type: 'loadSettings' });
   }, []);
+
+  useEffect(() => {
+    viewRef.current = view;
+    currentStreamIdRef.current = currentStream?.id ?? null;
+  }, [view, currentStream?.id]);
 
   // Keep native file-drop routing in sync with the active page.
   useEffect(() => {
@@ -133,11 +140,15 @@ export function App() {
           setStreams((message.payload?.streams as StreamSummary[]) || []);
           setIsLoading(false);
           break;
-        case 'streamLoaded':
-          setCurrentStream(message.payload?.stream as Stream);
+        case 'streamLoaded': {
+          const loadedStream = message.payload?.stream as Stream;
+          currentStreamIdRef.current = loadedStream?.id ?? null;
+          viewRef.current = 'stream';
+          setCurrentStream(loadedStream);
           setIsLoadingStream(false);
           setView('stream');
           break;
+        }
         case 'settingsLoaded': {
           const raw = message.payload?.settings as Partial<EditorTypographySettings> | undefined;
           applyEditorTypography(normalizeEditorTypography(raw));
@@ -147,6 +158,11 @@ export function App() {
           // Quick Panel appended to a document - if it's a new stream, load it.
           if (message.payload?.isNewStream && message.payload?.streamId) {
             const streamId = message.payload.streamId as string;
+            if (viewRef.current === 'stream' && currentStreamIdRef.current === streamId) {
+              debugLog('[App] Quick Panel appended to current stream document; editor handler owns it', { streamId });
+              break;
+            }
+
             debugLog('[App] Quick Panel created new stream document', { streamId });
 
             bridge.send({ type: 'loadStream', payload: { id: streamId } });

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -143,28 +143,12 @@ export function App() {
           applyEditorTypography(normalizeEditorTypography(raw));
           break;
         }
-        case 'quickPanelCellsAdded':
-          // Quick Panel added cells - if it's a new stream, load it and update list
+        case 'streamDocumentAppended':
+          // Quick Panel appended to a document - if it's a new stream, load it.
           if (message.payload?.isNewStream && message.payload?.streamId) {
             const streamId = message.payload.streamId as string;
-            const cellCount = (message.payload.cells as unknown[])?.length || 0;
-            debugLog('[App] Quick Panel created new stream with cells', { streamId, cellCount });
+            debugLog('[App] Quick Panel created new stream document', { streamId });
 
-            // Add to streams list so it appears when navigating back
-            setStreams(prev => {
-              // Avoid duplicates
-              if (prev.some(s => s.id === streamId)) return prev;
-              return [{
-                id: streamId,
-                title: 'Untitled',
-                sourceCount: 0,
-                cellCount,
-                updatedAt: new Date().toISOString(),
-                previewText: null
-              }, ...prev];
-            });
-
-            // Load the stream from DB - cells are already saved
             bridge.send({ type: 'loadStream', payload: { id: streamId } });
           }
           break;

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -258,6 +258,30 @@ export function StreamEditor({
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
+      if (message.type === 'streamDocumentAppended') {
+        const payloadStreamId = message.payload?.streamId as string | undefined;
+        const fragment = message.payload?.fragment as string | undefined;
+
+        if (!payloadStreamId || payloadStreamId !== stream.id || typeof fragment !== 'string' || fragment.length === 0) {
+          return;
+        }
+
+        const view = editorViewRef.current;
+        if (!view) return;
+
+        const end = view.state.doc.length;
+        const sep = end > 0 ? '\n\n' : '';
+        const insert = `${sep}${fragment}`;
+        const insertedEnd = end + insert.length;
+
+        view.dispatch({
+          changes: { from: end, insert },
+          effects: EditorView.scrollIntoView(insertedEnd, { y: 'nearest' }),
+        });
+        setMarkdownContent(view.state.doc.toString());
+        return;
+      }
+
       const active = aiRequestRef.current;
       if (!active) return;
 
@@ -365,7 +389,7 @@ export function StreamEditor({
     });
 
     return () => unsubscribe();
-  }, [addToast]);
+  }, [addToast, stream.id]);
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -32,19 +32,23 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
   'modelSelected',
   'proxyAuthState',
   'pdfHighlightLinked',
-  'quickPanelCellsAdded',
   'settingsLoaded',
   'sourceAdded',
   'sourceError',
   'sourceRemoveError',
   'sourceRemoved',
+  'streamDocumentAppended',
   'streamLoaded',
   'streamTitleUpdated',
   'streamsChanged',
   'streamsLoaded',
 ] as const;
 
-export type SwiftToWebMessageType = (typeof SWIFT_TO_WEB_MESSAGE_TYPES)[number];
+type LegacySwiftToWebMessageType = 'quickPanelCellsAdded';
+
+export type SwiftToWebMessageType =
+  | (typeof SWIFT_TO_WEB_MESSAGE_TYPES)[number]
+  | LegacySwiftToWebMessageType;
 
 export interface BridgeMessage {
   type: string;

--- a/docs/contracts/bridge.v1.json
+++ b/docs/contracts/bridge.v1.json
@@ -113,10 +113,6 @@
       "streamsChanged": {
         "requiredPayloadKeys": []
       },
-      "quickPanelCellsAdded": {
-        "requiredPayloadKeys": ["streamId", "cells", "isNewStream"],
-        "optionalPayloadKeys": ["triggerAI"]
-      },
       "callback": {
         "requiredPayloadKeys": [],
         "requiredCallbackId": true

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -22,6 +22,9 @@
       },
       "documentModelSelected": {
         "requiredPayloadKeys": ["requestId", "modelId"]
+      },
+      "streamDocumentAppended": {
+        "requiredPayloadKeys": ["streamId", "fragment", "isNewStream", "source"]
       }
     }
   }


### PR DESCRIPTION
Fixes the P0 bug where Quick Panel captures never appeared in the main window (plan: docs/PRODUCTION_READINESS_PLAN.md, Phase 1). Stacked on #23.

- `appendToStreamDocument` — single primitive for all external stream writes (TDD, StreamDocumentTests).
- Quick Panel persists markdown fragments to `stream_documents` (was: orphaned rows in the legacy `cells` table); new `streamDocumentAppended` v2 bridge event.
- Open editors apply appends live as CodeMirror transactions; no reload, local edits survive concurrent captures.
- ⌘↵ AI+Save reworked on the document model: capture appends, orchestrator runs with full document context, response appends as a second fragment; failures append a visible error line.
- Migration `v11` recovers all captures orphaned by the old bug under a "## Recovered captures" heading (pre-migration backup verified).

Verification: 17/17 Swift tests; live GUI drive on the real app — closed-stream capture, open-editor live append, local-edit race, real-proxy ⌘↵ round-trip (PONG test), and v11 run against the production DB (3 streams recovered, backup created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)