### PR TITLE
Phase 3: editor rendering, selection popover, quick panel ergonomics, design tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable user-facing changes to Ticker are documented here.
 
 ### Fixed
 - Recovered quick-capture notes that previously didn't appear in streams.
+- Stopped embedded stream images from flickering or refetching while editing nearby text, and made cursor movement skip image tokens atomically.
 
 ### Removed
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
-- TBD
+- Live markdown concealment in the stream editor so formatting marks fade away off the active line while styled text remains readable.
 
 ### Changed
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable user-facing changes to Ticker are documented here.
 ### Fixed
 - Recovered quick-capture notes that previously didn't appear in streams.
 - Stopped embedded stream images from flickering or refetching while editing nearby text, and made cursor movement skip image tokens atomically.
+- Restored the stream editor selection action menu using CodeMirror selection state.
 
 ### Removed
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable user-facing changes to Ticker are documented here.
 - Recovered quick-capture notes that previously didn't appear in streams.
 - Stopped embedded stream images from flickering or refetching while editing nearby text, and made cursor movement skip image tokens atomically.
 - Restored the stream editor selection action menu using CodeMirror selection state.
+- Made Quick Panel dismissal consistent, stabilized stream picking, and added visible save feedback.
 
 ### Removed
 - TBD

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -24,6 +24,44 @@ private enum PDFReaderPanePresentationError: LocalizedError {
     }
 }
 
+private enum PDFPaneStyle {
+    static let background = dynamicColor(
+        light: NSColor(red: 251 / 255, green: 251 / 255, blue: 250 / 255, alpha: 1),
+        dark: NSColor(red: 28 / 255, green: 28 / 255, blue: 27 / 255, alpha: 1)
+    )
+    static let surface = dynamicColor(
+        light: NSColor(red: 244 / 255, green: 244 / 255, blue: 242 / 255, alpha: 1),
+        dark: NSColor(red: 36 / 255, green: 36 / 255, blue: 35 / 255, alpha: 1)
+    )
+    static let text = dynamicColor(
+        light: NSColor(red: 31 / 255, green: 31 / 255, blue: 29 / 255, alpha: 1),
+        dark: NSColor(red: 243 / 255, green: 242 / 255, blue: 237 / 255, alpha: 1)
+    )
+    static let textMuted = dynamicColor(
+        light: NSColor(red: 111 / 255, green: 111 / 255, blue: 104 / 255, alpha: 1),
+        dark: NSColor(red: 170 / 255, green: 167 / 255, blue: 157 / 255, alpha: 1)
+    )
+    static let accent = dynamicColor(
+        light: NSColor(red: 37 / 255, green: 99 / 255, blue: 235 / 255, alpha: 1),
+        dark: NSColor(red: 138 / 255, green: 168 / 255, blue: 255 / 255, alpha: 1)
+    )
+    static let separator = dynamicColor(
+        light: NSColor(red: 31 / 255, green: 31 / 255, blue: 29 / 255, alpha: 0.08),
+        dark: NSColor(red: 243 / 255, green: 242 / 255, blue: 237 / 255, alpha: 0.08)
+    )
+
+    private static func dynamicColor(light: NSColor, dark: NSColor) -> NSColor {
+        NSColor(name: nil) { appearance in
+            switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
+            case .darkAqua:
+                return dark
+            default:
+                return light
+            }
+        }
+    }
+}
+
 private final class PDFPaneResizeHandleView: NSView {
     override func resetCursorRects() {
         super.resetCursorRects()
@@ -142,7 +180,7 @@ final class PDFReaderPaneController: NSViewController {
     private func configurePDFPane() {
         pdfPaneView.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneView.wantsLayer = true
-        pdfPaneView.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        pdfPaneView.layer?.backgroundColor = PDFPaneStyle.background.cgColor
         pdfPaneView.isHidden = true
 
         pdfPaneWidthConstraint = pdfPaneView.widthAnchor.constraint(equalToConstant: 0)
@@ -151,9 +189,11 @@ final class PDFReaderPaneController: NSViewController {
         let divider = NSView(frame: .zero)
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.wantsLayer = true
-        divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        divider.layer?.backgroundColor = PDFPaneStyle.separator.cgColor
 
         pdfPaneHeaderView.translatesAutoresizingMaskIntoConstraints = false
+        pdfPaneHeaderView.wantsLayer = true
+        pdfPaneHeaderView.layer?.backgroundColor = PDFPaneStyle.background.cgColor
         pdfPaneResizeHandle.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneTitleField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneLinkButton.translatesAutoresizingMaskIntoConstraints = false
@@ -167,7 +207,8 @@ final class PDFReaderPaneController: NSViewController {
             action: #selector(handlePDFPaneResizePan(_:))
         ))
 
-        pdfPaneTitleField.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        pdfPaneTitleField.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
+        pdfPaneTitleField.textColor = PDFPaneStyle.text
         pdfPaneTitleField.lineBreakMode = .byTruncatingTail
         pdfPaneTitleField.maximumNumberOfLines = 1
         pdfPaneTitleField.usesSingleLineMode = true
@@ -178,17 +219,19 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneLinkButton.bezelStyle = .rounded
         pdfPaneLinkButton.controlSize = .small
         pdfPaneLinkButton.isEnabled = false
+        pdfPaneLinkButton.contentTintColor = PDFPaneStyle.accent
 
         pdfPaneCloseButton.target = self
         pdfPaneCloseButton.action = #selector(handlePDFPaneClose)
         pdfPaneCloseButton.bezelStyle = .rounded
         pdfPaneCloseButton.controlSize = .small
+        pdfPaneCloseButton.contentTintColor = PDFPaneStyle.textMuted
 
         pdfPanePDFView.autoScales = true
         pdfPanePDFView.displayMode = .singlePageContinuous
         pdfPanePDFView.displayDirection = .vertical
         pdfPanePDFView.displaysAsBook = false
-        pdfPanePDFView.backgroundColor = NSColor.windowBackgroundColor
+        pdfPanePDFView.backgroundColor = PDFPaneStyle.surface
         let pageControllerSelector = NSSelectorFromString("usePageViewController:withViewOptions:")
         if pdfPanePDFView.responds(to: pageControllerSelector) {
             pdfPanePDFView.perform(pageControllerSelector, with: NSNumber(value: true), with: nil)

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -64,6 +64,8 @@ final class QuickPanelManager: ObservableObject {
 
     private var streamingTask: Task<Void, Never>?
     private var documentAITasks: [UUID: Task<Void, Never>] = [:]
+    private var statusClearTask: Task<Void, Never>?
+    private var saveFeedbackTask: Task<Void, Never>?
     private var isStreamingCancelled = false  // Explicit flag since nested Tasks don't inherit cancellation
 
     // MARK: - Height Management
@@ -95,6 +97,8 @@ final class QuickPanelManager: ObservableObject {
     deinit {
         streamingTask?.cancel()
         documentAITasks.values.forEach { $0.cancel() }
+        statusClearTask?.cancel()
+        saveFeedbackTask?.cancel()
     }
 
     /// Configure services after initialization (for dependency injection)
@@ -181,15 +185,7 @@ final class QuickPanelManager: ObservableObject {
         )
 
         show(with: contextWithoutClipboard, showAccessibilityWarning: false)
-        statusMessage = message
-
-        // Auto-clear after a short delay so it doesn't linger.
-        Task {
-            try? await Task.sleep(nanoseconds: 4_000_000_000)  // 4s
-            if self.statusMessage == message {
-                self.statusMessage = nil
-            }
-        }
+        showTimedStatusMessage(message, durationNanoseconds: 4_000_000_000)
     }
 
     /// Show the quick panel with specific context
@@ -230,6 +226,7 @@ final class QuickPanelManager: ObservableObject {
 
     /// Hide the quick panel
     func hide() {
+        cancelFeedbackTasks()
         // Cancel any in-flight streaming to avoid orphan AI calls
         cancelStreaming()
 
@@ -253,6 +250,45 @@ final class QuickPanelManager: ObservableObject {
         inputText = ""
         isLoading = false
         error = nil
+        statusMessage = nil
+    }
+
+    private func cancelFeedbackTasks() {
+        statusClearTask?.cancel()
+        statusClearTask = nil
+        saveFeedbackTask?.cancel()
+        saveFeedbackTask = nil
+    }
+
+    private func showTimedStatusMessage(_ message: String, durationNanoseconds: UInt64) {
+        statusClearTask?.cancel()
+        statusMessage = message
+
+        statusClearTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: durationNanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, self.statusMessage == message else { return }
+                self.statusMessage = nil
+                self.statusClearTask = nil
+            }
+        }
+    }
+
+    private func showSaveFeedbackThenHide(_ message: String) {
+        statusClearTask?.cancel()
+        statusClearTask = nil
+        saveFeedbackTask?.cancel()
+        statusMessage = message
+
+        saveFeedbackTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 700_000_000)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, self.statusMessage == message else { return }
+                self.hide()
+            }
+        }
     }
 
     /// Update panel appearance (light/dark mode)
@@ -433,6 +469,7 @@ final class QuickPanelManager: ObservableObject {
         do {
             // Get target stream (may create new one)
             let (streamId, isNewStream) = try getTargetStreamId()
+            let streamTitle = displayTitle(for: streamId, persistence: persistence)
 
             let fragment = try buildMarkdownFragment(streamId: streamId)
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
@@ -456,8 +493,13 @@ final class QuickPanelManager: ObservableObject {
                 }
             }
 
-            // Success - hide panel
-            hide()
+            inputText = ""
+            context = nil
+            isLoading = false
+            let feedbackMessage = triggerDocumentAI
+                ? "Saved to \(streamTitle) — asking AI…"
+                : "Saved to \(streamTitle)"
+            showSaveFeedbackThenHide(feedbackMessage)
 
             if let aiPrompt {
                 if let orchestratorForAI, let documentMarkdownForAI {
@@ -476,6 +518,7 @@ final class QuickPanelManager: ObservableObject {
                     )
                 }
             }
+            return
 
         } catch {
             self.error = error.localizedDescription
@@ -586,6 +629,20 @@ final class QuickPanelManager: ObservableObject {
             return nil
         }
         return trimmed
+    }
+
+    private func displayTitle(for streamId: UUID, persistence: PersistenceService) -> String {
+        if let summaryTitle = availableStreams.first(where: { $0.id == streamId })?.title,
+           let title = nonEmptyTrimmed(summaryTitle) {
+            return title
+        }
+
+        if let storedTitle = try? persistence.getStreamTitle(id: streamId),
+           let title = nonEmptyTrimmed(storedTitle) {
+            return title
+        }
+
+        return "Untitled"
     }
 
     private func escapeMarkdownEmphasis(_ text: String) -> String {
@@ -705,6 +762,9 @@ final class QuickPanelManager: ObservableObject {
 
         newPanel.onDismiss = { [weak self] in
             self?.hide()
+        }
+        newPanel.onEscape = { [weak self] in
+            self?.handleEscape()
         }
 
         let view = QuickPanelView(manager: self)

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -1,6 +1,73 @@
 import SwiftUI
 import AppKit
 
+private enum QuickPanelStyle {
+    static let radius: CGFloat = 8
+    static let badgeVerticalPadding: CGFloat = 2
+    static let optionVerticalPadding: CGFloat = 5
+    static let pickerMaxHeight: CGFloat = 180
+    static let responseMaxHeight: CGFloat = 250
+    static let progressSize: CGFloat = 16
+    static let typingDotSize: CGFloat = 4
+    static let markdownLineSpacing: CGFloat = 3
+    static let inputInsetY: CGFloat = 2
+    static let inputHeightPadding: CGFloat = 4
+    static let minInputHeight: CGFloat = 22
+    static let maxInputHeight: CGFloat = 120
+
+    static let microTextSize: CGFloat = 9
+    static let iconSize: CGFloat = 10
+    static let captionSize: CGFloat = 11
+    static let bodySize: CGFloat = 12
+    static let inputSize: CGFloat = 15
+    static let actionIconSize: CGFloat = 18
+
+    static let surface = Color(
+        light: Color(red: 251 / 255, green: 251 / 255, blue: 250 / 255),
+        dark: Color(red: 28 / 255, green: 28 / 255, blue: 27 / 255)
+    )
+    static let surfaceRaised = Color(
+        light: Color.white,
+        dark: Color(red: 43 / 255, green: 43 / 255, blue: 41 / 255)
+    )
+    static let surfaceMuted = Color(
+        light: Color(red: 244 / 255, green: 244 / 255, blue: 242 / 255),
+        dark: Color(red: 48 / 255, green: 48 / 255, blue: 46 / 255)
+    )
+    static let text = Color(
+        light: Color(red: 31 / 255, green: 31 / 255, blue: 29 / 255),
+        dark: Color(red: 243 / 255, green: 242 / 255, blue: 237 / 255)
+    )
+    static let textMuted = Color(
+        light: Color(red: 111 / 255, green: 111 / 255, blue: 104 / 255),
+        dark: Color(red: 170 / 255, green: 167 / 255, blue: 157 / 255)
+    )
+    static let textSubtle = Color(
+        light: Color(red: 155 / 255, green: 154 / 255, blue: 145 / 255),
+        dark: Color(red: 119 / 255, green: 116 / 255, blue: 108 / 255)
+    )
+    static let accent = Color(
+        light: Color(red: 37 / 255, green: 99 / 255, blue: 235 / 255),
+        dark: Color(red: 138 / 255, green: 168 / 255, blue: 255 / 255)
+    )
+    static let success = Color(
+        light: Color(red: 22 / 255, green: 129 / 255, blue: 61 / 255),
+        dark: Color(red: 104 / 255, green: 185 / 255, blue: 130 / 255)
+    )
+    static let danger = Color(
+        light: Color(red: 199 / 255, green: 58 / 255, blue: 50 / 255),
+        dark: Color(red: 238 / 255, green: 127 / 255, blue: 118 / 255)
+    )
+
+    static func font(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        design: Font.Design = .default
+    ) -> Font {
+        .system(size: size, weight: weight, design: design)
+    }
+}
+
 // MARK: - Content Height Preference Key
 
 /// PreferenceKey for bubbling up content height from SwiftUI to the panel
@@ -52,7 +119,7 @@ struct QuickPanelView: View {
         .padding(Spacing.lg)
         .frame(width: QuickPanelWindow.defaultWidth, alignment: .top)
         .fixedSize(horizontal: false, vertical: true)
-        .background(Colors.windowBackground)
+        .background(QuickPanelStyle.surfaceRaised)
         .background(
             GeometryReader { geometry in
                 Color.clear
@@ -64,9 +131,9 @@ struct QuickPanelView: View {
                 manager.contentHeightChanged(height)
             }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .clipShape(RoundedRectangle(cornerRadius: QuickPanelStyle.radius))
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: QuickPanelStyle.radius)
                 .stroke(Color.clear, lineWidth: 1)
         )
         .onReceive(NotificationCenter.default.publisher(for: .quickPanelDidShow)) { _ in
@@ -79,16 +146,16 @@ struct QuickPanelView: View {
 
     private func contextBadge(context: QuickPanelContext) -> some View {
         let isScreenshot = context.isScreenshot
-        let accentColor = isScreenshot ? Colors.successAccent : Colors.secondaryText
-        let backgroundColor = isScreenshot ? Colors.successAccent.opacity(0.15) : Colors.userMessageBackground
+        let accentColor = isScreenshot ? QuickPanelStyle.success : QuickPanelStyle.textMuted
+        let backgroundColor = isScreenshot ? QuickPanelStyle.success.opacity(0.15) : QuickPanelStyle.accent.opacity(0.1)
 
         return HStack(spacing: Spacing.xs) {
             Image(systemName: context.hasImage ? "photo" : "text.quote")
-                .font(.system(size: 10))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize))
                 .foregroundColor(accentColor)
 
             Text(contextPreview(context))
-                .font(.system(size: 11))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
                 .foregroundColor(accentColor)
                 .lineLimit(1)
 
@@ -96,19 +163,19 @@ struct QuickPanelView: View {
 
             if let app = context.activeApp {
                 Text(app)
-                    .font(.system(size: 9))
-                    .foregroundColor(Colors.secondaryText.opacity(0.7))
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize))
+                    .foregroundColor(QuickPanelStyle.textMuted.opacity(0.7))
                     .padding(.horizontal, Spacing.xs)
-                    .padding(.vertical, 2)
-                    .background(Colors.hoverBackground)
-                    .cornerRadius(Spacing.radiusSm)
+                    .padding(.vertical, QuickPanelStyle.badgeVerticalPadding)
+                    .background(QuickPanelStyle.surfaceMuted)
+                    .cornerRadius(QuickPanelStyle.radius)
             }
 
             // Dismiss button
             Button(action: { manager.clearContext() }) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundColor(Colors.secondaryText.opacity(0.6))
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .semibold))
+                    .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
             }
             .buttonStyle(.plain)
             .help("Clear context")
@@ -117,10 +184,10 @@ struct QuickPanelView: View {
         .padding(.vertical, Spacing.xs)
         .background(backgroundColor)
         .overlay(
-            RoundedRectangle(cornerRadius: Spacing.radiusSm)
-                .stroke(isScreenshot ? Colors.successAccent.opacity(0.35) : Color.clear, lineWidth: 1)
+            RoundedRectangle(cornerRadius: QuickPanelStyle.radius)
+                .stroke(isScreenshot ? QuickPanelStyle.success.opacity(0.35) : Color.clear, lineWidth: 1)
         )
-        .cornerRadius(Spacing.radiusSm)
+        .cornerRadius(QuickPanelStyle.radius)
     }
 
     private func contextPreview(_ context: QuickPanelContext) -> String {
@@ -151,20 +218,20 @@ struct QuickPanelView: View {
             }) {
                 HStack(spacing: Spacing.xs) {
                     Image(systemName: "tray.and.arrow.down")
-                        .font(.system(size: 11))
-                        .foregroundColor(Colors.secondaryText)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
+                        .foregroundColor(QuickPanelStyle.textMuted)
                     Text(selectedStreamTitle)
-                        .font(.system(size: 11))
-                        .foregroundColor(Colors.secondaryText)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
+                        .foregroundColor(QuickPanelStyle.textMuted)
                         .lineLimit(1)
                     Image(systemName: isPickerExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundColor(Colors.tertiaryText)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .semibold))
+                        .foregroundColor(QuickPanelStyle.textSubtle)
                 }
                 .padding(.horizontal, Spacing.sm)
                 .padding(.vertical, Spacing.xs)
-                .background(Colors.hoverBackground)
-                .cornerRadius(Spacing.radiusSm)
+                .background(QuickPanelStyle.surfaceMuted)
+                .cornerRadius(QuickPanelStyle.radius)
             }
             .buttonStyle(.plain)
 
@@ -188,7 +255,7 @@ struct QuickPanelView: View {
 
                 if !manager.availableStreams.isEmpty {
                     Divider()
-                        .padding(.vertical, 2)
+                        .padding(.vertical, QuickPanelStyle.badgeVerticalPadding)
                 }
 
                 streamOptionButton(title: "New Stream...", systemImage: "plus", isSelected: false) {
@@ -196,15 +263,15 @@ struct QuickPanelView: View {
                     isPickerExpanded = false
                 }
             }
-            .padding(4)
+            .padding(Spacing.xs)
         }
-        .frame(maxHeight: 180)
-        .background(Colors.windowBackground)
+        .frame(maxHeight: QuickPanelStyle.pickerMaxHeight)
+        .background(QuickPanelStyle.surfaceRaised)
         .overlay(
-            RoundedRectangle(cornerRadius: Spacing.radiusSm)
-                .stroke(Colors.secondaryText.opacity(0.16), lineWidth: 1)
+            RoundedRectangle(cornerRadius: QuickPanelStyle.radius)
+                .stroke(QuickPanelStyle.textMuted.opacity(0.16), lineWidth: 1)
         )
-        .cornerRadius(Spacing.radiusSm)
+        .cornerRadius(QuickPanelStyle.radius)
     }
 
     private func streamOptionButton(
@@ -217,25 +284,25 @@ struct QuickPanelView: View {
             HStack(spacing: Spacing.xs) {
                 if let systemImage {
                     Image(systemName: systemImage)
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(Colors.secondaryText)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize, weight: .semibold))
+                        .foregroundColor(QuickPanelStyle.textMuted)
                 }
 
                 Text(title)
-                    .font(.system(size: 11))
-                    .foregroundColor(Colors.secondaryText)
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
+                    .foregroundColor(QuickPanelStyle.textMuted)
                     .lineLimit(1)
 
                 Spacer(minLength: Spacing.sm)
 
                 if isSelected {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(Colors.primaryAccent)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize, weight: .semibold))
+                        .foregroundColor(QuickPanelStyle.accent)
                 }
             }
             .padding(.horizontal, Spacing.sm)
-            .padding(.vertical, 5)
+            .padding(.vertical, QuickPanelStyle.optionVerticalPadding)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -267,9 +334,9 @@ struct QuickPanelView: View {
                 }
                 .padding(Spacing.sm)
             }
-            .frame(maxHeight: 250)
-            .background(Colors.hoverBackground.opacity(0.3))
-            .cornerRadius(Spacing.radiusMd)
+            .frame(maxHeight: QuickPanelStyle.responseMaxHeight)
+            .background(QuickPanelStyle.surfaceMuted.opacity(0.3))
+            .cornerRadius(QuickPanelStyle.radius)
             .onChange(of: manager.ephemeralConversation.currentResponse) { _, _ in
                 withAnimation(.easeOut(duration: 0.1)) {
                     proxy.scrollTo("streaming", anchor: .bottom)
@@ -289,16 +356,16 @@ struct QuickPanelView: View {
         VStack(alignment: .leading, spacing: 2) {
             // Role indicator
             Text(turn.role == .user ? "You" : "AI")
-                .font(.system(size: 9, weight: .medium))
-                .foregroundColor(Colors.tertiaryText)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
+                .foregroundColor(QuickPanelStyle.textSubtle)
 
             // Content - render markdown for AI responses
             if turn.role == .assistant {
                 MarkdownContentView(content: turn.content)
             } else {
                 Text(turn.content)
-                    .font(.system(size: 12))
-                    .foregroundColor(Colors.secondaryText)
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
+                    .foregroundColor(QuickPanelStyle.textMuted)
                     .textSelection(.enabled)
             }
         }
@@ -309,26 +376,26 @@ struct QuickPanelView: View {
     private var streamingResponseView: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text("AI")
-                .font(.system(size: 9, weight: .medium))
-                .foregroundColor(Colors.tertiaryText)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
+                .foregroundColor(QuickPanelStyle.textSubtle)
 
             if manager.ephemeralConversation.currentResponse.isEmpty {
                 // Typing indicator when waiting for first chunk
-                HStack(spacing: 4) {
+                HStack(spacing: QuickPanelStyle.typingDotSize) {
                     ForEach(0..<3, id: \.self) { _ in
                         Circle()
-                            .fill(Colors.tertiaryText)
-                            .frame(width: 4, height: 4)
+                            .fill(QuickPanelStyle.textSubtle)
+                            .frame(width: QuickPanelStyle.typingDotSize, height: QuickPanelStyle.typingDotSize)
                     }
                 }
-                .padding(.vertical, 4)
+                .padding(.vertical, Spacing.xs)
             } else {
                 // Render streaming content with markdown + cursor
                 HStack(alignment: .bottom, spacing: 0) {
                     MarkdownContentView(content: manager.ephemeralConversation.currentResponse)
                     Text(" ●")
-                        .font(.system(size: 10))
-                        .foregroundColor(Colors.primaryAccent)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize))
+                        .foregroundColor(QuickPanelStyle.accent)
                 }
             }
         }
@@ -352,12 +419,12 @@ struct QuickPanelView: View {
             if manager.isLoading {
                 ProgressView()
                     .scaleEffect(0.6)
-                    .frame(width: 16, height: 16)
+                    .frame(width: QuickPanelStyle.progressSize, height: QuickPanelStyle.progressSize)
             } else {
                 Button(action: handleSubmit) {
                     Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(canSubmit ? Colors.primaryAccent : Colors.tertiaryText.opacity(0.5))
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.actionIconSize))
+                        .foregroundColor(canSubmit ? QuickPanelStyle.accent : QuickPanelStyle.textSubtle.opacity(0.5))
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSubmit)
@@ -365,8 +432,8 @@ struct QuickPanelView: View {
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.sm)
-        .background(Colors.hoverBackground)
-        .cornerRadius(Spacing.radiusMd)
+        .background(QuickPanelStyle.surfaceMuted)
+        .cornerRadius(QuickPanelStyle.radius)
     }
 
     private var placeholderText: String {
@@ -387,16 +454,16 @@ struct QuickPanelView: View {
     private var modeHintsBar: some View {
         HStack(spacing: Spacing.md) {
             Text("↵ save")
-                .font(.system(size: 9))
-                .foregroundColor(Colors.secondaryText.opacity(0.6))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
 
             Text("⌘↵ AI+save")
-                .font(.system(size: 9))
-                .foregroundColor(Colors.secondaryText.opacity(0.6))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
 
             Text("⌥↵ ask")
-                .font(.system(size: 9))
-                .foregroundColor(Colors.secondaryText.opacity(0.6))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
 
             Spacer()
         }
@@ -408,17 +475,17 @@ struct QuickPanelView: View {
     private func errorView(_ error: String) -> some View {
         HStack(spacing: Spacing.xs) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 10))
-                .foregroundColor(Colors.errorAccent)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize))
+                .foregroundColor(QuickPanelStyle.danger)
 
             Text(error)
-                .font(.system(size: 11))
-                .foregroundColor(Colors.errorText)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
+                .foregroundColor(QuickPanelStyle.danger)
                 .lineLimit(2)
         }
         .padding(Spacing.sm)
-        .background(Colors.errorAccent.opacity(0.1))
-        .cornerRadius(Spacing.radiusMd)
+        .background(QuickPanelStyle.danger.opacity(0.1))
+        .cornerRadius(QuickPanelStyle.radius)
     }
 
     // MARK: - Status View
@@ -426,21 +493,21 @@ struct QuickPanelView: View {
     private func statusView(_ status: String) -> some View {
         let isWarning = status.contains("permission") || status.contains("Permission")
         let icon = isWarning ? "info.circle" : "checkmark.circle"
-        let color = isWarning ? Colors.secondaryText : Color.green
+        let color = isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.success
 
         return HStack(spacing: Spacing.xs) {
             Image(systemName: icon)
-                .font(.system(size: 10))
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize))
                 .foregroundColor(color)
 
             Text(status)
-                .font(.system(size: 11))
-                .foregroundColor(isWarning ? Colors.secondaryText : Colors.primaryText)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
+                .foregroundColor(isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.text)
                 .lineLimit(2)
         }
         .padding(Spacing.sm)
         .background(color.opacity(0.1))
-        .cornerRadius(Spacing.radiusMd)
+        .cornerRadius(QuickPanelStyle.radius)
     }
 
     // MARK: - Actions
@@ -502,8 +569,8 @@ struct QuickPanelInputField: NSViewRepresentable {
         // Appearance
         textView.backgroundColor = .clear
         textView.drawsBackground = false
-        textView.font = NSFont.systemFont(ofSize: 15, weight: .regular)
-        textView.textColor = NSColor(Colors.primaryText)
+        textView.font = NSFont.systemFont(ofSize: QuickPanelStyle.inputSize, weight: .regular)
+        textView.textColor = NSColor(QuickPanelStyle.text)
 
         // Text container - enable word wrapping
         textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
@@ -518,7 +585,7 @@ struct QuickPanelInputField: NSViewRepresentable {
 
         // Remove focus ring and insets
         textView.focusRingType = .none
-        textView.textContainerInset = NSSize(width: 0, height: 2)
+        textView.textContainerInset = NSSize(width: 0, height: QuickPanelStyle.inputInsetY)
 
         textView.string = text
         textView.delegate = context.coordinator
@@ -583,14 +650,14 @@ struct QuickPanelInputField: NSViewRepresentable {
             guard let textView = textView, parent.text.isEmpty else { return }
             isShowingPlaceholder = true
             textView.string = placeholder
-            textView.textColor = NSColor(Colors.tertiaryText)
+            textView.textColor = NSColor(QuickPanelStyle.textSubtle)
         }
 
         func hidePlaceholder() {
             guard let textView = textView, isShowingPlaceholder else { return }
             isShowingPlaceholder = false
             textView.string = ""
-            textView.textColor = NSColor(Colors.primaryText)
+            textView.textColor = NSColor(QuickPanelStyle.text)
         }
 
         func updateScrollViewHeight() {
@@ -608,8 +675,11 @@ struct QuickPanelInputField: NSViewRepresentable {
                 height += layoutManager.extraLineFragmentRect.height
             }
 
-            // Clamp height: min 22pt, max 120pt
-            let finalHeight = min(max(height + 4, 22), 120)
+            let paddedHeight = height + QuickPanelStyle.inputHeightPadding
+            let finalHeight = min(
+                max(paddedHeight, QuickPanelStyle.minInputHeight),
+                QuickPanelStyle.maxInputHeight
+            )
 
             if let heightConstraint = scrollView.constraints.first(where: { $0.firstAttribute == .height }) {
                 heightConstraint.constant = finalHeight
@@ -691,7 +761,7 @@ private struct MarkdownContentView: View {
     let content: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
             ForEach(parseBlocks(content)) { block in
                 switch block {
                 case .text(let text):
@@ -740,16 +810,16 @@ private struct MarkdownTextView: View {
             )
         ) {
             Text(attributed)
-                .font(.system(size: 12))
-                .foregroundColor(Colors.primaryText)
-                .lineSpacing(3)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
+                .foregroundColor(QuickPanelStyle.text)
+                .lineSpacing(QuickPanelStyle.markdownLineSpacing)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
         } else {
             Text(text)
-                .font(.system(size: 12))
-                .foregroundColor(Colors.primaryText)
-                .lineSpacing(3)
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
+                .foregroundColor(QuickPanelStyle.text)
+                .lineSpacing(QuickPanelStyle.markdownLineSpacing)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
         }
@@ -766,25 +836,25 @@ private struct CodeBlockView: View {
             if let lang = language, !lang.isEmpty {
                 HStack {
                     Text(lang.uppercased())
-                        .font(.system(size: 8, weight: .bold, design: .monospaced))
-                        .foregroundColor(Colors.secondaryText)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .bold, design: .monospaced))
+                        .foregroundColor(QuickPanelStyle.textMuted)
                     Spacer()
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Colors.hoverBackground)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.xs)
+                .background(QuickPanelStyle.surfaceMuted)
             }
 
             ScrollView(.horizontal, showsIndicators: false) {
                 Text(code)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(Colors.primaryText)
-                    .padding(8)
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize, design: .monospaced))
+                    .foregroundColor(QuickPanelStyle.text)
+                    .padding(Spacing.sm)
                     .textSelection(.enabled)
             }
         }
-        .background(Colors.hoverBackground.opacity(0.5))
-        .cornerRadius(6)
+        .background(QuickPanelStyle.surfaceMuted.opacity(0.5))
+        .cornerRadius(QuickPanelStyle.radius)
     }
 }
 

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -16,6 +16,7 @@ private struct ContentHeightKey: PreferenceKey {
 struct QuickPanelView: View {
     @ObservedObject var manager: QuickPanelManager
     @FocusState private var isInputFocused: Bool
+    @State private var isPickerExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -70,6 +71,7 @@ struct QuickPanelView: View {
         )
         .onReceive(NotificationCenter.default.publisher(for: .quickPanelDidShow)) { _ in
             isInputFocused = true
+            isPickerExpanded = false
         }
     }
 
@@ -141,49 +143,102 @@ struct QuickPanelView: View {
     // MARK: - Stream Destination Picker
 
     private var streamDestinationPicker: some View {
-        Menu {
-            ForEach(manager.availableStreams, id: \.id) { stream in
-                Button(action: { manager.selectedStreamId = stream.id }) {
-                    HStack {
-                        Text(stream.title)
-                        if manager.selectedStreamId == stream.id {
-                            Spacer()
-                            Image(systemName: "checkmark")
-                        }
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Button(action: {
+                withAnimation(.easeOut(duration: 0.12)) {
+                    isPickerExpanded.toggle()
+                }
+            }) {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: "tray.and.arrow.down")
+                        .font(.system(size: 11))
+                        .foregroundColor(Colors.secondaryText)
+                    Text(selectedStreamTitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(Colors.secondaryText)
+                        .lineLimit(1)
+                    Image(systemName: isPickerExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(Colors.tertiaryText)
+                }
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, Spacing.xs)
+                .background(Colors.hoverBackground)
+                .cornerRadius(Spacing.radiusSm)
+            }
+            .buttonStyle(.plain)
+
+            if isPickerExpanded {
+                streamDestinationOptions
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var streamDestinationOptions: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 1) {
+                ForEach(manager.availableStreams, id: \.id) { stream in
+                    streamOptionButton(title: stream.title, isSelected: manager.selectedStreamId == stream.id) {
+                        manager.selectedStreamId = stream.id
+                        isPickerExpanded = false
                     }
                 }
-            }
 
-            if !manager.availableStreams.isEmpty {
-                Divider()
-            }
+                if !manager.availableStreams.isEmpty {
+                    Divider()
+                        .padding(.vertical, 2)
+                }
 
-            Button(action: { manager.createAndSelectNewStream() }) {
-                HStack {
-                    Image(systemName: "plus")
-                    Text("New Stream...")
+                streamOptionButton(title: "New Stream...", systemImage: "plus", isSelected: false) {
+                    manager.createAndSelectNewStream()
+                    isPickerExpanded = false
                 }
             }
-        } label: {
+            .padding(4)
+        }
+        .frame(maxHeight: 180)
+        .background(Colors.windowBackground)
+        .overlay(
+            RoundedRectangle(cornerRadius: Spacing.radiusSm)
+                .stroke(Colors.secondaryText.opacity(0.16), lineWidth: 1)
+        )
+        .cornerRadius(Spacing.radiusSm)
+    }
+
+    private func streamOptionButton(
+        title: String,
+        systemImage: String? = nil,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
             HStack(spacing: Spacing.xs) {
-                Image(systemName: "tray.and.arrow.down")
-                    .font(.system(size: 11))
-                    .foregroundColor(Colors.secondaryText)
-                Text(selectedStreamTitle)
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(Colors.secondaryText)
+                }
+
+                Text(title)
                     .font(.system(size: 11))
                     .foregroundColor(Colors.secondaryText)
                     .lineLimit(1)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 9))
-                    .foregroundColor(Colors.tertiaryText)
+
+                Spacer(minLength: Spacing.sm)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(Colors.primaryAccent)
+                }
             }
             .padding(.horizontal, Spacing.sm)
-            .padding(.vertical, Spacing.xs)
-            .background(Colors.hoverBackground)
-            .cornerRadius(Spacing.radiusSm)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
+        .buttonStyle(.plain)
     }
 
     private var selectedStreamTitle: String {

--- a/Sources/Ticker/App/QuickPanel/QuickPanelWindow.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelWindow.swift
@@ -13,6 +13,8 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
 
     /// Callback when panel should dismiss
     var onDismiss: (() -> Void)?
+    /// Callback for Escape so all focus states use the same graduated handling.
+    var onEscape: (() -> Void)?
 
     // MARK: - NSPanel Overrides
 
@@ -76,9 +78,9 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
     // MARK: - Keyboard Handling
 
     override func keyDown(with event: NSEvent) {
-        // ESC dismisses the panel
+        // ESC uses the same graduated Quick Panel semantics regardless of focus.
         if event.keyCode == 53 {
-            onDismiss?()
+            onEscape?()
             return
         }
         super.keyDown(with: event)
@@ -86,7 +88,7 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
 
     override func cancelOperation(_ sender: Any?) {
         // ESC via responder chain
-        onDismiss?()
+        onEscape?()
     }
 
     // MARK: - Positioning

--- a/Web/src/components/Settings.tsx
+++ b/Web/src/components/Settings.tsx
@@ -350,14 +350,14 @@ export function Settings({ onClose }: SettingsProps) {
               </div>
             ) : proxyAuth?.state === 'validating' ? (
               <div className="settings-device-key-entry">
-                <p className="settings-hint" style={{ marginTop: 0 }}>
+                <p className="settings-hint settings-hint--flush">
                   Validating device key...
                 </p>
                 <div className="loading-spinner" />
               </div>
             ) : (
               <div className="settings-device-key-entry">
-                <p className="settings-hint" style={{ marginTop: 0 }}>
+                <p className="settings-hint settings-hint--flush">
                   Enter your device key to enable AI features.
                 </p>
                 <div className="settings-key-input">
@@ -428,7 +428,7 @@ export function Settings({ onClose }: SettingsProps) {
           <section className="settings-section">
             <h2>Testing</h2>
             <div className="settings-field">
-              <p className="settings-hint" style={{ marginTop: 0 }}>
+              <p className="settings-hint settings-hint--flush">
                 Help improve Ticker by reporting bugs or suggesting features.
               </p>
 

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -47,23 +47,23 @@ const DEFAULT_SELECTION_MENU_HEIGHT = 44;
 const markdownHighlightStyle = HighlightStyle.define([
   {
     tag: t.heading,
-    color: 'var(--color-text)',
+    color: 'var(--text)',
     textDecoration: 'none',
     fontWeight: '620',
   },
   {
     tag: t.heading1,
-    fontSize: '1.26em',
+    fontSize: 'var(--editor-heading-1)',
     fontWeight: '650',
   },
   {
     tag: t.heading2,
-    fontSize: '1.16em',
+    fontSize: 'var(--editor-heading-2)',
     fontWeight: '640',
   },
   {
     tag: t.heading3,
-    fontSize: '1.08em',
+    fontSize: 'var(--editor-heading-3)',
     fontWeight: '630',
   },
   {
@@ -77,12 +77,12 @@ const markdownHighlightStyle = HighlightStyle.define([
   },
   {
     tag: t.emphasis,
-    color: 'var(--color-text)',
+    color: 'var(--text)',
     fontStyle: 'italic',
   },
   {
     tag: t.strong,
-    color: 'var(--color-text)',
+    color: 'var(--text)',
     fontWeight: '640',
   },
   {

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -3,7 +3,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
-import { Transaction } from '@codemirror/state';
+import { Transaction, type Extension } from '@codemirror/state';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { bridge, Stream, SourceReference } from '../types';
@@ -37,6 +37,12 @@ interface FloatingMenuState {
   left: number;
   top: number;
 }
+
+const SELECTION_MENU_DELAY_MS = 180;
+const SELECTION_MENU_GAP = 10;
+const SELECTION_MENU_HORIZONTAL_INSET = 8;
+const DEFAULT_SELECTION_MENU_WIDTH = 82;
+const DEFAULT_SELECTION_MENU_HEIGHT = 44;
 
 const markdownHighlightStyle = HighlightStyle.define([
   {
@@ -125,9 +131,12 @@ export function StreamEditor({
   const titleInputRef = useRef<HTMLInputElement>(null);
   const editorShellRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
+  const selectionActionMenuRef = useRef<HTMLDivElement>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
+  const showPromptRef = useRef(showPrompt);
+  const isAiThinkingRef = useRef(false);
   const aiRequestRef = useRef<{
     id: string;
     buffer: string;
@@ -527,7 +536,7 @@ export function StreamEditor({
     const doc = view.state.doc;
 
     if (selection.from !== selection.to) {
-      const text = doc.sliceString(selection.from, selection.to);
+      const text = view.state.sliceDoc(selection.from, selection.to);
       return {
         text,
         from: selection.from,
@@ -556,10 +565,10 @@ export function StreamEditor({
 
     const from = doc.line(startLine).from;
     const to = doc.line(endLine).to;
-    let text = doc.sliceString(from, to).trim();
+    let text = view.state.sliceDoc(from, to).trim();
 
     if (!text) {
-      text = doc.toString().trim();
+      text = view.state.sliceDoc(0, doc.length).trim();
       if (!text) return null;
       return {
         text,
@@ -589,51 +598,108 @@ export function StreamEditor({
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
-  const getFloatingMenuPlacement = useCallback((): { left: number; top: number } | null => {
+  const getSelectionMenuPlacement = useCallback((view: EditorView): { left: number; top: number } | null => {
     const shell = editorShellRef.current;
     if (!shell) return null;
 
-    const domSelection = window.getSelection();
-    if (!domSelection || domSelection.rangeCount === 0) return null;
-    if (!domSelection.anchorNode || !domSelection.focusNode) return null;
-    if (!shell.contains(domSelection.anchorNode) || !shell.contains(domSelection.focusNode)) return null;
-    if (domSelection.isCollapsed) return null;
+    const selection = view.state.selection.main;
+    const coords = view.coordsAtPos(selection.head) ?? view.coordsAtPos(selection.anchor);
+    if (!coords) return null;
 
-    const range = domSelection.getRangeAt(0);
-    const rect = range.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) return null;
+    const shellRect = shell.getBoundingClientRect();
+    const menu = selectionActionMenuRef.current;
+    const menuWidth = menu?.offsetWidth ?? DEFAULT_SELECTION_MENU_WIDTH;
+    const menuHeight = menu?.offsetHeight ?? DEFAULT_SELECTION_MENU_HEIGHT;
+    const rawLeft = (coords.left + coords.right) / 2;
+    const minEdge = shellRect.left + SELECTION_MENU_HORIZONTAL_INSET;
+    const maxEdge = shellRect.right - SELECTION_MENU_HORIZONTAL_INSET;
+    const availableWidth = maxEdge - minEdge;
 
-    const horizontalPadding = 16;
-    const left = Math.min(
-      window.innerWidth - horizontalPadding,
-      Math.max(horizontalPadding, rect.left + rect.width / 2),
-    );
-    const top = rect.bottom + 10;
+    const left = availableWidth > menuWidth
+      ? Math.min(maxEdge - menuWidth / 2, Math.max(minEdge + menuWidth / 2, rawLeft))
+      : minEdge + availableWidth / 2;
+
+    const topBoundary = Math.max(0, shellRect.top) + SELECTION_MENU_HORIZONTAL_INSET;
+    const bottomBoundary = Math.min(window.innerHeight, shellRect.bottom) - SELECTION_MENU_HORIZONTAL_INSET;
+    const aboveTop = coords.top - menuHeight - SELECTION_MENU_GAP;
+    const belowTop = coords.bottom + SELECTION_MENU_GAP;
+    const maxTop = Math.max(topBoundary, bottomBoundary - menuHeight);
+    const top = aboveTop >= topBoundary
+      ? aboveTop
+      : Math.min(Math.max(belowTop, topBoundary), maxTop);
 
     return { left, top };
   }, []);
 
-  const scheduleSelectionMenu = useCallback(() => {
+  const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
-    if (showPrompt || isAiThinking) {
-      setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+
+    if (showPromptRef.current || isAiThinkingRef.current) {
+      hideSelectionMenu();
+      return;
+    }
+
+    const selection = view.state.selection.main;
+    if (selection.empty || !view.state.sliceDoc(selection.from, selection.to).trim()) {
+      hideSelectionMenu();
       return;
     }
 
     selectionMenuTimerRef.current = window.setTimeout(() => {
-      const selection = getSelectionContext(false);
-      const placement = getFloatingMenuPlacement();
-      if (!selection || !selection.text.trim() || !placement) {
-        setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+      selectionMenuTimerRef.current = null;
+
+      const currentView = editorViewRef.current;
+      if (!currentView || currentView !== view || showPromptRef.current || isAiThinkingRef.current) {
+        hideSelectionMenu();
         return;
       }
+
+      const currentSelection = currentView.state.selection.main;
+      const selectedText = currentView.state.sliceDoc(currentSelection.from, currentSelection.to);
+      const placement = getSelectionMenuPlacement(currentView);
+      if (currentSelection.empty || !selectedText.trim() || !placement) {
+        hideSelectionMenu();
+        return;
+      }
+
       setFloatingMenu({
         visible: true,
         left: placement.left,
         top: placement.top,
       });
-    }, 180);
-  }, [clearSelectionMenuTimer, getFloatingMenuPlacement, getSelectionContext, isAiThinking, showPrompt]);
+    }, SELECTION_MENU_DELAY_MS);
+  }, [clearSelectionMenuTimer, getSelectionMenuPlacement, hideSelectionMenu]);
+
+  useEffect(() => {
+    showPromptRef.current = showPrompt;
+    isAiThinkingRef.current = isAiThinking;
+
+    if (showPrompt || isAiThinking) {
+      hideSelectionMenu();
+    }
+  }, [hideSelectionMenu, isAiThinking, showPrompt]);
+
+  const selectionMenuExtension = useMemo<Extension>(() => [
+    EditorView.updateListener.of((update) => {
+      const selection = update.state.selection.main;
+
+      if (selection.empty) {
+        if (update.selectionSet || update.docChanged) {
+          hideSelectionMenu();
+        }
+        return;
+      }
+
+      if (update.selectionSet || update.geometryChanged) {
+        scheduleSelectionMenu(update.view);
+      }
+    }),
+    EditorView.domEventHandlers({
+      blur: () => {
+        hideSelectionMenu();
+      },
+    }),
+  ], [hideSelectionMenu, scheduleSelectionMenu]);
 
   const startDocumentAI = useCallback((options: {
     query: string;
@@ -789,46 +855,6 @@ export function StreamEditor({
   }, [clearSelectionMenuTimer]);
 
   useEffect(() => {
-    const handleSelectionChange = () => {
-      const selection = window.getSelection();
-      if (!selection || selection.rangeCount === 0) {
-        hideSelectionMenu();
-        return;
-      }
-      scheduleSelectionMenu();
-    };
-
-    document.addEventListener('selectionchange', handleSelectionChange);
-    return () => document.removeEventListener('selectionchange', handleSelectionChange);
-  }, [hideSelectionMenu, scheduleSelectionMenu]);
-
-  useEffect(() => {
-    if (!floatingMenu.visible) return;
-
-    const updatePlacement = () => {
-      const selection = getSelectionContext(false);
-      const placement = getFloatingMenuPlacement();
-      if (!selection || !placement) {
-        hideSelectionMenu();
-        return;
-      }
-      setFloatingMenu((previous) => ({
-        ...previous,
-        visible: true,
-        left: placement.left,
-        top: placement.top,
-      }));
-    };
-
-    window.addEventListener('resize', updatePlacement);
-    window.addEventListener('scroll', updatePlacement, true);
-    return () => {
-      window.removeEventListener('resize', updatePlacement);
-      window.removeEventListener('scroll', updatePlacement, true);
-    };
-  }, [floatingMenu.visible, getFloatingMenuPlacement, getSelectionContext, hideSelectionMenu]);
-
-  useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       if (!isEditorActive()) return;
       if (!event.clipboardData?.items?.length) return;
@@ -849,14 +875,6 @@ export function StreamEditor({
     window.addEventListener('paste', handlePaste);
     return () => window.removeEventListener('paste', handlePaste);
   }, [insertImageFiles, isEditorActive]);
-
-  useEffect(() => {
-    if (!showPrompt) {
-      scheduleSelectionMenu();
-    } else {
-      hideSelectionMenu();
-    }
-  }, [hideSelectionMenu, scheduleSelectionMenu, showPrompt]);
 
   const handleDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     const files = Array.from(event.dataTransfer.files || []).filter((file) => file.type.startsWith('image/'));
@@ -1001,6 +1019,7 @@ export function StreamEditor({
 
       {floatingMenu.visible && (
         <div
+          ref={selectionActionMenuRef}
           className="selection-action-menu"
           style={{ left: `${floatingMenu.left}px`, top: `${floatingMenu.top}px` }}
         >
@@ -1058,6 +1077,7 @@ export function StreamEditor({
                   autocorrect: 'on',
                 }),
                 EditorView.editable.of(!isAiThinking),
+                selectionMenuExtension,
                 markdown({ base: markdownLanguage, codeLanguages: languages }),
                 syntaxHighlighting(markdownHighlightStyle),
                 markdownConcealExtension,

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -11,6 +11,7 @@ import { SidePanel } from './SidePanel';
 import { SearchModal } from './SearchModal';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
+import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
 
 interface StreamEditorProps {
@@ -1059,6 +1060,7 @@ export function StreamEditor({
                 EditorView.editable.of(!isAiThinking),
                 markdown({ base: markdownLanguage, codeLanguages: languages }),
                 syntaxHighlighting(markdownHighlightStyle),
+                markdownConcealExtension,
                 markdownImageWidgetExtension,
               ]}
               onCreateEditor={(view) => {

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -1,0 +1,111 @@
+import { type Extension, type Range } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+
+const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark']);
+const LINK_CONCEAL_NODE_NAMES = new Set(['LinkMark', 'URL', 'LinkTitle']);
+
+function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boolean {
+  const doc = view.state.doc;
+  const lineEnd = lineTo < doc.length ? lineTo + 1 : lineTo;
+
+  return view.state.selection.ranges.some((range) => {
+    const from = Math.min(range.from, range.to);
+    const to = Math.max(range.from, range.to);
+
+    if (from === to) {
+      const cursorLine = doc.lineAt(from);
+      return cursorLine.from === lineFrom;
+    }
+
+    return lineFrom < to && lineEnd > from;
+  });
+}
+
+function rangeWithFollowingSpace(view: EditorView, from: number, to: number): { from: number; to: number } {
+  if (to >= view.state.doc.length) return { from, to };
+  const nextCharacter = view.state.doc.sliceString(to, to + 1);
+  return nextCharacter === ' ' ? { from, to: to + 1 } : { from, to };
+}
+
+function rangeWithFollowingSpaces(view: EditorView, from: number, to: number): { from: number; to: number } {
+  let end = to;
+  while (end < view.state.doc.length && view.state.doc.sliceString(end, end + 1) === ' ') {
+    end += 1;
+  }
+
+  return { from, to: end };
+}
+
+function concealRange(from: number, to: number): Range<Decoration> | null {
+  if (from >= to) return null;
+  return Decoration.replace({}).range(from, to);
+}
+
+function buildMarkdownConcealDecorations(view: EditorView): DecorationSet {
+  const decorations: Array<Range<Decoration>> = [];
+  const blockquoteLineStarts = new Set<number>();
+  const tree = syntaxTree(view.state);
+
+  for (const visibleRange of view.visibleRanges) {
+    tree.iterate({
+      from: visibleRange.from,
+      to: visibleRange.to,
+      enter: (node) => {
+        const line = view.state.doc.lineAt(node.from);
+        if (isLineSelected(view, line.from, line.to)) return;
+
+        if (node.name === 'HeaderMark') {
+          const range = rangeWithFollowingSpace(view, node.from, node.to);
+          const decoration = concealRange(range.from, range.to);
+          if (decoration) decorations.push(decoration);
+          return;
+        }
+
+        if (node.name === 'QuoteMark') {
+          const range = rangeWithFollowingSpace(view, node.from, node.to);
+          const decoration = concealRange(range.from, range.to);
+          if (decoration) decorations.push(decoration);
+
+          if (!blockquoteLineStarts.has(line.from)) {
+            blockquoteLineStarts.add(line.from);
+            decorations.push(Decoration.line({ class: 'cm-blockquote-line' }).range(line.from));
+          }
+          return;
+        }
+
+        if (MARK_NODE_NAMES.has(node.name)) {
+          const decoration = concealRange(node.from, node.to);
+          if (decoration) decorations.push(decoration);
+          return;
+        }
+
+        if (LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link'])) {
+          const range = node.name === 'URL' ? rangeWithFollowingSpaces(view, node.from, node.to) : { from: node.from, to: node.to };
+          const decoration = concealRange(range.from, range.to);
+          if (decoration) decorations.push(decoration);
+        }
+      },
+    });
+  }
+
+  return Decoration.set(decorations, true);
+}
+
+const markdownConcealPlugin = ViewPlugin.fromClass(class {
+  decorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.decorations = buildMarkdownConcealDecorations(view);
+  }
+
+  update(update: ViewUpdate): void {
+    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+      this.decorations = buildMarkdownConcealDecorations(update.view);
+    }
+  }
+}, {
+  decorations: (value) => value.decorations,
+});
+
+export const markdownConcealExtension: Extension = markdownConcealPlugin;

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -2,7 +2,7 @@ import { type Extension, type Range } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
-const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark']);
+const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark', 'CodeInfo']);
 const LINK_CONCEAL_NODE_NAMES = new Set(['LinkMark', 'URL', 'LinkTitle']);
 
 function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boolean {

--- a/Web/src/extensions/MarkdownImageWidget.ts
+++ b/Web/src/extensions/MarkdownImageWidget.ts
@@ -1,11 +1,11 @@
-import { RangeSetBuilder } from '@codemirror/state';
+import { RangeSetBuilder, type Range } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate, WidgetType } from '@codemirror/view';
 
 const MARKDOWN_IMAGE_TOKEN_REGEX = /!\[([^\]]*)\]\((ticker-asset:\/\/[^)]+)\)(?:\{width=(\d{2,4})\})?/g;
 const MIN_IMAGE_WIDTH = 120;
 const DEFAULT_MAX_IMAGE_WIDTH = 920;
 
-interface MarkdownImageToken {
+export interface MarkdownImageToken {
   raw: string;
   from: number;
   to: number;
@@ -59,7 +59,7 @@ export function extractMarkdownImageUrls(markdownText: string): string[] {
   return urls;
 }
 
-function parseMarkdownImageTokens(text: string): MarkdownImageToken[] {
+export function findImageTokens(text: string, offset = 0): MarkdownImageToken[] {
   const tokens: MarkdownImageToken[] = [];
   const regex = new RegExp(MARKDOWN_IMAGE_TOKEN_REGEX.source, 'g');
 
@@ -75,8 +75,8 @@ function parseMarkdownImageTokens(text: string): MarkdownImageToken[] {
 
     tokens.push({
       raw,
-      from: match.index,
-      to: match.index + raw.length,
+      from: offset + match.index,
+      to: offset + match.index + raw.length,
       alt,
       url: normalizeTickerAssetUrl(url),
       width,
@@ -86,13 +86,19 @@ function parseMarkdownImageTokens(text: string): MarkdownImageToken[] {
   return tokens;
 }
 
+function imageDecorationForToken(token: MarkdownImageToken): Range<Decoration> {
+  return Decoration.replace({
+    widget: new MarkdownImageBlockWidget(token),
+  }).range(token.from, token.to);
+}
+
 class MarkdownImageBlockWidget extends WidgetType {
   constructor(private readonly token: MarkdownImageToken) {
     super();
   }
 
   eq(other: MarkdownImageBlockWidget): boolean {
-    return this.token.raw === other.token.raw && this.token.from === other.token.from && this.token.to === other.token.to;
+    return this.token.raw === other.token.raw;
   }
 
   toDOM(view: EditorView): HTMLElement {
@@ -167,20 +173,75 @@ function buildImageDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   const text = view.state.doc.toString();
 
-  for (const token of parseMarkdownImageTokens(text)) {
-    builder.add(
-      token.from,
-      token.to,
-      Decoration.replace({
-        widget: new MarkdownImageBlockWidget(token),
-      }),
-    );
+  for (const token of findImageTokens(text)) {
+    builder.add(token.from, token.to, Decoration.replace({ widget: new MarkdownImageBlockWidget(token) }));
   }
 
   return builder.finish();
 }
 
-export const markdownImageWidgetExtension = ViewPlugin.fromClass(class {
+function changedLineRanges(update: ViewUpdate): Array<{ from: number; to: number }> {
+  const doc = update.state.doc;
+  const ranges: Array<{ from: number; to: number }> = [];
+
+  update.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
+    if (doc.length === 0) {
+      ranges.push({ from: 0, to: 0 });
+      return;
+    }
+
+    const fromLine = doc.lineAt(Math.min(fromB, doc.length));
+    const toLine = doc.lineAt(Math.min(Math.max(fromB, toB), doc.length));
+    ranges.push({
+      from: fromLine.from,
+      to: toLine.to,
+    });
+  });
+
+  return mergeRanges(ranges);
+}
+
+function mergeRanges(ranges: Array<{ from: number; to: number }>): Array<{ from: number; to: number }> {
+  if (ranges.length < 2) return ranges;
+
+  const sorted = [...ranges].sort((a, b) => a.from - b.from || a.to - b.to);
+  const merged: Array<{ from: number; to: number }> = [];
+
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.from > previous.to) {
+      merged.push({ ...range });
+      continue;
+    }
+
+    previous.to = Math.max(previous.to, range.to);
+  }
+
+  return merged;
+}
+
+function refreshChangedImageDecorations(decorations: DecorationSet, update: ViewUpdate): DecorationSet {
+  let nextDecorations = decorations.map(update.changes);
+  const additions: Array<Range<Decoration>> = [];
+
+  for (const range of changedLineRanges(update)) {
+    nextDecorations = nextDecorations.update({
+      filterFrom: range.from,
+      filterTo: range.to,
+      filter: () => false,
+    });
+
+    const text = update.state.doc.sliceString(range.from, range.to);
+    for (const token of findImageTokens(text, range.from)) {
+      additions.push(imageDecorationForToken(token));
+    }
+  }
+
+  if (additions.length === 0) return nextDecorations;
+  return nextDecorations.update({ add: additions, sort: true });
+}
+
+const markdownImageWidgetPlugin = ViewPlugin.fromClass(class {
   decorations: DecorationSet;
 
   constructor(view: EditorView) {
@@ -188,10 +249,12 @@ export const markdownImageWidgetExtension = ViewPlugin.fromClass(class {
   }
 
   update(update: ViewUpdate): void {
-    if (update.docChanged || update.viewportChanged) {
-      this.decorations = buildImageDecorations(update.view);
-    }
+    if (!update.docChanged) return;
+    this.decorations = refreshChangedImageDecorations(this.decorations, update);
   }
 }, {
   decorations: (value) => value.decorations,
+  provide: (plugin) => EditorView.atomicRanges.of((view) => view.plugin(plugin)?.decorations ?? Decoration.none),
 });
+
+export const markdownImageWidgetExtension = markdownImageWidgetPlugin;

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1,70 +1,113 @@
 :root {
-  /* Warm, refined palette */
+  /* Semantic palette */
+  --bg: #fbfbfa;
+  --surface: #f4f4f2;
+  --surface-raised: #ffffff;
+  --text: #1f1f1d;
+  --text-muted: #6f6f68;
+  --accent: #2563eb;
+  --border: rgba(31, 31, 29, 0.1);
+  --border-subtle: rgba(31, 31, 29, 0.06);
+  --on-accent: #ffffff;
 
-  /* Backgrounds - warmer whites */
-  --color-bg: #fefefe;
-  --color-surface: #f8f8f7;
-  --color-surface-hover: #f2f1ef;
-  --color-surface-active: #eae9e6;
+  --surface-hover: #ecebea;
+  --surface-active: #e2e1de;
+  --text-subtle: #9b9a91;
+  --text-faint: #c8c7bf;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+  --accent-hover: #1d4ed8;
+  --success: #16813d;
+  --warning: #9d6a03;
+  --danger: #c73a32;
+  --success-soft: rgba(22, 129, 61, 0.1);
+  --success-border: rgba(22, 129, 61, 0.22);
+  --warning-soft: rgba(157, 106, 3, 0.14);
+  --danger-soft: rgba(199, 58, 50, 0.1);
+  --danger-hover: rgba(199, 58, 50, 0.18);
+  --danger-border: rgba(199, 58, 50, 0.3);
+  --overlay-scrim: rgba(31, 31, 29, 0.34);
+  --focus-ring: rgba(37, 99, 235, 0.18);
+  --control-shadow: 0 4px 12px rgba(31, 31, 29, 0.12);
 
-  /* Text - warmer, softer contrast */
-  --color-text: #1a1a1a;
-  --color-text-secondary: #6b6b6b;
-  --color-text-tertiary: #9a9a9a;
-  --color-text-muted: #c4c4c4;
+  /* 4px spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 40px;
+  --space-8: 64px;
 
-  /* Accent - refined, confident */
-  --color-accent: #2563eb;
-  --color-accent-soft: rgba(37, 99, 235, 0.08);
-  --color-accent-hover: #1d4ed8;
-  --color-primary: var(--color-accent);
+  /* One shared surface radius and overlay shadow */
+  --radius: 8px;
+  --overlay-shadow: 0 16px 44px rgba(31, 31, 29, 0.16);
+  --overlay-backdrop: blur(10px);
 
-  /* Status */
-  --color-success: #16a34a;
-  --color-warning: #ca8a04;
-  --color-error: #dc2626;
+  /* Type scale */
+  --type-ui-caption: 11px;
+  --type-ui-small: 13px;
+  --type-ui: 15px;
+  --type-ui-title: 17px;
+  --type-ui-display: 28px;
+  --editor-body: 16px;
+  --editor-heading-1: 1.26em;
+  --editor-heading-2: 1.16em;
+  --editor-heading-3: 1.08em;
+  --editor-line-height: 1.58;
 
-  /* Borders - nearly invisible */
-  --color-border: rgba(0, 0, 0, 0.06);
-  --color-border-subtle: rgba(0, 0, 0, 0.03);
-  --color-bg-secondary: var(--color-surface);
-  --color-bg-tertiary: var(--color-surface-hover);
-  --color-surface-elevated: #ffffff;
+  /* Compatibility aliases for existing component CSS */
+  --color-bg: var(--bg);
+  --color-background: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-hover: var(--surface-hover);
+  --color-surface-active: var(--surface-active);
+  --color-surface-elevated: var(--surface-raised);
+  --color-bg-secondary: var(--surface);
+  --color-bg-tertiary: var(--surface-hover);
+  --color-text: var(--text);
+  --color-text-secondary: var(--text-muted);
+  --color-text-tertiary: var(--text-subtle);
+  --color-text-muted: var(--text-faint);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-hover: var(--accent-hover);
+  --color-primary: var(--accent);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-error: var(--danger);
+  --color-border: var(--border);
+  --color-border-subtle: var(--border-subtle);
 
-  /* Generous spacing scale */
-  --spacing-xs: 4px;
-  --spacing-sm: 8px;
-  --spacing-md: 16px;
-  --spacing-lg: 24px;
-  --spacing-xl: 40px;
-  --spacing-xxl: 64px;
+  --spacing-xs: var(--space-1);
+  --spacing-sm: var(--space-2);
+  --spacing-md: var(--space-4);
+  --spacing-lg: var(--space-5);
+  --spacing-xl: var(--space-7);
+  --spacing-xxl: var(--space-8);
 
-  /* Softer corners */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
-  --radius-xl: 20px;
-  --radius-xs: 4px;
+  --radius-xs: var(--radius);
+  --radius-sm: var(--radius);
+  --radius-md: var(--radius);
+  --radius-lg: var(--radius);
+  --radius-xl: var(--radius);
 
-  /* Typography - slightly larger, more readable */
-  --font-size-xs: 11px;
-  --font-size-sm: 13px;
-  --font-size-md: 15px;
-  --font-size-lg: 17px;
+  --font-size-xs: var(--type-ui-caption);
+  --font-size-sm: var(--type-ui-small);
+  --font-size-md: var(--type-ui);
+  --font-size-lg: var(--type-ui-title);
   --font-size-xl: 20px;
-  --font-size-2xl: 28px;
-  --font-size-base: var(--font-size-md);
+  --font-size-2xl: var(--type-ui-display);
+  --font-size-base: var(--type-ui);
   --font-mono: 'SF Mono', 'JetBrains Mono', monospace;
   --font-editor-sans: 'SF Pro Text', -apple-system, BlinkMacSystemFont, system-ui, 'Helvetica Neue', sans-serif;
   --editor-font-family: var(--font-editor-sans);
-  --editor-font-size: 16px;
-  --editor-line-height: 1.55;
+  --editor-font-size: var(--editor-body);
 
-  /* Line heights */
   --line-height-tight: 1.3;
   --line-height-normal: 1.6;
   --line-height-relaxed: 1.8;
-  --shadow-lg: 0 20px 46px rgba(0, 0, 0, 0.16);
+  --shadow-lg: var(--overlay-shadow);
 
   font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
   line-height: var(--line-height-normal);
@@ -119,7 +162,7 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius);
 }
 
 ::-webkit-scrollbar-thumb:hover {
@@ -168,7 +211,7 @@ body {
 
 .stream-list-header button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--control-shadow);
 }
 
 .settings-button {
@@ -299,7 +342,7 @@ body {
 
 .primary-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--control-shadow);
 }
 
 .primary-button:active {
@@ -375,7 +418,7 @@ body {
 .delete-stream-button:hover {
   border-color: var(--color-error);
   color: var(--color-error);
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-soft);
 }
 
 /* Export menu */
@@ -397,7 +440,7 @@ body {
 .export-stream-button:hover {
   border-color: var(--color-accent);
   color: var(--color-accent);
-  background: rgba(59, 130, 246, 0.1);
+  background: var(--accent-soft);
 }
 
 .export-menu-dropdown {
@@ -405,10 +448,10 @@ body {
   top: 100%;
   right: 0;
   margin-top: var(--spacing-xs);
-  background: var(--color-surface);
+  background: var(--surface-raised);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--overlay-shadow);
   z-index: 100;
   min-width: 160px;
   overflow: hidden;
@@ -439,7 +482,7 @@ body {
 .delete-confirm-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -453,12 +496,14 @@ body {
 }
 
 .delete-confirm-dialog {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: var(--spacing-xl);
   max-width: 400px;
   width: 90%;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
   animation: dialog-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -491,7 +536,7 @@ body {
   position: fixed;
   inset: 0;
   z-index: 940;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--overlay-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -500,11 +545,12 @@ body {
 
 .ai-prompt-dialog {
   width: min(520px, 92vw);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: var(--spacing-lg);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
   animation: dialog-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -538,7 +584,7 @@ body {
 
 .ai-prompt-input:focus {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .ai-prompt-actions {
@@ -566,7 +612,7 @@ body {
 .ai-prompt-send {
   background: var(--color-accent);
   border: none;
-  color: white;
+  color: var(--on-accent);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -605,7 +651,7 @@ body {
 .delete-confirm-delete {
   background: var(--color-error);
   border: none;
-  color: white;
+  color: var(--on-accent);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -615,7 +661,8 @@ body {
 }
 
 .delete-confirm-delete:hover {
-  background: #dc2626;
+  background: var(--color-error);
+  opacity: 0.9;
 }
 
 .back-button {
@@ -667,22 +714,20 @@ body {
   transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px;
-  border-radius: 10px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.14),
-    0 1px 2px rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(8px);
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
 }
 
 .selection-action-button {
   width: 30px;
   height: 30px;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -698,7 +743,7 @@ body {
 
 .selection-action-button:hover:not(:disabled) {
   color: var(--color-accent);
-  background: rgba(59, 130, 246, 0.12);
+  background: var(--accent-soft);
   transform: translateY(-1px);
 }
 
@@ -736,13 +781,13 @@ body {
 
 .document-editor-codemirror .cm-scroller {
   font-family: var(--editor-font-family);
-  padding: clamp(22px, 3.6vw, 40px) clamp(20px, 4.6vw, 72px) clamp(220px, 30vh, 360px);
+  padding: clamp(var(--space-5), 3.6vw, var(--space-7)) clamp(var(--space-5), 4.6vw, var(--space-8)) clamp(220px, 30vh, 360px);
   overflow-x: hidden;
   overflow-y: visible;
 }
 
 .document-editor-codemirror .cm-content {
-  max-width: 78ch;
+  max-width: 68ch;
   margin: 0 auto;
   caret-color: var(--color-text);
 }
@@ -758,8 +803,8 @@ body {
 }
 
 .document-editor-codemirror .cm-blockquote-line {
-  padding-left: 0.9em;
-  border-left: 2px solid rgba(59, 130, 246, 0.24);
+  padding-left: var(--space-3);
+  border-left: 2px solid var(--border);
   color: var(--color-text-secondary);
 }
 
@@ -767,7 +812,7 @@ body {
   position: relative;
   display: inline-block;
   max-width: 100%;
-  margin: 0.65em 0 0.95em;
+  margin: var(--space-3) 0 var(--space-4);
   line-height: 0;
 }
 
@@ -776,23 +821,23 @@ body {
   width: auto;
   max-width: 100%;
   min-width: 120px;
-  border-radius: 10px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--control-shadow);
 }
 
 .document-editor-codemirror .cm-md-image-resize-handle {
   position: absolute;
-  right: 8px;
-  bottom: 8px;
+  right: var(--space-2);
+  bottom: var(--space-2);
   width: 18px;
   height: 18px;
-  border-radius: 6px;
-  border: 1px solid rgba(15, 23, 42, 0.14);
-  background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 3px 10px rgba(15, 23, 42, 0.2);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface-raised);
+  box-shadow: var(--control-shadow);
   cursor: nwse-resize;
-  color: rgba(15, 23, 42, 0.56);
+  color: var(--text-muted);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -812,8 +857,8 @@ body {
 }
 
 .document-editor-codemirror .cm-md-image-resize-handle:hover {
-  background: rgba(255, 255, 255, 0.95);
-  color: rgba(15, 23, 42, 0.72);
+  background: var(--surface-hover);
+  color: var(--text);
 }
 
 .document-editor-codemirror .cm-md-image-widget:hover .cm-md-image-resize-handle,
@@ -825,8 +870,8 @@ body {
 .stream-sources-dock {
   display: flex;
   height: 100%;
-  border-left: 1px solid var(--color-border-subtle);
-  background: var(--color-surface);
+  border-left: 1px solid var(--border-subtle);
+  background: var(--bg);
 }
 
 .stream-sources-dock .side-panel {
@@ -834,554 +879,11 @@ body {
   height: 100%;
 }
 
-/* ==================== Block Wrapper ==================== */
-
-.block-wrapper {
-  position: relative;
-  max-width: 780px;
-  margin: 0 auto;
-  padding-left: 34px;
-}
-
-.block-wrapper + .block-wrapper {
-  margin-top: 8px;
-}
-
-.block-wrapper--dragging {
-  opacity: 0.4;
-}
-
-.block-wrapper--drag-over {
-  position: relative;
-}
-
-.block-drop-indicator {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: var(--color-accent);
-  border-radius: 1px;
-  z-index: 100;
-}
-
-.block-wrapper--hovered > .block-content > .cell {
-  background: rgba(0, 0, 0, 0.012);
-}
-
-.block-wrapper:focus-within > .block-controls {
-  opacity: 1;
-}
-
-/* Block controls - appear on hover */
-.block-controls {
-  position: absolute;
-  left: 4px;
-  top: 12px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.14s ease;
-  z-index: 10;
-}
-
-.block-controls--visible {
-  opacity: 1;
-}
-
-/* Info button - appears above drag handle for AI cells */
-.block-info-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.block-info-button:hover {
-  background: var(--color-surface-hover);
-  color: var(--color-accent);
-}
-
-.block-drag-handle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--color-text-tertiary);
-  cursor: grab;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.block-drag-handle:hover {
-  background: var(--color-border);
-  color: var(--color-text-secondary);
-}
-
-.block-drag-handle:active {
-  cursor: grabbing;
-}
-
-.block-indicator {
-  font-size: 12px;
-  line-height: 1;
-}
-
-.block-indicator--live {
-  color: var(--color-accent);
-}
-
-.block-indicator--dependent {
-  color: var(--color-text-tertiary);
-}
-
-.block-content {
-  /* Wrapper for cell content */
-}
-
-/* ==================== Cells ==================== */
-
-.cell {
-  max-width: none;
-  margin: 0;
-  padding: 14px var(--spacing-lg);
-  position: relative;
-  transition: background 0.15s ease;
-  border-radius: var(--radius-md);
-}
-
-/* Tighter spacing between cells for document feel */
-.cell + .cell {
-  margin-top: 0;
-}
-
-.cell:hover {
-  /* Subtle indication without background change */
-}
-
-.cell:focus-within {
-  background: rgba(0, 0, 0, 0.01);
-}
-
-/* AI Response cells */
-.cell--ai {
-  position: relative;
-}
-
-/* AI cell metadata badge - appears on hover in top-right */
-.cell-meta-badge {
-  position: absolute;
-  top: var(--spacing-xs);
-  right: var(--spacing-xs);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: all 0.15s ease;
-  z-index: 5;
-}
-
-.cell:hover .cell-meta-badge {
-  opacity: 1;
-}
-
-.cell-block-wrapper:hover .cell-meta-badge {
-  opacity: 1;
-}
-
-.cell-meta-badge:hover {
-  color: var(--color-text-secondary);
-}
-
-.cell-meta-badge-label {
-  font-family: 'SF Mono', monospace;
-  font-size: 10px;
-  cursor: pointer;
-}
-
-.cell-meta-badge-label:hover {
-  color: var(--color-text-secondary);
-}
-
-.cell-meta-live-toggle {
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: 10px;
-  cursor: pointer;
-  opacity: 0.3;
-  transition: all 0.15s ease;
-}
-
-.cell-meta-live-toggle:hover {
-  opacity: 0.6;
-}
-
-.cell-meta-live-toggle--active {
-  opacity: 1;
-  filter: none;
-}
-
-/* Quote cells */
-.cell--quote {
-  padding-left: calc(var(--spacing-xl) + var(--spacing-md));
-  position: relative;
-}
-
-.cell--quote::before {
-  content: '';
-  position: absolute;
-  left: var(--spacing-xl);
-  top: var(--spacing-lg);
-  bottom: var(--spacing-lg);
-  width: 2px;
-  background: var(--color-success);
-  border-radius: 1px;
-  opacity: 0.5;
-}
-
-/* Restatement - becomes the heading */
-.cell-restatement {
-  font-size: var(--font-size-xl);
-  font-weight: 600;
-  color: var(--color-text);
-  cursor: pointer;
-  padding: var(--spacing-xs) 0;
-  line-height: var(--line-height-tight);
-  letter-spacing: -0.01em;
-  transition: color 0.15s ease;
-}
-
-.cell-restatement:hover {
-  color: var(--color-accent);
-}
-
-/* Inline restatement while editing */
-.cell-restatement-inline {
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  color: var(--color-text-tertiary);
-  padding: var(--spacing-xs) 0;
-  margin-bottom: var(--spacing-sm);
-}
-
-/* Restatement header for AI cells */
-.cell-restatement-header {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--color-text);
-  padding: var(--spacing-xs) 0;
-  margin-bottom: var(--spacing-sm);
-  line-height: var(--line-height-tight);
-  letter-spacing: -0.01em;
-}
-
-/* Animated entrance */
-.cell-restatement--animated {
-  animation: restatement-enter 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes restatement-enter {
-  0% {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* ==================== Prompt Drawer (AI cells) ==================== */
-
-.cell-prompt-header {
-  margin-bottom: var(--spacing-sm);
-}
-
-.cell-prompt-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  background: none;
-  border: none;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  margin-left: calc(-1 * var(--spacing-sm));
-  font-family: inherit;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-tertiary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: all 0.15s ease;
-}
-
-.cell-prompt-toggle:hover {
-  background: var(--color-bg-tertiary);
-  color: var(--color-text-secondary);
-}
-
-.cell-prompt-arrow {
-  font-size: 10px;
-  transition: transform 0.15s ease;
-}
-
-.cell-prompt-label {
-  font-weight: 500;
-}
-
-.cell-prompt-drawer {
-  display: flex;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-sm);
-  padding: var(--spacing-sm);
-  background: var(--color-bg-tertiary);
-  border-radius: var(--radius-md);
-  animation: drawer-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes drawer-enter {
-  0% {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.cell-prompt-input {
-  flex: 1;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  font-family: inherit;
-  font-size: var(--font-size-base);
-  color: var(--color-text);
-  outline: none;
-  transition: border-color 0.15s ease;
-}
-
-.cell-prompt-input:focus {
-  border-color: var(--color-accent);
-}
-
-.cell-prompt-input::placeholder {
-  color: var(--color-text-tertiary);
-}
-
-.cell-prompt-regenerate {
-  background: var(--color-accent);
-  border: none;
-  border-radius: var(--radius-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  font-size: var(--font-size-lg);
-  color: white;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  line-height: 1;
-}
-
-.cell-prompt-regenerate:hover:not(:disabled) {
-  background: var(--color-accent-hover);
-  transform: rotate(45deg);
-}
-
-.cell-prompt-regenerate:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-/* ==================== Cell Editor / TipTap ==================== */
-
-.cell-editor {
-  min-height: 1.5em;
-  cursor: text;
-}
-
-/* Cell images */
-.cell-image {
-  max-width: 100%;
-  height: auto;
-  border-radius: var(--radius-md);
-  margin: var(--spacing-sm) 0;
-  display: block;
-}
-
-.cell-image.ProseMirror-selectednode {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-/* Gap cursor styling - shows cursor before/after block elements like images */
-.ProseMirror .ProseMirror-gapcursor {
-  display: block;
-  position: relative;
-  height: 0;
-  margin: var(--spacing-xs) 0;
-}
-
-.ProseMirror .ProseMirror-gapcursor::after {
-  content: '';
-  display: block;
-  position: absolute;
-  top: -2px;
-  width: 20px;
-  height: 1px;
-  background-color: var(--color-text);
-  animation: gapcursor-blink 1s step-end infinite;
-}
-
-@keyframes gapcursor-blink {
-  50% {
-    opacity: 0;
-  }
-}
-
-/* Image block container (for preserved images in AI cells) */
-.cell-images-block {
-  margin-bottom: var(--spacing-md);
-}
-
-.cell-images-block .cell-image {
-  margin-bottom: var(--spacing-sm);
-}
-
-.cell-images-block .cell-image:last-child {
-  margin-bottom: 0;
-}
-
-.ProseMirror {
-  outline: none;
-  font-size: var(--font-size-md);
-  line-height: 1.72;
-  color: var(--color-text);
-}
-
-.ProseMirror p {
-  margin: 0;
-}
-
-.ProseMirror p + p {
-  margin-top: 0.62em;
-}
-
-.ProseMirror p.is-editor-empty:first-child::before {
-  content: attr(data-placeholder);
-  float: left;
-  color: var(--color-text-muted);
-  pointer-events: none;
-  height: 0;
-}
-
-/* Typography */
-.ProseMirror strong {
-  font-weight: 600;
-}
-
-.ProseMirror em {
-  font-style: italic;
-}
-
-/* Inline code */
-.ProseMirror code {
-  font-family: 'SF Mono', 'JetBrains Mono', monospace;
-  font-size: 0.9em;
-  background: var(--color-surface);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-}
-
-/* Code blocks */
-.ProseMirror pre {
-  background: var(--color-surface);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-md);
-  margin: var(--spacing-md) 0;
-  overflow-x: auto;
-}
-
-.ProseMirror pre code {
-  background: none;
-  padding: 0;
-  font-size: 0.85em;
-  line-height: 1.6;
-}
-
-/* Headings */
-.ProseMirror h1,
-.ProseMirror h2,
-.ProseMirror h3 {
-  font-weight: 600;
-  color: var(--color-text);
-  line-height: var(--line-height-tight);
-  letter-spacing: -0.01em;
-  margin: 1.4em 0 0.46em 0;
-}
-
-.ProseMirror h1:first-child,
-.ProseMirror h2:first-child,
-.ProseMirror h3:first-child {
-  margin-top: 0;
-}
-
-.ProseMirror h1 { font-size: 1.5em; }
-.ProseMirror h2 { font-size: 1.25em; }
-.ProseMirror h3 { font-size: 1.07em; }
-
-/* Lists */
-.ProseMirror ul,
-.ProseMirror ol {
-  padding-left: 1.5em;
-  margin: var(--spacing-sm) 0;
-}
-
-.ProseMirror li {
-  margin: var(--spacing-xs) 0;
-}
-
-.ProseMirror li p {
-  margin: 0;
-}
-
-/* Blockquote */
-.ProseMirror blockquote {
-  border-left: 2px solid var(--color-border);
-  padding-left: var(--spacing-md);
-  margin: var(--spacing-md) 0;
-  color: var(--color-text-secondary);
-}
-
-/* Horizontal rule */
-.ProseMirror hr {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-xl) 0;
-}
-
 /* ==================== Side Panel (sources) ==================== */
 
 .side-panel {
-  background: var(--color-surface);
-  border-left: 1px solid var(--color-border-subtle);
+  background: var(--bg);
+  border-left: 1px solid var(--border-subtle);
   width: 240px;
   flex-shrink: 0;
   display: flex;
@@ -1402,7 +904,8 @@ body {
   align-items: center;
   padding: var(--spacing-sm) var(--spacing-sm);
   gap: var(--spacing-xs);
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg);
   min-height: 44px;
 }
 
@@ -1417,7 +920,7 @@ body {
   color: var(--color-text-tertiary);
   cursor: pointer;
   padding: var(--spacing-xs);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   border-radius: var(--radius-sm);
   transition: color 0.15s ease;
   flex-shrink: 0;
@@ -1459,10 +962,10 @@ body {
 }
 
 .side-panel-tab-count {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   background: var(--color-surface-elevated);
-  padding: 1px 5px;
-  border-radius: 8px;
+  padding: calc(var(--space-1) / 2) var(--space-1);
+  border-radius: var(--radius);
   color: var(--color-text-tertiary);
 }
 
@@ -1470,7 +973,7 @@ body {
   color: var(--color-error);
   font-size: var(--font-size-xs);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-soft);
 }
 
 .side-panel-content {
@@ -1482,7 +985,7 @@ body {
 
 .side-panel-actions {
   padding: var(--spacing-sm);
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .side-panel-add-btn {
@@ -1555,7 +1058,7 @@ body {
 }
 
 .side-panel-item:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
 }
 
@@ -1577,7 +1080,7 @@ body {
 }
 
 .side-panel-item-icon {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
   width: 18px;
   height: 18px;
@@ -1614,12 +1117,12 @@ body {
 .side-panel-item-meta {
   display: flex;
   gap: var(--spacing-sm);
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
 .side-panel-embedding {
-  font-size: 9px;
+  font-size: var(--font-size-xs);
 }
 
 .side-panel-embedding--complete {
@@ -1641,7 +1144,7 @@ body {
 }
 
 .side-panel-badge {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   line-height: 1;
 }
 
@@ -1650,8 +1153,8 @@ body {
   border: none;
   color: var(--color-text-muted);
   cursor: pointer;
-  padding: 2px 4px;
-  font-size: 14px;
+  padding: calc(var(--space-1) / 2) var(--space-1);
+  font-size: var(--font-size-sm);
   line-height: 1;
   border-radius: var(--radius-sm);
   opacity: 0;
@@ -1664,7 +1167,7 @@ body {
 
 .side-panel-item-remove:hover {
   color: var(--color-error);
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-soft);
 }
 
 /* ==================== Search Modal ==================== */
@@ -1675,7 +1178,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-scrim);
   display: flex;
   justify-content: center;
   padding-top: 15vh;
@@ -1683,14 +1186,16 @@ body {
 }
 
 .search-modal {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   width: 100%;
   max-width: 560px;
   max-height: 60vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
   overflow: hidden;
 }
 
@@ -1698,12 +1203,12 @@ body {
   display: flex;
   align-items: center;
   padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
   gap: var(--spacing-sm);
 }
 
 .search-modal-icon {
-  font-size: 16px;
+  font-size: var(--font-size-md);
   opacity: 0.6;
 }
 
@@ -1721,7 +1226,7 @@ body {
 }
 
 .search-modal-spinner {
-  font-size: 14px;
+  font-size: var(--font-size-sm);
   animation: spin 1s linear infinite;
 }
 
@@ -1752,7 +1257,7 @@ body {
 }
 
 .search-modal-section-divider {
-  border-top: 1px solid var(--color-border-subtle);
+  border-top: 1px solid var(--border-subtle);
   margin-top: var(--spacing-sm);
   padding-top: var(--spacing-md);
 }
@@ -1791,7 +1296,7 @@ body {
 }
 
 .search-result-icon {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   width: 20px;
   height: 20px;
   display: flex;
@@ -1833,7 +1338,7 @@ body {
 }
 
 .search-result-badge {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
 }
 
@@ -1887,7 +1392,7 @@ body {
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-accent);
-  color: white;
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -1897,116 +1402,7 @@ body {
 }
 
 .search-modal-go-button:hover {
-  background: var(--color-accent-hover, #2563eb);
-}
-
-/* ==================== Streaming & Error States ==================== */
-
-.cell--streaming {
-  /* Keep it subtle */
-}
-
-.cell--streaming .ProseMirror::after {
-  content: '';
-  display: inline-block;
-  width: 2px;
-  height: 1em;
-  background: var(--color-accent);
-  margin-left: 2px;
-  animation: cursor-blink 1s step-end infinite;
-  vertical-align: text-bottom;
-}
-
-@keyframes cursor-blink {
-  50% { opacity: 0; }
-}
-
-.cell--error::before {
-  background: var(--color-error) !important;
-}
-
-.cell-error-message {
-  color: var(--color-error);
-  font-size: var(--font-size-sm);
-  padding: var(--spacing-sm) 0;
-}
-
-/* Error banner - shows above content without replacing it */
-.cell-error-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-xs) var(--spacing-sm);
-  background: rgba(220, 38, 38, 0.1);
-  border: 1px solid rgba(220, 38, 38, 0.2);
-  border-radius: var(--radius-sm);
-  margin-bottom: var(--spacing-sm);
-  font-size: var(--font-size-sm);
-}
-
-.cell-error-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  background: var(--color-error);
-  color: white;
-  border-radius: 50%;
-  font-size: 11px;
-  font-weight: 600;
-  flex-shrink: 0;
-}
-
-.cell-error-text {
-  flex: 1;
-  color: var(--color-error);
-}
-
-.cell-error-dismiss {
-  background: transparent;
-  border: none;
-  color: var(--color-error);
-  font-size: var(--font-size-xs);
-  cursor: pointer;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border-radius: var(--radius-sm);
-  transition: background 0.15s ease;
-}
-
-.cell-error-dismiss:hover {
-  background: rgba(220, 38, 38, 0.15);
-}
-
-/* Refreshing state (live blocks, cascade updates) */
-.cell--refreshing {
-  position: relative;
-}
-
-.cell--refreshing::before {
-  background: var(--color-accent) !important;
-  animation: refresh-pulse 1.5s ease-in-out infinite;
-}
-
-.cell--refreshing .ProseMirror {
-  opacity: 0.7;
-}
-
-.cell--refreshing::after {
-  content: 'Refreshing...';
-  position: absolute;
-  top: var(--spacing-xs);
-  right: var(--spacing-sm);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  background: var(--color-surface);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-}
-
-@keyframes refresh-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+  background: var(--color-accent-hover);
 }
 
 /* ==================== Settings ==================== */
@@ -2047,7 +1443,7 @@ body {
 
 .settings-close:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--control-shadow);
 }
 
 .settings-content {
@@ -2142,9 +1538,9 @@ body {
 
 .settings-delete-key {
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  border: 1px solid var(--danger-border);
   border-radius: var(--radius-md);
-  background: rgba(220, 38, 38, 0.1);
+  background: var(--danger-soft);
   color: var(--color-error);
   font-size: var(--font-size-sm);
   cursor: pointer;
@@ -2152,8 +1548,8 @@ body {
 }
 
 .settings-delete-key:hover {
-  background: rgba(220, 38, 38, 0.2);
-  border-color: rgba(220, 38, 38, 0.5);
+  background: var(--danger-hover);
+  border-color: var(--color-error);
 }
 
 .settings-hint {
@@ -2161,6 +1557,10 @@ body {
   color: var(--color-text-tertiary);
   margin: 0;
   line-height: var(--line-height-relaxed);
+}
+
+.settings-hint--flush {
+  margin-top: 0;
 }
 
 .settings-error {
@@ -2187,12 +1587,12 @@ body {
   display: inline-flex;
   align-items: center;
   padding: var(--spacing-xs) var(--spacing-sm);
-  background: rgba(22, 163, 74, 0.1);
+  background: var(--success-soft);
   color: var(--color-success);
   font-size: var(--font-size-sm);
   font-weight: 500;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(22, 163, 74, 0.2);
+  border: 1px solid var(--success-border);
 }
 
 .settings-device-key-support-id {
@@ -2203,7 +1603,7 @@ body {
 .settings-device-key-support-id code {
   font-family: 'SF Mono', monospace;
   background: var(--color-surface);
-  padding: 2px 6px;
+  padding: calc(var(--space-1) / 2) var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--color-text);
 }
@@ -2223,7 +1623,7 @@ body {
 .settings-disconnect-btn:hover {
   border-color: var(--color-error);
   color: var(--color-error);
-  background: rgba(220, 38, 38, 0.05);
+  background: var(--danger-soft);
 }
 
 .settings-device-key-entry {
@@ -2305,24 +1705,24 @@ body {
 .usage-badge {
   font-size: var(--font-size-xs);
   font-weight: 600;
-  padding: 2px 6px;
+  padding: calc(var(--space-1) / 2) var(--space-2);
   border-radius: var(--radius-sm);
 }
 
 .usage-badge--warning {
-  background: rgba(202, 138, 4, 0.15);
+  background: var(--warning-soft);
   color: var(--color-warning);
 }
 
 .usage-badge--error {
-  background: rgba(220, 38, 38, 0.15);
+  background: var(--danger-soft);
   color: var(--color-error);
 }
 
 .usage-bar {
   height: 8px;
   background: var(--color-surface);
-  border-radius: 4px;
+  border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--color-border);
 }
@@ -2330,7 +1730,7 @@ body {
 .usage-bar-fill {
   height: 100%;
   background: var(--color-accent);
-  border-radius: 3px;
+  border-radius: var(--radius);
   transition: width 0.3s ease;
 }
 
@@ -2365,7 +1765,7 @@ body {
 }
 
 .classifier-ready {
-  color: var(--color-success, #22c55e);
+  color: var(--color-success);
 }
 
 .classifier-loading {
@@ -2373,7 +1773,7 @@ body {
 }
 
 .classifier-error {
-  color: var(--color-error, #ef4444);
+  color: var(--color-error);
 }
 
 .settings-toggle-label {
@@ -2494,7 +1894,7 @@ body {
   font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
   background: var(--color-surface);
-  padding: 2px 6px;
+  padding: calc(var(--space-1) / 2) var(--space-2);
   border-radius: var(--radius-sm);
 }
 
@@ -2508,8 +1908,8 @@ body {
 
 .settings-editor-slider::-webkit-slider-runnable-track {
   height: 6px;
-  border-radius: 999px;
-  background: #e6e8ec;
+  border-radius: var(--radius);
+  background: var(--surface-hover);
 }
 
 .settings-editor-slider::-webkit-slider-thumb {
@@ -2521,13 +1921,13 @@ body {
   border-radius: 50%;
   border: none;
   background: var(--color-accent);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 0 0 1px var(--border);
 }
 
 .settings-editor-slider::-moz-range-track {
   height: 6px;
-  border-radius: 999px;
-  background: #e6e8ec;
+  border-radius: var(--radius);
+  background: var(--surface-hover);
 }
 
 .settings-editor-slider::-moz-range-thumb {
@@ -2536,7 +1936,7 @@ body {
   border: none;
   border-radius: 50%;
   background: var(--color-accent);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 0 0 1px var(--border);
 }
 
 .settings-editor-preview {
@@ -2551,547 +1951,6 @@ body {
 .settings-editor-preview p {
   margin: 0;
 }
-
-/* ==================== Action Menu ==================== */
-
-.action-menu {
-  position: fixed;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-  min-width: 220px;
-  max-width: 300px;
-  z-index: 1000;
-  overflow: hidden;
-  padding: var(--spacing-xs);
-}
-
-.action-menu-item {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  width: 100%;
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  text-align: left;
-  color: inherit;
-  font: inherit;
-  transition: background-color 0.1s ease;
-}
-
-.action-menu-item:hover,
-.action-menu-item.selected {
-  background: var(--color-surface);
-}
-
-.action-menu-item.selected {
-  background: var(--color-text);
-  color: var(--color-bg);
-}
-
-.action-menu-item.selected .action-description {
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.action-name {
-  font-weight: 500;
-  font-size: var(--font-size-md);
-}
-
-.action-description {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-/* ==================== Reference System ==================== */
-
-/* Inline cell reference styling */
-.cell-reference {
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-decoration: none;
-}
-
-.cell-reference:hover {
-  background: var(--color-accent);
-  color: white;
-}
-
-/* Reference preview tooltip */
-.reference-preview {
-  position: fixed;
-  z-index: 1000;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-  padding: var(--spacing-sm) var(--spacing-md);
-  max-width: 320px;
-  min-width: 200px;
-  cursor: pointer;
-}
-
-.reference-preview--below {
-  animation: preview-fade-in-below 0.15s ease;
-}
-
-.reference-preview--above {
-  animation: preview-fade-in-above 0.15s ease forwards;
-}
-
-@keyframes preview-fade-in-below {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes preview-fade-in-above {
-  from {
-    opacity: 0;
-    transform: translateY(calc(-100% + 4px));
-  }
-  to {
-    opacity: 1;
-    transform: translateY(-100%);
-  }
-}
-
-.reference-preview:hover {
-  border-color: var(--color-accent);
-}
-
-.reference-preview-title {
-  font-weight: 600;
-  font-size: var(--font-size-sm);
-  color: var(--color-text);
-  margin-bottom: var(--spacing-xs);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.reference-preview-content {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.reference-preview-hint {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-  margin-top: var(--spacing-xs);
-  padding-top: var(--spacing-xs);
-  border-top: 1px solid var(--color-border);
-}
-
-/* Reference suggestion dropdown */
-.reference-suggestion-list {
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-  min-width: 240px;
-  max-width: 360px;
-  max-height: 400px;
-  overflow-y: auto;
-  padding: var(--spacing-xs);
-}
-
-.reference-suggestion-item {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-  width: 100%;
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  text-align: left;
-  color: inherit;
-  font: inherit;
-  transition: background-color 0.1s ease;
-}
-
-.reference-suggestion-item--active {
-  background: var(--color-text);
-  color: var(--color-bg);
-}
-
-.reference-suggestion-item--active .reference-suggestion-id {
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.reference-suggestion-item--empty {
-  color: var(--color-text-tertiary);
-  cursor: default;
-}
-
-.reference-suggestion-item--empty:hover {
-  background: transparent;
-}
-
-.reference-suggestion-label {
-  font-weight: 500;
-  font-size: var(--font-size-sm);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-}
-
-.reference-suggestion-id {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-  font-family: 'SF Mono', monospace;
-}
-
-/* Dependency indicators */
-.cell-dependency-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-  margin-left: var(--spacing-sm);
-}
-
-.cell-dependency-indicator--has-deps {
-  color: var(--color-accent);
-}
-
-/* Stale cell indicator (dependency changed) */
-.cell--stale {
-  position: relative;
-}
-
-.cell--stale::after {
-  content: 'Needs refresh';
-  position: absolute;
-  top: var(--spacing-xs);
-  right: var(--spacing-sm);
-  font-size: var(--font-size-xs);
-  color: var(--color-warning);
-  background: rgba(202, 138, 4, 0.1);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-}
-
-/* Cell refresh button */
-.cell-refresh-button {
-  position: absolute;
-  top: var(--spacing-xs);
-  right: var(--spacing-sm);
-  background: transparent;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-tertiary);
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  font-size: var(--font-size-xs);
-  cursor: pointer;
-  opacity: 0;
-  transition: all 0.15s ease;
-}
-
-.cell:hover .cell-refresh-button {
-  opacity: 1;
-}
-
-.cell-refresh-button:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-}
-
-/* Reference navigation highlight */
-.block-wrapper--highlighted {
-  animation: highlight-fade 2s ease-out;
-}
-
-@keyframes highlight-fade {
-  0% {
-    background: var(--color-accent-soft);
-    border-radius: var(--radius-md);
-  }
-  100% {
-    background: transparent;
-  }
-}
-
-/* ==================== Cell Overlay ==================== */
-
-.cell-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.65);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-md);
-  z-index: 50;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-  animation: overlay-fade-in 0.15s ease;
-}
-
-@keyframes overlay-fade-in {
-  from {
-    opacity: 0;
-    transform: scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-.cell-overlay-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.cell-overlay-title {
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.cell-overlay-close {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--color-text-tertiary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.cell-overlay-close:hover {
-  background: var(--color-surface-hover);
-  color: var(--color-text);
-}
-
-.cell-overlay-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-}
-
-.cell-overlay-label {
-  font-size: var(--font-size-xs);
-  font-weight: 500;
-  color: var(--color-text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.cell-overlay-prompt-row {
-  display: flex;
-  gap: var(--spacing-xs);
-  align-items: flex-start;
-}
-
-.cell-overlay-prompt-row .prompt-editor {
-  flex: 1;
-  font-size: var(--font-size-sm);
-  font-family: inherit;
-  color: var(--color-text);
-  line-height: 1.5;
-  background: var(--color-surface);
-  padding: var(--spacing-sm);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border-subtle);
-  min-height: 2.5em;
-  max-height: 150px;
-  overflow-y: auto;
-  transition: border-color 0.15s ease;
-}
-
-.cell-overlay-prompt-row .prompt-editor:focus-within {
-  border-color: var(--color-accent);
-}
-
-.prompt-editor .ProseMirror {
-  outline: none;
-  font-size: var(--font-size-sm);
-  line-height: 1.5;
-}
-
-.prompt-editor .ProseMirror p {
-  margin: 0;
-}
-
-.prompt-editor .ProseMirror p.is-editor-empty:first-child::before {
-  content: attr(data-placeholder);
-  float: left;
-  color: var(--color-text-tertiary);
-  pointer-events: none;
-  height: 0;
-}
-
-.cell-overlay-regenerate {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: var(--color-accent);
-  border: none;
-  border-radius: var(--radius-sm);
-  color: white;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  flex-shrink: 0;
-}
-
-.cell-overlay-regenerate:hover:not(:disabled) {
-  background: var(--color-accent-hover);
-}
-
-.cell-overlay-regenerate:hover:not(:disabled) svg {
-  transform: rotate(45deg);
-}
-
-.cell-overlay-regenerate svg {
-  transition: transform 0.2s ease;
-}
-
-.cell-overlay-regenerate:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.cell-overlay-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.cell-overlay-model {
-  font-family: 'SF Mono', monospace;
-  font-weight: 500;
-  color: var(--color-text);
-}
-
-.cell-overlay-separator {
-  color: var(--color-text-tertiary);
-}
-
-.cell-overlay-time {
-  color: var(--color-text-tertiary);
-}
-
-.cell-overlay-live {
-  color: var(--color-accent);
-  font-weight: 500;
-}
-
-.cell-overlay-dependency {
-  color: var(--color-success);
-  font-weight: 500;
-}
-
-.cell-overlay-references {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xs);
-}
-
-.cell-overlay-ref-link {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-full);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.cell-overlay-ref-link:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-}
-
-/* Live toggle in overlay */
-.cell-overlay-live-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  width: 100%;
-  padding: var(--spacing-sm);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-align: left;
-}
-
-.cell-overlay-live-toggle:hover {
-  border-color: var(--color-text-tertiary);
-}
-
-.cell-overlay-live-toggle--active {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-}
-
-.cell-overlay-live-toggle--active:hover {
-  border-color: var(--color-accent);
-}
-
-.cell-overlay-live-icon {
-  font-size: 14px;
-  opacity: 0.3;
-  transition: opacity 0.15s ease;
-}
-
-.cell-overlay-live-toggle--active .cell-overlay-live-icon {
-  opacity: 1;
-}
-
-.cell-overlay-live-text {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.cell-overlay-live-toggle--active .cell-overlay-live-text {
-  color: var(--color-accent);
-}
-
 
 /* ==================== Appearance Settings ==================== */
 
@@ -3296,7 +2155,7 @@ body {
   right: 0;
   padding: var(--spacing-xs) var(--spacing-sm);
   background: var(--color-error);
-  color: white;
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-xs);
   font-size: var(--font-size-xs);
@@ -3310,7 +2169,7 @@ body {
 .settings-feedback-submit {
   padding: var(--spacing-sm) var(--spacing-lg);
   background: var(--color-accent);
-  color: white;
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
@@ -3329,14 +2188,14 @@ body {
 }
 
 .settings-success {
-  color: var(--color-success, #22c55e);
+  color: var(--color-success);
   font-size: var(--font-size-sm);
   margin-top: var(--spacing-sm);
 }
 
 .settings-success code {
   background: var(--color-surface);
-  padding: 2px 6px;
+  padding: calc(var(--space-1) / 2) var(--space-2);
   border-radius: var(--radius-xs);
   font-family: var(--font-mono);
 }
@@ -3361,280 +2220,40 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg: #1a1a1a;
-    --color-surface: #242424;
-    --color-surface-hover: #2e2e2e;
-    --color-surface-active: #383838;
-    --color-surface-elevated: #2e2e2e;
+    --bg: #1c1c1b;
+    --surface: #242423;
+    --surface-raised: #2b2b29;
+    --text: #f3f2ed;
+    --text-muted: #aaa79d;
+    --accent: #8aa8ff;
+    --border: rgba(243, 242, 237, 0.12);
+    --border-subtle: rgba(243, 242, 237, 0.07);
+    --on-accent: #111110;
 
-    --color-text: #f5f5f5;
-    --color-text-secondary: #a0a0a0;
-    --color-text-tertiary: #707070;
-    --color-text-muted: #505050;
-
-    --color-border: rgba(255, 255, 255, 0.1);
-    --color-border-subtle: rgba(255, 255, 255, 0.05);
-
-    --color-accent-soft: rgba(37, 99, 235, 0.15);
-  }
-
-  .cell-overlay {
-    background: rgba(30, 30, 30, 0.75);
-  }
-
-  .block-wrapper--hovered > .block-content > .cell {
-    background: rgba(255, 255, 255, 0.02);
+    --surface-hover: #30302e;
+    --surface-active: #393936;
+    --text-subtle: #77746c;
+    --text-faint: #56534e;
+    --accent-soft: rgba(138, 168, 255, 0.16);
+    --accent-hover: #a8bdff;
+    --success: #68b982;
+    --warning: #d5a13a;
+    --danger: #ee7f76;
+    --success-soft: rgba(104, 185, 130, 0.14);
+    --success-border: rgba(104, 185, 130, 0.3);
+    --warning-soft: rgba(213, 161, 58, 0.18);
+    --danger-soft: rgba(238, 127, 118, 0.14);
+    --danger-hover: rgba(238, 127, 118, 0.22);
+    --danger-border: rgba(238, 127, 118, 0.32);
+    --overlay-scrim: rgba(0, 0, 0, 0.42);
+    --focus-ring: rgba(138, 168, 255, 0.24);
+    --control-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
+    --overlay-shadow: 0 16px 44px rgba(0, 0, 0, 0.32);
   }
 
   .settings-appearance-btn {
     background: var(--color-surface);
   }
-
-  .cell-block-wrapper--hovered .cell-block-content {
-    background: rgba(255, 255, 255, 0.02);
-  }
-}
-
-/* ============================================
-   UNIFIED EDITOR STYLES (Slice 01+)
-   ============================================ */
-
-.unified-editor-container {
-  padding: var(--spacing-lg) var(--spacing-lg) calc(var(--spacing-lg) + var(--stream-end-scroll-space)) var(--spacing-lg);
-}
-
-.unified-editor-content {
-  max-width: 720px;
-  margin: 0 auto;
-  /* Left padding to prevent hover controls (left: -36px) from being clipped */
-  padding-left: 40px;
-}
-
-/* Cell Block Wrapper - similar to block-wrapper */
-.cell-block-wrapper {
-  position: relative;
-  margin: 0 auto;
-  max-width: 720px;
-}
-
-.cell-block-wrapper + .cell-block-wrapper {
-  margin-top: 2px;
-}
-
-.cell-block-wrapper--hovered .cell-block-content {
-  background: rgba(0, 0, 0, 0.015);
-}
-
-/* Cell Block Controls - appear on hover, left side */
-.cell-block-controls {
-  position: absolute;
-  left: -36px;
-  top: 8px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  z-index: 10;
-}
-
-.cell-block-controls--visible {
-  opacity: 1;
-}
-
-.cell-block-info-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.cell-block-info-button:hover {
-  background: var(--color-surface-hover);
-  color: var(--color-accent);
-}
-
-.cell-block-drag-handle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--color-text-tertiary);
-  cursor: grab;
-  border-radius: var(--radius-sm);
-  transition: all 0.1s ease;
-}
-
-.cell-block-drag-handle:hover {
-  background: var(--color-border);
-  color: var(--color-text-secondary);
-}
-
-.cell-block-indicator {
-  font-size: 12px;
-  line-height: 1;
-}
-
-.cell-block-indicator--live {
-  color: var(--color-accent);
-}
-
-.cell-block-indicator--dependent {
-  color: var(--color-text-secondary);
-}
-
-.cell-block-indicator--streaming {
-  display: flex;
-  align-items: center;
-  color: var(--color-accent);
-}
-
-.cell-block-spinner {
-  animation: spin 1s linear infinite;
-}
-
-/* Streaming state - show subtle background */
-.cell-block-wrapper--streaming {
-  background: var(--color-surface);
-  border-radius: var(--radius-sm);
-}
-
-/* Thinking window - blurred scrolling pseudo-text during AI streaming */
-.thinking-window {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  border-radius: var(--radius-sm);
-  /* Gradient mask for fade-out at top and bottom */
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 20%,
-    black 80%,
-    transparent 100%
-  );
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 20%,
-    black 80%,
-    transparent 100%
-  );
-}
-
-.thinking-window-scroll {
-  animation: thinking-scroll 12s linear infinite;
-  filter: blur(5px);
-  opacity: 0.4;
-  color: var(--color-text-secondary);
-  padding: var(--spacing-md);
-  font-size: var(--font-size-sm);
-  line-height: 1.8;
-}
-
-.thinking-window-line {
-  margin: 0 0 var(--spacing-sm) 0;
-}
-
-@keyframes thinking-scroll {
-  0% {
-    transform: translateY(0);
-  }
-  100% {
-    transform: translateY(-50%);
-  }
-}
-
-/* Reduced motion fallback */
-.thinking-window-fallback {
-  display: none;
-  position: absolute;
-  inset: 0;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
-}
-
-.thinking-dots span {
-  animation: thinking-dot 1.4s infinite;
-  animation-fill-mode: both;
-}
-
-.thinking-dots span:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.thinking-dots span:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes thinking-dot {
-  0%, 80%, 100% {
-    opacity: 0.3;
-  }
-  40% {
-    opacity: 1;
-  }
-}
-
-/* Respect prefers-reduced-motion */
-@media (prefers-reduced-motion: reduce) {
-  .thinking-window-scroll {
-    display: none;
-  }
-
-  .thinking-window-fallback {
-    display: flex;
-  }
-}
-
-/* Cell Block Content - the editable area */
-.cell-block-content {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--radius-sm);
-  min-height: 1.6em;
-}
-
-.cell-block-content p {
-  margin: 0;
-}
-
-.cell-block-content p + p {
-  margin-top: 0.5em;
-}
-
-/* Drag reorder polish */
-.is-cell-dragging {
-  user-select: none;
-  cursor: grabbing !important;
-}
-
-.is-cell-dragging * {
-  cursor: grabbing !important;
-}
-
-.cell-block-wrapper--drag-target {
-  background: var(--color-surface-hover);
-  border-radius: var(--radius-sm);
-}
-
-.cell-block-wrapper--dragging {
-  opacity: 0.5;
 }
 
 /* ==================== Toasts ==================== */
@@ -3655,12 +2274,13 @@ body {
   align-items: flex-start;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
   border-left-width: 4px;
-  border-radius: var(--radius-md);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius);
+  box-shadow: var(--overlay-shadow);
   color: var(--color-text);
+  backdrop-filter: var(--overlay-backdrop);
 }
 
 .toast[data-kind='error'] {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -757,6 +757,12 @@ body {
   word-break: break-word;
 }
 
+.document-editor-codemirror .cm-blockquote-line {
+  padding-left: 0.9em;
+  border-left: 2px solid rgba(59, 130, 246, 0.24);
+  color: var(--color-text-secondary);
+}
+
 .document-editor-codemirror .cm-md-image-widget {
   position: relative;
   display: inline-block;

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -93,15 +93,16 @@ If you hit SwiftPM/Sparkle artifact issues, run:
 
 ## Quick Panel (capture + ephemeral chat)
 
-Quick Panel is the fast capture surface (hotkey-driven) and has two distinct modes:
+Quick Panel is the fast capture surface (hotkey-driven) and has three distinct modes:
 
-- **Save** (`↵`): saves captured context and/or your input into a stream.
-- **AI + Save** (`⌘↵`): saves, then triggers AI on the saved stream context.
+- **Save** (`↵`): appends captured context and/or your input directly to the selected stream document, shows “Saved to <stream>”, then hides.
+- **AI + Save** (`⌘↵`): appends to the selected stream document, shows “Saved to <stream> — asking AI…”, then hides while the AI answer appends in the background.
 - **Ask (ephemeral)** (`⌥↵`): runs an in-memory chat turn that is **not** saved to the stream DB.
 
 Cancellation / escape behavior:
 - `Esc` cancels streaming + clears the ephemeral chat (if active).
-- Otherwise `Esc` clears input/context; a second `Esc` hides the panel.
+- Otherwise `Esc` clears input/context; the next `Esc` hides the panel.
+- Clicking outside the panel hides it immediately.
 
 ## Drag & drop (native → stream)
 
@@ -112,7 +113,7 @@ You can drag files from Finder directly onto the app window:
 
 Notes:
 - Drops are routed to the **most recently opened stream**.
-- If no stream has been opened yet, Ticker shows an error toast (“Open a stream before dropping files.”).
+- If no stream is open, dropping a PDF creates a new stream; other files show “Drop files in a stream, or return to Streams to create one from PDF.”
 
 ## Local data (what exists on disk)
 


### PR DESCRIPTION
The visible-quality phase per docs/PRODUCTION_READINESS_PLAN.md Phase 3. Stacked on #25.

- **Image widget**: surgical decoration updates (map-through-changes + changed-lines rescan), content-keyed `eq()`, atomic cursor traversal — kills the type/scroll flicker and O(doc) scans.
- **Live markdown concealment** (`MarkdownConceal.ts`): iA/Obsidian-style rendering — heading/emphasis/code/link/quote marks conceal except on selection lines; blockquotes get a left border; link URLs hide behind styled labels; code-fence info concealed. Syntax-tree driven, visible ranges only.
- **Selection popover** rebuilt on CodeMirror state (`updateListener` + `coordsAtPos`) — replaces the DOM `selectionchange` mechanism that silently failed in WKWebView. The "missing" selection menu now appears reliably.
- **Quick panel ergonomics**: graduated Esc from any focus, in-panel stream dropdown (eliminates the Menu blur-dismiss race), and a "✓ Saved to <stream>" confirmation beat before hiding. START_HERE.md updated to match reality.
- **Design tokens**: semantic color/type/spacing/radius/shadow tokens with light+dark values; one overlay surface language (search/settings/prompt/toasts/selection menu); ~68ch centered editor measure; Quick Panel + PDF pane header aligned to the same palette; dead cell-era CSS removed.

Verification: typecheck/build/swift-test green per task; live GUI verification of concealment (real streams), image rendering, selection popover, and the full quick-panel matrix (save feedback, dropdown-keeps-panel-open, Esc graduation) — screenshots in session log.

**Open item:** dark-mode visual pass needs one human glance — the dark token block is in, but live system-appearance toggling misbehaved in my automated session (app window stayed light; likely a macOS automation quirk rather than app code — worth confirming by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)