### PR TITLE
Phase 4: shell decomposition + bridge hardening

### DIFF
--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -23,6 +23,7 @@ struct TickerApp {
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var mainWindow: NSWindow?
+    private var serviceContainer: ServiceContainer?
     private var webViewManager: WebViewManager?
     private var onboardingWindow: NSWindow?
     private var didCompleteStartup = false
@@ -59,8 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func completeStartup() {
         guard !didCompleteStartup else { return }
         didCompleteStartup = true
-        setupMainWindow()
-        setupQuickPanel()
+        let container = ServiceContainer()
+        serviceContainer = container
+        setupMainWindow(container: container)
+        setupQuickPanel(container: container)
         requestAccessibilityPermissionIfNeeded()
         // Apply initial appearance after Quick Panel is set up
         Task { @MainActor in
@@ -290,7 +293,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    private func setupMainWindow() {
+    private func setupMainWindow(container: ServiceContainer) {
         // Position window to cover right 3/8 of screen
         let screen = NSScreen.main ?? NSScreen.screens.first!
         let screenFrame = screen.visibleFrame
@@ -315,7 +318,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         mainWindow?.level = .floating  // Always on top
         mainWindow?.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
-        webViewManager = WebViewManager()
+        webViewManager = WebViewManager(container: container)
         mainWindow?.contentView = webViewManager?.rootView
         webViewManager?.load()
 
@@ -324,21 +327,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     // MARK: - Quick Panel Setup
 
-    private func setupQuickPanel() {
+    private func setupQuickPanel(container: ServiceContainer) {
         // Initialize Quick Panel manager on main actor
         Task { @MainActor in
             let manager = QuickPanelManager()
             self.quickPanelManager = manager
-
-            // Configure with services from WebViewManager
-            if let wvm = self.webViewManager,
-               let persistence = wvm.persistence {
-                manager.configure(
-                    persistence: persistence,
-                    bridgeService: wvm.bridgeService,
-                    orchestrator: wvm.orchestrator
-                )
-            }
+            manager.configure(container: container)
         }
 
         // Initialize hotkey service

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+final class AIMessageHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "thinkDocument"
+    ]
+
+    private let persistence: PersistenceService
+    private let bridgeService: BridgeService
+    private let assetService: AssetService
+    private let orchestrator: AIOrchestrator
+    private let deviceKeyService: DeviceKeyService
+
+    init?(container: ServiceContainer) {
+        guard let persistence = container.persistence else { return nil }
+        self.persistence = persistence
+        self.bridgeService = container.bridgeService
+        self.assetService = container.assetService
+        self.orchestrator = container.orchestrator
+        self.deviceKeyService = container.deviceKeyService
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "thinkDocument":
+            guard let payload = message.payload,
+                  let requestId = payload["requestId"]?.value as? String,
+                  let query = payload["query"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid thinkDocument payload")
+                return
+            }
+
+            let imageURLs = payload["imageURLs"]?.value as? [String] ?? []
+            let imageDataURLs = assetService.assetsToDataURLs(imageURLs)
+            if !imageDataURLs.isEmpty {
+                DebugLog.log("ThinkDocument: Converting \(imageURLs.count) images to data URLs")
+            }
+
+            var streamIdForRAG: UUID? = nil
+            var sourceContext: String? = nil
+
+            if let streamIdValue = payload["streamId"]?.value as? String,
+               let streamId = UUID(uuidString: streamIdValue) {
+                streamIdForRAG = streamId
+
+                if let stream = try? persistence.loadStream(id: streamId) {
+                    let combinedText = stream.sources
+                        .compactMap { $0.extractedText }
+                        .joined(separator: "\n\n---\n\n")
+                    if !combinedText.isEmpty {
+                        sourceContext = combinedText
+                    }
+                }
+            }
+
+            var resolvedQuery = query
+            if let context = payload["context"]?.value as? String, !context.isEmpty {
+                let cleanContext = context
+                    .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                    .replacingOccurrences(of: "&nbsp;", with: " ")
+                    .replacingOccurrences(of: "&amp;", with: "&")
+                    .replacingOccurrences(of: "&lt;", with: "<")
+                    .replacingOccurrences(of: "&gt;", with: ">")
+                    .replacingOccurrences(of: "&quot;", with: "\"")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if !cleanContext.isEmpty {
+                    resolvedQuery = "Regarding this context:\n\"\"\"\n\(cleanContext)\n\"\"\"\n\n\(resolvedQuery)"
+                }
+            }
+
+            let onChunk: (String) -> Void = { [weak self] chunk in
+                self?.bridgeService.send(BridgeMessage(
+                    type: "documentAIChunk",
+                    payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
+                ))
+            }
+            let onComplete: () -> Void = { [weak self] in
+                self?.bridgeService.send(BridgeMessage(
+                    type: "documentAIComplete",
+                    payload: ["requestId": AnyCodable(requestId)]
+                ))
+            }
+            let onError: (Error) -> Void = { [weak self] error in
+                var payload: [String: AnyCodable] = [
+                    "requestId": AnyCodable(requestId),
+                    "error": AnyCodable(error.localizedDescription)
+                ]
+
+                if let proxyError = error as? ProxyLLMError {
+                    payload["errorCode"] = AnyCodable(proxyError.errorCode)
+                    if let proxyRequestId = proxyError.requestId {
+                        payload["proxyRequestId"] = AnyCodable(proxyRequestId)
+                    }
+
+                    if case .quotaExceeded(let details) = proxyError {
+                        payload["quotaScope"] = AnyCodable(details.scope)
+                        payload["quotaLimit"] = AnyCodable(details.limit)
+                        payload["quotaUsed"] = AnyCodable(details.used)
+                        payload["quotaResetAt"] = AnyCodable(details.resetAt)
+                    }
+
+                    if case .rateLimited(let retryAfter) = proxyError {
+                        if let seconds = retryAfter {
+                            payload["retryAfter"] = AnyCodable(seconds)
+                        }
+                    }
+                }
+
+                self?.bridgeService.send(BridgeMessage(
+                    type: "documentAIError",
+                    payload: payload
+                ))
+            }
+
+            Task { [weak self] in
+                guard let self else { return }
+
+                let proxyUsable = await self.deviceKeyService.currentState.isUsable
+
+                guard proxyUsable else {
+                    await MainActor.run {
+                        onError(OrchestratorError.noProviderAvailable)
+                    }
+                    return
+                }
+
+                await self.orchestrator.route(
+                    query: resolvedQuery,
+                    queryImages: imageDataURLs,
+                    streamId: streamIdForRAG,
+                    priorCells: [],
+                    sourceContext: sourceContext,
+                    includeHeading: false,
+                    onChunk: onChunk,
+                    onComplete: onComplete,
+                    onError: onError,
+                    onModelSelected: { [weak self] modelId in
+                        self?.bridgeService.send(BridgeMessage(
+                            type: "documentModelSelected",
+                            payload: ["requestId": AnyCodable(requestId), "modelId": AnyCodable(modelId)]
+                        ))
+                    }
+                )
+            }
+
+        default:
+            DebugLog.log("[AIMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+}

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -27,6 +27,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                   let requestId = payload["requestId"]?.value as? String,
                   let query = payload["query"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid thinkDocument payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid thinkDocument payload")
                 return
             }
 

--- a/Sources/Ticker/App/Bridge/BridgeRouter.swift
+++ b/Sources/Ticker/App/Bridge/BridgeRouter.swift
@@ -5,6 +5,11 @@ protocol BridgeMessageHandler {
 
 final class BridgeRouter {
     private var handlersByType: [String: BridgeMessageHandler] = [:]
+    private let bridgeService: BridgeService
+
+    init(bridgeService: BridgeService) {
+        self.bridgeService = bridgeService
+    }
 
     func register(_ handler: BridgeMessageHandler) {
         for type in handler.handledTypes {
@@ -18,6 +23,7 @@ final class BridgeRouter {
     func route(_ message: BridgeMessage) async {
         guard let handler = handlersByType[message.type] else {
             DebugLog.log("[BridgeRouter] Unknown message type: \(message.type)")
+            await bridgeService.sendBridgeError(type: message.type, reason: "Unknown bridge message type")
             return
         }
 

--- a/Sources/Ticker/App/Bridge/BridgeRouter.swift
+++ b/Sources/Ticker/App/Bridge/BridgeRouter.swift
@@ -1,0 +1,26 @@
+protocol BridgeMessageHandler {
+    var handledTypes: Set<String> { get }
+    func handle(_ message: BridgeMessage) async
+}
+
+final class BridgeRouter {
+    private var handlersByType: [String: BridgeMessageHandler] = [:]
+
+    func register(_ handler: BridgeMessageHandler) {
+        for type in handler.handledTypes {
+            if handlersByType[type] != nil {
+                DebugLog.log("[BridgeRouter] Replacing handler for message type: \(type)")
+            }
+            handlersByType[type] = handler
+        }
+    }
+
+    func route(_ message: BridgeMessage) async {
+        guard let handler = handlersByType[message.type] else {
+            DebugLog.log("[BridgeRouter] Unknown message type: \(message.type)")
+            return
+        }
+
+        await handler.handle(message)
+    }
+}

--- a/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
+++ b/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+final class ProxyAuthHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "loadProxyAuth",
+        "setProxyDeviceKey",
+        "clearProxyDeviceKey",
+        "validateProxyDeviceKey",
+        "refreshProxyAuth",
+        "submitFeedback",
+        "getSupportBundle"
+    ]
+
+    private let bridgeService: BridgeService
+    private let deviceKeyService: DeviceKeyService
+
+    init(container: ServiceContainer) {
+        self.bridgeService = container.bridgeService
+        self.deviceKeyService = container.deviceKeyService
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "loadProxyAuth":
+            // Pure read of cached state - no network call
+            guard let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid loadProxyAuth payload")
+                return
+            }
+            Task {
+                let auth = await self.deviceKeyService.loadProxyAuth()
+                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
+
+                await MainActor.run {
+                    var response: [String: AnyCodable] = [
+                        "state": AnyCodable(auth.state.rawValue),
+                        "supportId": AnyCodable(auth.supportId as Any),
+                        "deviceId": AnyCodable(auth.deviceId)
+                    ]
+
+                    // Include limits if available
+                    if let limits = limits {
+                        response["limits"] = AnyCodable([
+                            "reqsPerMin": limits.reqsPerMin as Any,
+                            "tokensPerDay": limits.tokensPerDay as Any,
+                            "tokensPerMonth": limits.tokensPerMonth as Any
+                        ])
+                    }
+
+                    // Include usage if available
+                    if let usage = usage {
+                        response["usage"] = AnyCodable([
+                            "reqsThisMinute": usage.reqsThisMinute as Any,
+                            "tokensToday": usage.tokensToday as Any,
+                            "tokensThisMonth": usage.tokensThisMonth as Any,
+                            "dayResetAt": usage.dayResetAt as Any,
+                            "monthResetAt": usage.monthResetAt as Any
+                        ])
+                    }
+
+                    bridgeService.respond(to: callbackId, with: response)
+                }
+            }
+
+        case "setProxyDeviceKey":
+            guard let payload = message.payload,
+                  let key = payload["key"]?.value as? String,
+                  let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid setProxyDeviceKey payload")
+                return
+            }
+            Task {
+                do {
+                    let result = try await self.deviceKeyService.setProxyDeviceKey(key)
+                    let newAuth = await self.deviceKeyService.loadProxyAuth()
+                    await MainActor.run {
+                        bridgeService.respond(to: callbackId, with: [
+                            "success": AnyCodable(true),
+                            "state": AnyCodable(newAuth.state.rawValue),
+                            "supportId": AnyCodable(result.supportId),
+                            "limits": AnyCodable([
+                                "reqsPerMin": result.limits?.reqsPerMin as Any,
+                                "tokensPerDay": result.limits?.tokensPerDay as Any,
+                                "tokensPerMonth": result.limits?.tokensPerMonth as Any
+                            ]),
+                            "usage": AnyCodable([
+                                "reqsThisMinute": result.usage?.reqsThisMinute as Any,
+                                "tokensToday": result.usage?.tokensToday as Any,
+                                "tokensThisMonth": result.usage?.tokensThisMonth as Any,
+                                "dayResetAt": result.usage?.dayResetAt as Any,
+                                "monthResetAt": result.usage?.monthResetAt as Any
+                            ])
+                        ])
+                    }
+                } catch {
+                    let newAuth = await self.deviceKeyService.loadProxyAuth()
+                    await MainActor.run {
+                        bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+                        // Also push state change
+                        bridgeService.send(BridgeMessage(
+                            type: "proxyAuthState",
+                            payload: ["state": AnyCodable(newAuth.state.rawValue)]
+                        ))
+                    }
+                }
+            }
+
+        case "clearProxyDeviceKey":
+            guard let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid clearProxyDeviceKey payload")
+                return
+            }
+            Task {
+                await self.deviceKeyService.clearProxyDeviceKey()
+                let newAuth = await self.deviceKeyService.loadProxyAuth()
+                await MainActor.run {
+                    bridgeService.respond(to: callbackId, with: [
+                        "success": AnyCodable(true),
+                        "state": AnyCodable(newAuth.state.rawValue)
+                    ])
+                }
+            }
+
+        case "validateProxyDeviceKey", "refreshProxyAuth":
+            // Re-validate cached key with server and return fresh limits/usage
+            guard let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid validateProxyDeviceKey/refreshProxyAuth payload")
+                return
+            }
+            Task {
+                await self.deviceKeyService.revalidate()
+                let newAuth = await self.deviceKeyService.loadProxyAuth()
+                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
+
+                await MainActor.run {
+                    var response: [String: AnyCodable] = [
+                        "state": AnyCodable(newAuth.state.rawValue),
+                        "supportId": AnyCodable(newAuth.supportId as Any),
+                        "deviceId": AnyCodable(newAuth.deviceId)
+                    ]
+
+                    if let limits = limits {
+                        response["limits"] = AnyCodable([
+                            "reqsPerMin": limits.reqsPerMin as Any,
+                            "tokensPerDay": limits.tokensPerDay as Any,
+                            "tokensPerMonth": limits.tokensPerMonth as Any
+                        ])
+                    }
+
+                    if let usage = usage {
+                        response["usage"] = AnyCodable([
+                            "reqsThisMinute": usage.reqsThisMinute as Any,
+                            "tokensToday": usage.tokensToday as Any,
+                            "tokensThisMonth": usage.tokensThisMonth as Any,
+                            "dayResetAt": usage.dayResetAt as Any,
+                            "monthResetAt": usage.monthResetAt as Any
+                        ])
+                    }
+
+                    bridgeService.respond(to: callbackId, with: response)
+                }
+            }
+
+        case "submitFeedback":
+            guard let callbackId = message.callbackId,
+                  let payload = message.payload,
+                  let feedbackType = payload["type"]?.value as? String,
+                  let title = payload["title"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid submitFeedback payload")
+                return
+            }
+            let description = payload["description"]?.value as? String
+            let screenshotBase64 = payload["screenshot"]?.value as? String
+            let screenshotContentType = payload["screenshotContentType"]?.value as? String
+
+            Task {
+                do {
+                    let feedbackId = try await self.deviceKeyService.submitFeedback(
+                        type: feedbackType,
+                        title: title,
+                        description: description,
+                        screenshotBase64: screenshotBase64,
+                        screenshotContentType: screenshotContentType
+                    )
+                    await MainActor.run {
+                        bridgeService.respond(to: callbackId, with: [
+                            "success": AnyCodable(true),
+                            "feedbackId": AnyCodable(feedbackId)
+                        ])
+                    }
+                } catch {
+                    await MainActor.run {
+                        bridgeService.respond(to: callbackId, with: [
+                            "success": AnyCodable(false),
+                            "error": AnyCodable(error.localizedDescription)
+                        ])
+                    }
+                }
+            }
+
+        case "getSupportBundle":
+            guard let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid getSupportBundle payload")
+                return
+            }
+            Task {
+                let bundle = await self.deviceKeyService.getSupportBundle()
+                await MainActor.run {
+                    bridgeService.respond(to: callbackId, with: [
+                        "bundle": AnyCodable(bundle)
+                    ])
+                }
+            }
+
+        default:
+            DebugLog.log("[ProxyAuthHandler] Unknown message type: \(message.type)")
+        }
+    }
+}

--- a/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
+++ b/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
@@ -25,6 +25,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
             // Pure read of cached state - no network call
             guard let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid loadProxyAuth payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for loadProxyAuth")
                 return
             }
             Task {
@@ -67,6 +68,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
                   let key = payload["key"]?.value as? String,
                   let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid setProxyDeviceKey payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid setProxyDeviceKey payload")
                 return
             }
             Task {
@@ -108,6 +110,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
         case "clearProxyDeviceKey":
             guard let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid clearProxyDeviceKey payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for clearProxyDeviceKey")
                 return
             }
             Task {
@@ -125,6 +128,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
             // Re-validate cached key with server and return fresh limits/usage
             guard let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid validateProxyDeviceKey/refreshProxyAuth payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for validateProxyDeviceKey/refreshProxyAuth")
                 return
             }
             Task {
@@ -167,6 +171,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
                   let feedbackType = payload["type"]?.value as? String,
                   let title = payload["title"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid submitFeedback payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid submitFeedback payload")
                 return
             }
             let description = payload["description"]?.value as? String
@@ -201,6 +206,7 @@ final class ProxyAuthHandler: BridgeMessageHandler {
         case "getSupportBundle":
             guard let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid getSupportBundle payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for getSupportBundle")
                 return
             }
             Task {

--- a/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
@@ -22,13 +22,15 @@ final class SearchMessageHandler: BridgeMessageHandler {
                   let currentStreamId = UUID(uuidString: currentStreamIdStr),
                   let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid hybridSearch payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid hybridSearch payload")
                 return
             }
 
-            let limit = payload["limit"]?.value as? Int ?? 20
+            let limit = payload["limit"]?.intValue ?? 20
 
             guard let searchService = searchService else {
                 Task { @MainActor in
+                    bridgeService.sendBridgeError(type: message.type, reason: "Search service not available")
                     bridgeService.respondWithError(to: callbackId, error: "Search service not available")
                 }
                 return

--- a/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+final class SearchMessageHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "hybridSearch"
+    ]
+
+    private let bridgeService: BridgeService
+    private let searchService: SearchService?
+
+    init(container: ServiceContainer) {
+        self.bridgeService = container.bridgeService
+        self.searchService = container.searchService
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "hybridSearch":
+            guard let payload = message.payload,
+                  let query = payload["query"]?.value as? String,
+                  let currentStreamIdStr = payload["currentStreamId"]?.value as? String,
+                  let currentStreamId = UUID(uuidString: currentStreamIdStr),
+                  let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid hybridSearch payload")
+                return
+            }
+
+            let limit = payload["limit"]?.value as? Int ?? 20
+
+            guard let searchService = searchService else {
+                Task { @MainActor in
+                    bridgeService.respondWithError(to: callbackId, error: "Search service not available")
+                }
+                return
+            }
+
+            Task {
+                do {
+                    let results = try await searchService.hybridSearch(
+                        query: query,
+                        currentStreamId: currentStreamId,
+                        limit: limit
+                    )
+
+                    // Encode results to JSON-compatible format
+                    let encoder = JSONEncoder()
+                    let data = try encoder.encode(results)
+                    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+
+                    await MainActor.run {
+                        bridgeService.respond(to: callbackId, with: [
+                            "currentStreamResults": AnyCodable(json["currentStreamResults"]),
+                            "otherStreamResults": AnyCodable(json["otherStreamResults"])
+                        ])
+                    }
+                } catch {
+                    await MainActor.run {
+                        bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+                    }
+                }
+            }
+
+        default:
+            DebugLog.log("[SearchMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+}

--- a/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+final class SettingsMessageHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "loadSettings",
+        "saveSettings"
+    ]
+
+    private let settingsService: SettingsService
+    private let bridgeService: BridgeService
+    private let settingsProvider: () -> [String: Any]
+
+    init(container: ServiceContainer, settingsProvider: @escaping () -> [String: Any]) {
+        self.settingsService = container.settingsService
+        self.bridgeService = container.bridgeService
+        self.settingsProvider = settingsProvider
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "loadSettings":
+            let settings = settingsProvider()
+            bridgeService.send(BridgeMessage(
+                type: "settingsLoaded",
+                payload: ["settings": AnyCodable(settings)]
+            ))
+
+        case "saveSettings":
+            guard let payload = message.payload else {
+                DebugLog.log("[WebViewManager] Invalid saveSettings payload")
+                return
+            }
+
+            // Save OpenAI API key if provided
+            if let openaiKey = payload["openaiAPIKey"]?.value as? String {
+                settingsService.openaiAPIKey = openaiKey.isEmpty ? nil : openaiKey
+            }
+
+            // Save Anthropic API key if provided
+            if let anthropicKey = payload["anthropicAPIKey"]?.value as? String {
+                settingsService.anthropicAPIKey = anthropicKey.isEmpty ? nil : anthropicKey
+            }
+
+            // Save Perplexity API key if provided
+            if let perplexityKey = payload["perplexityAPIKey"]?.value as? String {
+                settingsService.perplexityAPIKey = perplexityKey.isEmpty ? nil : perplexityKey
+            }
+
+            // Save smart routing setting if provided
+            if let smartRouting = payload["smartRoutingEnabled"]?.value as? Bool {
+                settingsService.smartRoutingEnabled = smartRouting
+            }
+
+            // Save default model setting if provided
+            if let modelValue = payload["defaultModel"]?.value as? String,
+               let model = SettingsService.DefaultModel(rawValue: modelValue) {
+                settingsService.defaultModel = model
+            }
+
+            // Save appearance setting if provided
+            if let appearanceValue = payload["appearance"]?.value as? String,
+               let appearance = SettingsService.Appearance(rawValue: appearanceValue) {
+                settingsService.appearance = appearance
+                // Notify AppDelegate to update window appearances
+                NotificationCenter.default.post(name: .appearanceDidChange, object: nil)
+            }
+
+            // Save diagnostics setting if provided
+            if let diagnosticsEnabled = payload["diagnosticsEnabled"]?.value as? Bool {
+                settingsService.diagnosticsEnabled = diagnosticsEnabled
+            }
+
+            // Save editor font setting if provided
+            if let editorFontValue = payload["editorFont"]?.value as? String,
+               let editorFont = SettingsService.EditorFont(rawValue: editorFontValue) {
+                settingsService.editorFont = editorFont
+            }
+
+            // Save editor font size setting if provided
+            if let editorFontSize = payload["editorFontSize"]?.value as? Double {
+                settingsService.editorFontSize = editorFontSize
+            } else if let editorFontSize = payload["editorFontSize"]?.value as? NSNumber {
+                settingsService.editorFontSize = editorFontSize.doubleValue
+            }
+
+            // Save editor line spacing setting if provided
+            if let editorLineSpacing = payload["editorLineSpacing"]?.value as? Double {
+                settingsService.editorLineSpacing = editorLineSpacing
+            } else if let editorLineSpacing = payload["editorLineSpacing"]?.value as? NSNumber {
+                settingsService.editorLineSpacing = editorLineSpacing.doubleValue
+            }
+
+            // Send back updated settings
+            let settings = settingsProvider()
+            bridgeService.send(BridgeMessage(
+                type: "settingsLoaded",
+                payload: ["settings": AnyCodable(settings)]
+            ))
+
+        default:
+            DebugLog.log("[SettingsMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+}

--- a/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
@@ -28,6 +28,7 @@ final class SettingsMessageHandler: BridgeMessageHandler {
         case "saveSettings":
             guard let payload = message.payload else {
                 DebugLog.log("[WebViewManager] Invalid saveSettings payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveSettings payload")
                 return
             }
 
@@ -77,17 +78,13 @@ final class SettingsMessageHandler: BridgeMessageHandler {
             }
 
             // Save editor font size setting if provided
-            if let editorFontSize = payload["editorFontSize"]?.value as? Double {
+            if let editorFontSize = payload["editorFontSize"]?.doubleValue {
                 settingsService.editorFontSize = editorFontSize
-            } else if let editorFontSize = payload["editorFontSize"]?.value as? NSNumber {
-                settingsService.editorFontSize = editorFontSize.doubleValue
             }
 
             // Save editor line spacing setting if provided
-            if let editorLineSpacing = payload["editorLineSpacing"]?.value as? Double {
+            if let editorLineSpacing = payload["editorLineSpacing"]?.doubleValue {
                 settingsService.editorLineSpacing = editorLineSpacing
-            } else if let editorLineSpacing = payload["editorLineSpacing"]?.value as? NSNumber {
-                settingsService.editorLineSpacing = editorLineSpacing.doubleValue
             }
 
             // Send back updated settings

--- a/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
@@ -60,6 +60,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let streamId = UUID(uuidString: streamIdValue),
                   let sourceService else {
                 DebugLog.log("[WebViewManager] Invalid addSource payload or service unavailable")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid addSource payload or service unavailable")
                 return
             }
 
@@ -93,6 +94,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let filePath = payload["path"]?.value as? String,
                   let sourceService else {
                 DebugLog.log("[WebViewManager] Invalid addSourceFromPath payload or service unavailable")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid addSourceFromPath payload or service unavailable")
                 return
             }
 
@@ -112,6 +114,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let id = UUID(uuidString: idValue),
                   let sourceService else {
                 DebugLog.log("[WebViewManager] Invalid removeSource payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid removeSource payload")
                 return
             }
             do {
@@ -131,6 +134,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let sourceId = UUID(uuidString: sourceIdValue),
                   let sourceService else {
                 DebugLog.log("[WebViewManager] Invalid openSource payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid openSource payload")
                 return
             }
 
@@ -154,6 +158,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let imageData = Data(base64Encoded: base64Data) else {
                 DebugLog.log("[WebViewManager] Invalid saveImage payload")
                 let requestId = message.payload?["requestId"]?.value as? String
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveImage payload")
                 bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
                     "error": AnyCodable("Invalid image data"),
                     "requestId": AnyCodable(requestId as Any)
@@ -185,6 +190,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
             guard let payload = message.payload,
                   let relativePath = payload["relativePath"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid getAssetPath payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid getAssetPath payload")
                 return
             }
             let fullPath = assetService.assetURL(for: relativePath).path

--- a/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
@@ -1,0 +1,206 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+protocol SourceMessageHandlerDelegate: AnyObject {
+    func setFileDropContext(streamId: UUID?, allowsListFileDrops: Bool)
+    func hidePDFPane() async
+    func openSourceReference(_ source: SourceReference, sourceService: SourceService)
+}
+
+final class SourceMessageHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "setFileDropContext",
+        "addSource",
+        "addSourceFromPath",
+        "removeSource",
+        "openSource",
+        "saveImage",
+        "getAssetPath"
+    ]
+
+    private let persistence: PersistenceService
+    private let bridgeService: BridgeService
+    private let sourceService: SourceService?
+    private let assetService: AssetService
+    private weak var delegate: SourceMessageHandlerDelegate?
+
+    init?(container: ServiceContainer, delegate: SourceMessageHandlerDelegate) {
+        guard let persistence = container.persistence else { return nil }
+        self.persistence = persistence
+        self.bridgeService = container.bridgeService
+        self.sourceService = container.sourceService
+        self.assetService = container.assetService
+        self.delegate = delegate
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "setFileDropContext":
+            let mode = message.payload?["mode"]?.value as? String
+            switch mode {
+            case "stream":
+                if let streamIdValue = message.payload?["streamId"]?.value as? String,
+                   let streamId = UUID(uuidString: streamIdValue) {
+                    delegate?.setFileDropContext(streamId: streamId, allowsListFileDrops: false)
+                } else {
+                    delegate?.setFileDropContext(streamId: nil, allowsListFileDrops: false)
+                }
+            case "list":
+                delegate?.setFileDropContext(streamId: nil, allowsListFileDrops: true)
+                await delegate?.hidePDFPane()
+            default:
+                delegate?.setFileDropContext(streamId: nil, allowsListFileDrops: false)
+                await delegate?.hidePDFPane()
+            }
+
+        case "addSource":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let sourceService else {
+                DebugLog.log("[WebViewManager] Invalid addSource payload or service unavailable")
+                return
+            }
+
+            // Must run on main thread for NSOpenPanel
+            await MainActor.run {
+                let panel = NSOpenPanel()
+                panel.canChooseFiles = true
+                panel.canChooseDirectories = false
+                panel.allowsMultipleSelection = false
+                // Note: "net.daringfireball.markdown" is the standard UTI for markdown files
+                let markdownType = UTType(filenameExtension: "md") ?? UTType.plainText
+                panel.allowedContentTypes = [.pdf, .plainText, .text, .sourceCode, markdownType, .png, .jpeg, .heic, .image]
+                panel.message = "Select a file to attach"
+
+                if panel.runModal() == .OK, let url = panel.url {
+                    do {
+                        let source = try sourceService.addSource(from: url, to: streamId)
+                        let sourcePayload = StreamCodec.encodeSource(source)
+                        bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
+                    } catch {
+                        DebugLog.log("[WebViewManager] Failed to add source (\(DebugLog.errorSummary(error)))")
+                        bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
+                    }
+                }
+            }
+
+        case "addSourceFromPath":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let filePath = payload["path"]?.value as? String,
+                  let sourceService else {
+                DebugLog.log("[WebViewManager] Invalid addSourceFromPath payload or service unavailable")
+                return
+            }
+
+            let url = URL(fileURLWithPath: filePath)
+            do {
+                let source = try sourceService.addSource(from: url, to: streamId)
+                let sourcePayload = StreamCodec.encodeSource(source)
+                bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to add source from path (\(DebugLog.errorSummary(error)))")
+                bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
+            }
+
+        case "removeSource":
+            guard let payload = message.payload,
+                  let idValue = payload["id"]?.value as? String,
+                  let id = UUID(uuidString: idValue),
+                  let sourceService else {
+                DebugLog.log("[WebViewManager] Invalid removeSource payload")
+                return
+            }
+            do {
+                try sourceService.removeSource(id: id)
+                bridgeService.send(BridgeMessage(type: "sourceRemoved", payload: ["id": AnyCodable(id.uuidString)]))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to remove source (\(DebugLog.errorSummary(error)))")
+                bridgeService.send(BridgeMessage(type: "sourceRemoveError", payload: [
+                    "id": AnyCodable(id.uuidString),
+                    "error": AnyCodable(error.localizedDescription)
+                ]))
+            }
+
+        case "openSource":
+            guard let payload = message.payload,
+                  let sourceIdValue = payload["sourceId"]?.value as? String,
+                  let sourceId = UUID(uuidString: sourceIdValue),
+                  let sourceService else {
+                DebugLog.log("[WebViewManager] Invalid openSource payload")
+                return
+            }
+
+            do {
+                guard let source = try persistence.loadSource(id: sourceId) else {
+                    sendSourceError("Source not found.")
+                    return
+                }
+                delegate?.openSourceReference(source, sourceService: sourceService)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to open source (\(DebugLog.errorSummary(error)))")
+                sendSourceError(error.localizedDescription)
+            }
+
+        case "saveImage":
+            // Save base64-encoded image data to stream's assets folder
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let base64Data = payload["data"]?.value as? String,
+                  let imageData = Data(base64Encoded: base64Data) else {
+                DebugLog.log("[WebViewManager] Invalid saveImage payload")
+                let requestId = message.payload?["requestId"]?.value as? String
+                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
+                    "error": AnyCodable("Invalid image data"),
+                    "requestId": AnyCodable(requestId as Any)
+                ]))
+                return
+            }
+
+            let requestId = payload["requestId"]?.value as? String
+
+            do {
+                let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
+                let assetUrl = "ticker-asset:///\(relativePath)"
+
+                bridgeService.send(BridgeMessage(type: "imageSaved", payload: [
+                    "relativePath": AnyCodable(relativePath),
+                    "assetUrl": AnyCodable(assetUrl),
+                    "requestId": AnyCodable(requestId as Any)
+                ]))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save image (\(DebugLog.errorSummary(error)))")
+                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
+                    "error": AnyCodable(error.localizedDescription),
+                    "requestId": AnyCodable(requestId as Any)
+                ]))
+            }
+
+        case "getAssetPath":
+            // Get the full file path for an asset
+            guard let payload = message.payload,
+                  let relativePath = payload["relativePath"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid getAssetPath payload")
+                return
+            }
+            let fullPath = assetService.assetURL(for: relativePath).path
+            bridgeService.send(BridgeMessage(type: "assetPath", payload: [
+                "relativePath": AnyCodable(relativePath),
+                "fullPath": AnyCodable(fullPath)
+            ]))
+
+        default:
+            DebugLog.log("[SourceMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+
+    private func sendSourceError(_ message: String) {
+        bridgeService.send(BridgeMessage(type: "sourceError", payload: [
+            "error": AnyCodable(message)
+        ]))
+    }
+}

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -26,6 +26,7 @@ enum StreamCodec {
             "document": [
                 "streamId": document.streamId.uuidString,
                 "markdown": document.markdown,
+                "revision": document.revision,
                 "createdAt": formatter.string(from: document.createdAt),
                 "updatedAt": formatter.string(from: document.updatedAt)
             ]

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+enum StreamCodec {
+    static func encodeStream(_ stream: Stream, document: StreamDocument) -> [String: Any] {
+        let formatter = ISO8601DateFormatter()
+        return [
+            "id": stream.id.uuidString,
+            "title": stream.title,
+            "sources": stream.sources.map { source -> [String: Any] in
+                var dict: [String: Any] = [
+                    "id": source.id.uuidString,
+                    "streamId": source.streamId.uuidString,
+                    "displayName": source.displayName,
+                    "fileType": source.fileType.rawValue,
+                    "status": source.status.rawValue,
+                    "embeddingStatus": source.embeddingStatus.rawValue,
+                    "addedAt": formatter.string(from: source.addedAt)
+                ]
+                if let pageCount = source.pageCount {
+                    dict["pageCount"] = pageCount
+                }
+                return dict
+            },
+            "createdAt": formatter.string(from: stream.createdAt),
+            "updatedAt": formatter.string(from: stream.updatedAt),
+            "document": [
+                "streamId": document.streamId.uuidString,
+                "markdown": document.markdown,
+                "createdAt": formatter.string(from: document.createdAt),
+                "updatedAt": formatter.string(from: document.updatedAt)
+            ]
+        ]
+    }
+
+    static func encodeSource(_ source: SourceReference) -> [String: Any] {
+        let formatter = ISO8601DateFormatter()
+        var dict: [String: Any] = [
+            "id": source.id.uuidString,
+            "streamId": source.streamId.uuidString,
+            "displayName": source.displayName,
+            "fileType": source.fileType.rawValue,
+            "status": source.status.rawValue,
+            "addedAt": formatter.string(from: source.addedAt)
+        ]
+        if let pageCount = source.pageCount {
+            dict["pageCount"] = pageCount
+        }
+        if source.extractedText != nil {
+            dict["hasExtractedText"] = true
+        }
+        return dict
+    }
+
+    static func encodeSummaries(_ summaries: [StreamSummary]) -> [String: AnyCodable] {
+        let formatter = ISO8601DateFormatter()
+        return [
+            "streams": AnyCodable(summaries.map { summary -> [String: Any] in
+                var dict: [String: Any] = [
+                    "id": summary.id.uuidString,
+                    "title": summary.title,
+                    "sourceCount": summary.sourceCount,
+                    "cellCount": summary.cellCount,
+                    "updatedAt": formatter.string(from: summary.updatedAt)
+                ]
+                if let previewText = summary.previewText {
+                    dict["previewText"] = previewText
+                }
+                return dict
+            })
+        ]
+    }
+
+    /// Format a stream for export as markdown or plain text
+    static func formatStreamForExport(stream: Stream, document: StreamDocument, format: String) -> String {
+        var output = ""
+        let isMarkdown = format == "markdown"
+
+        if isMarkdown {
+            output += "# \(stream.title)\n\n"
+        } else {
+            output += "\(stream.title)\n\n"
+        }
+
+        let body = isMarkdown ? document.markdown : plainTextFromMarkdown(document.markdown)
+        if !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            output += body + "\n\n"
+        }
+
+        if !stream.sources.isEmpty {
+            output += isMarkdown ? "## Sources\n\n" : "Sources:\n"
+            for source in stream.sources {
+                output += "- \(source.displayName)\n"
+            }
+        }
+
+        return output
+    }
+
+    static func sanitizeFilename(_ name: String) -> String {
+        let invalidChars = CharacterSet(charactersIn: ":/\\?%*|\"<>")
+        return name.components(separatedBy: invalidChars).joined(separator: "-")
+    }
+
+    private static func plainTextFromMarkdown(_ markdown: String) -> String {
+        markdown
+            .replacingOccurrences(of: #"(?m)^#{1,6}\s+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: #"\!\[([^\]]*)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
+            .replacingOccurrences(of: #"\[([^\]]+)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
+            .replacingOccurrences(of: #"`([^`]*)`"#, with: "$1", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -49,6 +49,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let idValue = payload["id"]?.value as? String,
                   let id = UUID(uuidString: idValue) else {
                 DebugLog.log("[WebViewManager] Invalid loadStream payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid loadStream payload")
                 return
             }
             delegate?.setCurrentStreamIdForFileDrops(id)
@@ -82,6 +83,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let id = UUID(uuidString: idValue),
                   let title = payload["title"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid updateStreamTitle payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid updateStreamTitle payload")
                 return
             }
             do {
@@ -99,6 +101,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let idValue = payload["id"]?.value as? String,
                   let id = UUID(uuidString: idValue) else {
                 DebugLog.log("[WebViewManager] Invalid deleteStream payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid deleteStream payload")
                 return
             }
             do {
@@ -122,6 +125,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let streamId = UUID(uuidString: streamIdValue),
                   let markdown = payload["markdown"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveStreamDocument payload")
                 return
             }
             do {
@@ -136,6 +140,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let streamId = UUID(uuidString: streamIdString),
                   let format = payload["format"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid exportStream payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid exportStream payload")
                 return
             }
 

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -1,0 +1,200 @@
+import AppKit
+import Foundation
+
+protocol StreamMessageHandlerDelegate: AnyObject {
+    func setCurrentStreamIdForFileDrops(_ streamId: UUID?)
+    func clearCurrentStreamIdForFileDrops(ifMatches streamId: UUID)
+    func closePDFPaneIfShowingDifferentStream(_ streamId: UUID) async
+}
+
+final class StreamMessageHandler: BridgeMessageHandler {
+    let handledTypes: Set<String> = [
+        "loadStreams",
+        "loadStream",
+        "createStream",
+        "updateStreamTitle",
+        "deleteStream",
+        "saveStreamDocument",
+        "exportStream"
+    ]
+
+    private let persistence: PersistenceService
+    private let bridgeService: BridgeService
+    private let assetService: AssetService
+    private weak var delegate: StreamMessageHandlerDelegate?
+
+    init?(container: ServiceContainer, delegate: StreamMessageHandlerDelegate) {
+        guard let persistence = container.persistence else { return nil }
+        self.persistence = persistence
+        self.bridgeService = container.bridgeService
+        self.assetService = container.assetService
+        self.delegate = delegate
+    }
+
+    func handle(_ message: BridgeMessage) async {
+        switch message.type {
+        case "loadStreams":
+            do {
+                let summaries = try persistence.loadStreamSummaries()
+                let payload = StreamCodec.encodeSummaries(summaries)
+                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to load streams (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "loadStream":
+            guard let payload = message.payload,
+                  let idValue = payload["id"]?.value as? String,
+                  let id = UUID(uuidString: idValue) else {
+                DebugLog.log("[WebViewManager] Invalid loadStream payload")
+                return
+            }
+            delegate?.setCurrentStreamIdForFileDrops(id)
+            await delegate?.closePDFPaneIfShowingDifferentStream(id)
+            do {
+                if let stream = try persistence.loadStream(id: id) {
+                    let document = try persistence.loadOrCreateStreamDocument(streamId: id)
+
+                    let streamPayload = StreamCodec.encodeStream(stream, document: document)
+                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                }
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to load stream (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "createStream":
+            let title = (message.payload?["title"]?.value as? String) ?? "Untitled"
+            do {
+                let stream = try persistence.createStream(title: title)
+                delegate?.setCurrentStreamIdForFileDrops(stream.id)
+                let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
+                let streamPayload = StreamCodec.encodeStream(stream, document: document)
+                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "updateStreamTitle":
+            guard let payload = message.payload,
+                  let idValue = payload["id"]?.value as? String,
+                  let id = UUID(uuidString: idValue),
+                  let title = payload["title"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid updateStreamTitle payload")
+                return
+            }
+            do {
+                if var stream = try persistence.loadStream(id: id) {
+                    stream.title = title
+                    try persistence.updateStream(stream)
+                    bridgeService.send(BridgeMessage(type: "streamTitleUpdated", payload: ["id": AnyCodable(id.uuidString), "title": AnyCodable(title)]))
+                }
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to update stream title (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "deleteStream":
+            guard let payload = message.payload,
+                  let idValue = payload["id"]?.value as? String,
+                  let id = UUID(uuidString: idValue) else {
+                DebugLog.log("[WebViewManager] Invalid deleteStream payload")
+                return
+            }
+            do {
+                try persistence.deleteStream(id: id)
+                delegate?.clearCurrentStreamIdForFileDrops(ifMatches: id)
+                // Also delete stream assets (images, etc.)
+                try? assetService.deleteAssets(for: id)
+                // Reload streams list
+                let summaries = try persistence.loadStreamSummaries()
+                let summariesPayload = StreamCodec.encodeSummaries(summaries)
+                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: summariesPayload))
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to delete stream (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "saveStreamDocument":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let markdown = payload["markdown"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
+                return
+            }
+            do {
+                try persistence.saveStreamDocument(streamId: streamId, markdown: markdown)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "exportStream":
+            guard let payload = message.payload,
+                  let streamIdString = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdString),
+                  let format = payload["format"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid exportStream payload")
+                return
+            }
+
+            do {
+                guard let stream = try persistence.loadStream(id: streamId) else {
+                    DebugLog.log("[WebViewManager] Stream not found for export")
+                    bridgeService.send(BridgeMessage(type: "exportError", payload: [
+                        "streamId": AnyCodable(streamIdString),
+                        "error": AnyCodable("Stream not found")
+                    ]))
+                    return
+                }
+                let document = try persistence.loadOrCreateStreamDocument(streamId: streamId)
+
+                // Convert to export format
+                let content = StreamCodec.formatStreamForExport(stream: stream, document: document, format: format)
+                let fileExtension = format == "markdown" ? ".md" : ".txt"
+                let suggestedName = StreamCodec.sanitizeFilename(stream.title) + fileExtension
+
+                // Show save panel on main thread
+                await MainActor.run {
+                    let savePanel = NSSavePanel()
+                    savePanel.nameFieldStringValue = suggestedName
+                    // Use appropriate content type for the format
+                    if format == "markdown" {
+                        savePanel.allowedContentTypes = [.init(filenameExtension: "md") ?? .plainText]
+                    } else {
+                        savePanel.allowedContentTypes = [.plainText]
+                    }
+                    savePanel.message = "Export stream as \(format == "markdown" ? "Markdown" : "Plain Text")"
+
+                    let result = savePanel.runModal()
+                    if result == .OK, let url = savePanel.url {
+                        do {
+                            try content.write(to: url, atomically: true, encoding: .utf8)
+                            bridgeService.send(BridgeMessage(type: "exportComplete", payload: [
+                                "streamId": AnyCodable(streamId.uuidString),
+                                "path": AnyCodable(url.path)
+                            ]))
+                        } catch {
+                            DebugLog.log("[WebViewManager] Failed to write export file (\(DebugLog.errorSummary(error)))")
+                            bridgeService.send(BridgeMessage(type: "exportError", payload: [
+                                "streamId": AnyCodable(streamId.uuidString),
+                                "error": AnyCodable(error.localizedDescription)
+                            ]))
+                        }
+                    } else {
+                        // User canceled - no error, just inform frontend
+                        bridgeService.send(BridgeMessage(type: "exportCanceled", payload: [
+                            "streamId": AnyCodable(streamId.uuidString)
+                        ]))
+                    }
+                }
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to load stream for export (\(DebugLog.errorSummary(error)))")
+                bridgeService.send(BridgeMessage(type: "exportError", payload: [
+                    "streamId": AnyCodable(streamIdString),
+                    "error": AnyCodable(error.localizedDescription)
+                ]))
+            }
+
+        default:
+            DebugLog.log("[StreamMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+}

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -37,7 +37,9 @@ final class StreamMessageHandler: BridgeMessageHandler {
             do {
                 let summaries = try persistence.loadStreamSummaries()
                 let payload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
+                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
+                    "streams": payload["streams"]!
+                ]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to load streams (\(DebugLog.errorSummary(error)))")
             }
@@ -107,7 +109,9 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 // Reload streams list
                 let summaries = try persistence.loadStreamSummaries()
                 let summariesPayload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: summariesPayload))
+                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
+                    "streams": summariesPayload["streams"]!
+                ]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to delete stream (\(DebugLog.errorSummary(error)))")
             }

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -123,15 +123,32 @@ final class StreamMessageHandler: BridgeMessageHandler {
             guard let payload = message.payload,
                   let streamIdValue = payload["streamId"]?.value as? String,
                   let streamId = UUID(uuidString: streamIdValue),
-                  let markdown = payload["markdown"]?.value as? String else {
+                  let markdown = payload["markdown"]?.value as? String,
+                  let baseRevision = payload["baseRevision"]?.intValue,
+                  let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
                 await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveStreamDocument payload")
                 return
             }
             do {
-                try persistence.saveStreamDocument(streamId: streamId, markdown: markdown)
+                let revision = try persistence.saveStreamDocument(
+                    streamId: streamId,
+                    markdown: markdown,
+                    baseRevision: baseRevision
+                )
+                await bridgeService.respond(to: callbackId, with: [
+                    "revision": AnyCodable(revision)
+                ])
+            } catch let conflict as StreamDocumentRevisionConflict {
+                await bridgeService.send(BridgeMessage(type: "streamDocumentConflict", payload: [
+                    "streamId": AnyCodable(conflict.streamId.uuidString),
+                    "markdown": AnyCodable(conflict.markdown),
+                    "revision": AnyCodable(conflict.revision)
+                ]))
+                await bridgeService.respondWithError(to: callbackId, error: "Stream document revision conflict")
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
+                await bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/BridgeService.swift
+++ b/Sources/Ticker/App/BridgeService.swift
@@ -21,6 +21,29 @@ struct AnyCodable: Codable {
         self.value = value
     }
 
+    var doubleValue: Double? {
+        if let double = value as? Double {
+            return double
+        }
+        if let int = value as? Int {
+            return Double(int)
+        }
+        return nil
+    }
+
+    var intValue: Int? {
+        if let int = value as? Int {
+            return int
+        }
+        if let double = value as? Double,
+           double.rounded(.towardZero) == double,
+           double >= Double(Int.min),
+           double <= Double(Int.max) {
+            return Int(double)
+        }
+        return nil
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
@@ -97,6 +120,7 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
             onMessage?(bridgeMessage)
         } catch {
             DebugLog.log("Failed to decode bridge message (\(DebugLog.errorSummary(error)))")
+            sendBridgeError(type: originalType(from: message.body), reason: "Failed to decode bridge message: \(DebugLog.errorSummary(error))")
         }
     }
 
@@ -140,5 +164,24 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
         ]
         let message = BridgeMessage(type: "callback", payload: payload, callbackId: callbackId)
         send(message)
+    }
+
+    func sendBridgeError(type originalType: String, reason: String) {
+        send(BridgeMessage(type: "bridgeError", payload: [
+            "originalType": AnyCodable(originalType),
+            "reason": AnyCodable(reason)
+        ]))
+    }
+
+    private func originalType(from body: Any) -> String {
+        if let dict = body as? [String: Any],
+           let type = dict["type"] as? String {
+            return type
+        }
+        if let dict = body as? NSDictionary,
+           let type = dict["type"] as? String {
+            return type
+        }
+        return "undecodable"
     }
 }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -483,7 +483,7 @@ final class QuickPanelManager: ObservableObject {
 
             let fragment = try buildMarkdownFragment(streamId: streamId)
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
-            notifyFrontend(streamId: streamId, fragment: result.fragment, isNewStream: isNewStream)
+            notifyFrontend(streamId: streamId, fragment: result.fragment, revision: result.revision, isNewStream: isNewStream)
 
             let aiPrompt = triggerDocumentAI ? prompt : nil
             let orchestratorForAI = orchestrator
@@ -723,7 +723,7 @@ final class QuickPanelManager: ObservableObject {
     private func appendQuickPanelAIFragment(streamId: UUID, fragment: String, persistence: PersistenceService) {
         do {
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
-            notifyFrontend(streamId: streamId, fragment: result.fragment, source: "quickPanelAI")
+            notifyFrontend(streamId: streamId, fragment: result.fragment, revision: result.revision, source: "quickPanelAI")
         } catch {
             DebugLog.log("[QuickPanel] Failed to append AI response (\(DebugLog.errorSummary(error)))")
         }
@@ -750,6 +750,7 @@ final class QuickPanelManager: ObservableObject {
     private func notifyFrontend(
         streamId: UUID,
         fragment: String,
+        revision: Int,
         isNewStream: Bool = false,
         source: String = "quickPanel"
     ) {
@@ -758,6 +759,7 @@ final class QuickPanelManager: ObservableObject {
         let payload: [String: AnyCodable] = [
             "streamId": AnyCodable(streamId.uuidString),
             "fragment": AnyCodable(fragment),
+            "revision": AnyCodable(revision),
             "isNewStream": AnyCodable(isNewStream),
             "source": AnyCodable(source)
         ]

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -114,6 +114,16 @@ final class QuickPanelManager: ObservableObject {
         self.orchestrator = orchestrator
     }
 
+    func configure(container: ServiceContainer) {
+        guard let persistence = container.persistence else { return }
+        configure(
+            persistence: persistence,
+            bridgeService: container.bridgeService,
+            assetService: container.assetService,
+            orchestrator: container.orchestrator
+        )
+    }
+
     // MARK: - Public API
 
     /// Toggle the quick panel

--- a/Sources/Ticker/App/ServiceContainer.swift
+++ b/Sources/Ticker/App/ServiceContainer.swift
@@ -1,0 +1,68 @@
+/// App composition root for long-lived services.
+struct ServiceContainer {
+    let settingsService: SettingsService
+    let deviceKeyService: DeviceKeyService
+    let bridgeService: BridgeService
+    let assetService: AssetService
+    let proxyService: ProxyLLMService
+    let embeddingService: EmbeddingService
+    let chunkingService: ChunkingService
+    let orchestrator: AIOrchestrator
+    let persistence: PersistenceService?
+    let sourceService: SourceService?
+    let retrievalService: RetrievalService?
+    let searchService: SearchService?
+
+    init(
+        settingsService: SettingsService = .shared,
+        deviceKeyService: DeviceKeyService = .shared
+    ) {
+        self.settingsService = settingsService
+        self.deviceKeyService = deviceKeyService
+        self.bridgeService = BridgeService()
+        self.assetService = AssetService()
+
+        let proxyService = ProxyLLMService(deviceKeyService: deviceKeyService)
+        self.proxyService = proxyService
+
+        self.embeddingService = EmbeddingService(settings: settingsService)
+        self.chunkingService = ChunkingService()
+
+        let orchestrator = AIOrchestrator(
+            proxyService: proxyService,
+            settings: settingsService
+        )
+        self.orchestrator = orchestrator
+
+        do {
+            let persistence = try PersistenceService()
+            self.persistence = persistence
+
+            let sourceService = SourceService(
+                persistence: persistence,
+                chunkingService: chunkingService,
+                embeddingService: embeddingService
+            )
+            self.sourceService = sourceService
+
+            let retrievalService = RetrievalService(
+                persistence: persistence,
+                embeddingService: embeddingService
+            )
+            self.retrievalService = retrievalService
+            orchestrator.setRetrievalService(retrievalService)
+
+            self.searchService = SearchService(
+                persistence: persistence,
+                retrieval: retrievalService,
+                embedding: embeddingService
+            )
+        } catch {
+            DebugLog.log("[WebViewManager] Failed to initialize persistence (\(DebugLog.errorSummary(error)))")
+            self.persistence = nil
+            self.sourceService = nil
+            self.retrievalService = nil
+            self.searchService = nil
+        }
+    }
+}

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -176,7 +176,9 @@ final class WebViewManager: NSObject {
 
             let summaries = try persistence.loadStreamSummaries()
             let payload = StreamCodec.encodeSummaries(summaries)
-            bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
+            bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
+                "streams": payload["streams"]!
+            ]))
         } catch {
             DebugLog.log("[WebViewManager] Failed to create stream from dropped PDF (\(DebugLog.errorSummary(error)))")
             bridgeService.send(BridgeMessage(type: "fileDropError", payload: [

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -186,29 +186,14 @@ final class WebViewManager: NSObject {
             }
 
             let document = try persistence.loadOrCreateStreamDocument(streamId: createdStream.id)
-            let streamPayload = encodeStream(reloadedStream, document: document)
+            let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
             bridgeService.send(BridgeMessage(type: "streamLoaded", payload: [
                 "stream": AnyCodable(streamPayload)
             ]))
 
             // Refresh the list in the background so counts/titles stay current when user navigates back.
             let summaries = try persistence.loadStreamSummaries()
-            let formatter = ISO8601DateFormatter()
-            let payload: [String: AnyCodable] = [
-                "streams": AnyCodable(summaries.map { summary -> [String: Any] in
-                    var dict: [String: Any] = [
-                        "id": summary.id.uuidString,
-                        "title": summary.title,
-                        "sourceCount": summary.sourceCount,
-                        "cellCount": summary.cellCount,
-                        "updatedAt": formatter.string(from: summary.updatedAt)
-                    ]
-                    if let previewText = summary.previewText {
-                        dict["previewText"] = previewText
-                    }
-                    return dict
-                })
-            ]
+            let payload = StreamCodec.encodeSummaries(summaries)
             bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
         } catch {
             DebugLog.log("[WebViewManager] Failed to create stream from dropped PDF (\(DebugLog.errorSummary(error)))")
@@ -273,7 +258,7 @@ final class WebViewManager: NSObject {
 
         do {
             let source = try withSecurityScopedAccess(url) { try sourceService.addSource(from: url, to: streamId) }
-            let sourcePayload = encodeSource(source)
+            let sourcePayload = StreamCodec.encodeSource(source)
             bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
             if source.fileType == .pdf {
                 openSourceReference(source, sourceService: sourceService)
@@ -433,22 +418,7 @@ final class WebViewManager: NSObject {
         case "loadStreams":
             do {
                 let summaries = try persistence.loadStreamSummaries()
-                let formatter = ISO8601DateFormatter()
-                let payload: [String: AnyCodable] = [
-                    "streams": AnyCodable(summaries.map { summary -> [String: Any] in
-                        var dict: [String: Any] = [
-                            "id": summary.id.uuidString,
-                            "title": summary.title,
-                            "sourceCount": summary.sourceCount,
-                            "cellCount": summary.cellCount,
-                            "updatedAt": formatter.string(from: summary.updatedAt)
-                        ]
-                        if let previewText = summary.previewText {
-                            dict["previewText"] = previewText
-                        }
-                        return dict
-                    })
-                ]
+                let payload = StreamCodec.encodeSummaries(summaries)
                 bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to load streams (\(DebugLog.errorSummary(error)))")
@@ -472,7 +442,7 @@ final class WebViewManager: NSObject {
                 if let stream = try persistence.loadStream(id: id) {
                     let document = try persistence.loadOrCreateStreamDocument(streamId: id)
 
-                    let streamPayload = encodeStream(stream, document: document)
+                    let streamPayload = StreamCodec.encodeStream(stream, document: document)
                     bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
                 }
             } catch {
@@ -485,7 +455,7 @@ final class WebViewManager: NSObject {
                 let stream = try persistence.createStream(title: title)
                 currentStreamIdForFileDrops = stream.id
                 let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
-                let streamPayload = encodeStream(stream, document: document)
+                let streamPayload = StreamCodec.encodeStream(stream, document: document)
                 bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
@@ -525,22 +495,7 @@ final class WebViewManager: NSObject {
                 try? assetService.deleteAssets(for: id)
                 // Reload streams list
                 let summaries = try persistence.loadStreamSummaries()
-                let formatter = ISO8601DateFormatter()
-                let summariesPayload: [String: AnyCodable] = [
-                    "streams": AnyCodable(summaries.map { summary -> [String: Any] in
-                        var dict: [String: Any] = [
-                            "id": summary.id.uuidString,
-                            "title": summary.title,
-                            "sourceCount": summary.sourceCount,
-                            "cellCount": summary.cellCount,
-                            "updatedAt": formatter.string(from: summary.updatedAt)
-                        ]
-                        if let previewText = summary.previewText {
-                            dict["previewText"] = previewText
-                        }
-                        return dict
-                    })
-                ]
+                let summariesPayload = StreamCodec.encodeSummaries(summaries)
                 bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: summariesPayload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to delete stream (\(DebugLog.errorSummary(error)))")
@@ -611,7 +566,7 @@ final class WebViewManager: NSObject {
                 if panel.runModal() == .OK, let url = panel.url {
                     do {
                         let source = try sourceService.addSource(from: url, to: streamId)
-                        let sourcePayload = encodeSource(source)
+                        let sourcePayload = StreamCodec.encodeSource(source)
                         bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
                     } catch {
                         DebugLog.log("[WebViewManager] Failed to add source (\(DebugLog.errorSummary(error)))")
@@ -633,7 +588,7 @@ final class WebViewManager: NSObject {
             let url = URL(fileURLWithPath: filePath)
             do {
                 let source = try sourceService.addSource(from: url, to: streamId)
-                let sourcePayload = encodeSource(source)
+                let sourcePayload = StreamCodec.encodeSource(source)
                 bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to add source from path (\(DebugLog.errorSummary(error)))")
@@ -822,9 +777,9 @@ final class WebViewManager: NSObject {
                 let document = try persistence.loadOrCreateStreamDocument(streamId: streamId)
 
                 // Convert to export format
-                let content = formatStreamForExport(stream: stream, document: document, format: format)
+                let content = StreamCodec.formatStreamForExport(stream: stream, document: document, format: format)
                 let fileExtension = format == "markdown" ? ".md" : ".txt"
-                let suggestedName = sanitizeFilename(stream.title) + fileExtension
+                let suggestedName = StreamCodec.sanitizeFilename(stream.title) + fileExtension
 
                 // Show save panel on main thread
                 await MainActor.run {
@@ -1239,58 +1194,6 @@ final class WebViewManager: NSObject {
         }
     }
 
-    // MARK: - Encoding/Decoding Helpers
-
-    private func encodeStream(_ stream: Stream, document: StreamDocument) -> [String: Any] {
-        let formatter = ISO8601DateFormatter()
-        return [
-            "id": stream.id.uuidString,
-            "title": stream.title,
-            "sources": stream.sources.map { source -> [String: Any] in
-                var dict: [String: Any] = [
-                    "id": source.id.uuidString,
-                    "streamId": source.streamId.uuidString,
-                    "displayName": source.displayName,
-                    "fileType": source.fileType.rawValue,
-                    "status": source.status.rawValue,
-                    "embeddingStatus": source.embeddingStatus.rawValue,
-                    "addedAt": formatter.string(from: source.addedAt)
-                ]
-                if let pageCount = source.pageCount {
-                    dict["pageCount"] = pageCount
-                }
-                return dict
-            },
-            "createdAt": formatter.string(from: stream.createdAt),
-            "updatedAt": formatter.string(from: stream.updatedAt),
-            "document": [
-                "streamId": document.streamId.uuidString,
-                "markdown": document.markdown,
-                "createdAt": formatter.string(from: document.createdAt),
-                "updatedAt": formatter.string(from: document.updatedAt)
-            ]
-        ]
-    }
-
-    private func encodeSource(_ source: SourceReference) -> [String: Any] {
-        let formatter = ISO8601DateFormatter()
-        var dict: [String: Any] = [
-            "id": source.id.uuidString,
-            "streamId": source.streamId.uuidString,
-            "displayName": source.displayName,
-            "fileType": source.fileType.rawValue,
-            "status": source.status.rawValue,
-            "addedAt": formatter.string(from: source.addedAt)
-        ]
-        if let pageCount = source.pageCount {
-            dict["pageCount"] = pageCount
-        }
-        if source.extractedText != nil {
-            dict["hasExtractedText"] = true
-        }
-        return dict
-    }
-
     /// Get settings enriched with classifier state
     private func settingsWithClassifierState() -> [String: Any] {
         var settings = settingsService.allSettings()
@@ -1310,49 +1213,6 @@ final class WebViewManager: NSObject {
             settings["classifierLoading"] = true
         }
         return settings
-    }
-
-    // MARK: - Export Helpers
-
-    /// Format a stream for export as markdown or plain text
-    private func formatStreamForExport(stream: Stream, document: StreamDocument, format: String) -> String {
-        var output = ""
-        let isMarkdown = format == "markdown"
-
-        if isMarkdown {
-            output += "# \(stream.title)\n\n"
-        } else {
-            output += "\(stream.title)\n\n"
-        }
-
-        let body = isMarkdown ? document.markdown : plainTextFromMarkdown(document.markdown)
-        if !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            output += body + "\n\n"
-        }
-
-        if !stream.sources.isEmpty {
-            output += isMarkdown ? "## Sources\n\n" : "Sources:\n"
-            for source in stream.sources {
-                output += "- \(source.displayName)\n"
-            }
-        }
-
-        return output
-    }
-
-    private func plainTextFromMarkdown(_ markdown: String) -> String {
-        markdown
-            .replacingOccurrences(of: #"(?m)^#{1,6}\s+"#, with: "", options: .regularExpression)
-            .replacingOccurrences(of: #"\!\[([^\]]*)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
-            .replacingOccurrences(of: #"\[([^\]]+)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
-            .replacingOccurrences(of: #"`([^`]*)`"#, with: "$1", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Sanitize a string for use as a filename
-    private func sanitizeFilename(_ name: String) -> String {
-        let invalidChars = CharacterSet(charactersIn: ":/\\?%*|\"<>")
-        return name.components(separatedBy: invalidChars).joined(separator: "-")
     }
 
 }

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -65,6 +65,9 @@ final class WebViewManager: NSObject {
         if let streamHandler = StreamMessageHandler(container: container, delegate: self) {
             bridgeRouter.register(streamHandler)
         }
+        if let sourceHandler = SourceMessageHandler(container: container, delegate: self) {
+            bridgeRouter.register(sourceHandler)
+        }
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
@@ -294,7 +297,7 @@ final class WebViewManager: NSObject {
         ))
     }
 
-    private func openSourceReference(_ source: SourceReference, sourceService: SourceService) {
+    func openSourceReference(_ source: SourceReference, sourceService: SourceService) {
         do {
             let url = try sourceService.accessFile(source)
 
@@ -429,124 +432,14 @@ final class WebViewManager: NSObject {
              "exportStream":
             await bridgeRouter.route(message)
 
-        case "setFileDropContext":
-            let mode = message.payload?["mode"]?.value as? String
-            switch mode {
-            case "stream":
-                if let streamIdValue = message.payload?["streamId"]?.value as? String,
-                   let streamId = UUID(uuidString: streamIdValue) {
-                    currentStreamIdForFileDrops = streamId
-                    allowsListFileDrops = false
-                } else {
-                    currentStreamIdForFileDrops = nil
-                    allowsListFileDrops = false
-                }
-            case "list":
-                currentStreamIdForFileDrops = nil
-                allowsListFileDrops = true
-                await MainActor.run {
-                    pdfPaneController.setVisible(false)
-                    activePDFPaneStreamId = nil
-                }
-            default:
-                currentStreamIdForFileDrops = nil
-                allowsListFileDrops = false
-                await MainActor.run {
-                    pdfPaneController.setVisible(false)
-                    activePDFPaneStreamId = nil
-                }
-            }
-
-        case "addSource":
-            guard let payload = message.payload,
-                  let streamIdValue = payload["streamId"]?.value as? String,
-                  let streamId = UUID(uuidString: streamIdValue),
-                  let sourceService else {
-                DebugLog.log("[WebViewManager] Invalid addSource payload or service unavailable")
-                return
-            }
-
-            // Must run on main thread for NSOpenPanel
-            await MainActor.run {
-                let panel = NSOpenPanel()
-                panel.canChooseFiles = true
-                panel.canChooseDirectories = false
-                panel.allowsMultipleSelection = false
-                // Note: "net.daringfireball.markdown" is the standard UTI for markdown files
-                let markdownType = UTType(filenameExtension: "md") ?? UTType.plainText
-                panel.allowedContentTypes = [.pdf, .plainText, .text, .sourceCode, markdownType, .png, .jpeg, .heic, .image]
-                panel.message = "Select a file to attach"
-
-                if panel.runModal() == .OK, let url = panel.url {
-                    do {
-                        let source = try sourceService.addSource(from: url, to: streamId)
-                        let sourcePayload = StreamCodec.encodeSource(source)
-                        bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
-                    } catch {
-                        DebugLog.log("[WebViewManager] Failed to add source (\(DebugLog.errorSummary(error)))")
-                        bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
-                    }
-                }
-            }
-
-        case "addSourceFromPath":
-            guard let payload = message.payload,
-                  let streamIdValue = payload["streamId"]?.value as? String,
-                  let streamId = UUID(uuidString: streamIdValue),
-                  let filePath = payload["path"]?.value as? String,
-                  let sourceService else {
-                DebugLog.log("[WebViewManager] Invalid addSourceFromPath payload or service unavailable")
-                return
-            }
-
-            let url = URL(fileURLWithPath: filePath)
-            do {
-                let source = try sourceService.addSource(from: url, to: streamId)
-                let sourcePayload = StreamCodec.encodeSource(source)
-                bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to add source from path (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
-            }
-
-        case "removeSource":
-            guard let payload = message.payload,
-                  let idValue = payload["id"]?.value as? String,
-                  let id = UUID(uuidString: idValue),
-                  let sourceService else {
-                DebugLog.log("[WebViewManager] Invalid removeSource payload")
-                return
-            }
-            do {
-                try sourceService.removeSource(id: id)
-                bridgeService.send(BridgeMessage(type: "sourceRemoved", payload: ["id": AnyCodable(id.uuidString)]))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to remove source (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "sourceRemoveError", payload: [
-                    "id": AnyCodable(id.uuidString),
-                    "error": AnyCodable(error.localizedDescription)
-                ]))
-            }
-
-        case "openSource":
-            guard let payload = message.payload,
-                  let sourceIdValue = payload["sourceId"]?.value as? String,
-                  let sourceId = UUID(uuidString: sourceIdValue),
-                  let sourceService else {
-                DebugLog.log("[WebViewManager] Invalid openSource payload")
-                return
-            }
-
-            do {
-                guard let source = try persistence.loadSource(id: sourceId) else {
-                    sendSourceError("Source not found.")
-                    return
-                }
-                openSourceReference(source, sourceService: sourceService)
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to open source (\(DebugLog.errorSummary(error)))")
-                sendSourceError(error.localizedDescription)
-            }
+        case "setFileDropContext",
+             "addSource",
+             "addSourceFromPath",
+             "removeSource",
+             "openSource",
+             "saveImage",
+             "getAssetPath":
+            await bridgeRouter.route(message)
 
         case "thinkDocument":
             guard let payload = message.payload,
@@ -943,54 +836,6 @@ final class WebViewManager: NSObject {
                     ])
                 }
             }
-        case "saveImage":
-            // Save base64-encoded image data to stream's assets folder
-            guard let payload = message.payload,
-                  let streamIdValue = payload["streamId"]?.value as? String,
-                  let streamId = UUID(uuidString: streamIdValue),
-                  let base64Data = payload["data"]?.value as? String,
-                  let imageData = Data(base64Encoded: base64Data) else {
-                DebugLog.log("[WebViewManager] Invalid saveImage payload")
-                let requestId = message.payload?["requestId"]?.value as? String
-                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
-                    "error": AnyCodable("Invalid image data"),
-                    "requestId": AnyCodable(requestId as Any)
-                ]))
-                return
-            }
-
-            let requestId = payload["requestId"]?.value as? String
-
-            do {
-                let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
-                let assetUrl = "ticker-asset:///\(relativePath)"
-
-                bridgeService.send(BridgeMessage(type: "imageSaved", payload: [
-                    "relativePath": AnyCodable(relativePath),
-                    "assetUrl": AnyCodable(assetUrl),
-                    "requestId": AnyCodable(requestId as Any)
-                ]))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to save image (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
-                    "error": AnyCodable(error.localizedDescription),
-                    "requestId": AnyCodable(requestId as Any)
-                ]))
-            }
-
-        case "getAssetPath":
-            // Get the full file path for an asset
-            guard let payload = message.payload,
-                  let relativePath = payload["relativePath"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid getAssetPath payload")
-                return
-            }
-            let fullPath = assetService.assetURL(for: relativePath).path
-            bridgeService.send(BridgeMessage(type: "assetPath", payload: [
-                "relativePath": AnyCodable(relativePath),
-                "fullPath": AnyCodable(fullPath)
-            ]))
-
         case "hybridSearch":
             guard let payload = message.payload,
                   let query = payload["query"]?.value as? String,
@@ -1081,6 +926,20 @@ extension WebViewManager: StreamMessageHandlerDelegate {
                 pdfPaneController.setVisible(false)
                 activePDFPaneStreamId = nil
             }
+        }
+    }
+}
+
+extension WebViewManager: SourceMessageHandlerDelegate {
+    func setFileDropContext(streamId: UUID?, allowsListFileDrops: Bool) {
+        currentStreamIdForFileDrops = streamId
+        self.allowsListFileDrops = allowsListFileDrops
+    }
+
+    func hidePDFPane() async {
+        await MainActor.run {
+            pdfPaneController.setVisible(false)
+            activePDFPaneStreamId = nil
         }
     }
 }

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -6,6 +6,8 @@ import UniformTypeIdentifiers
 final class WebViewManager: NSObject {
     let webView: DroppableWebView
     var rootView: NSView { hostView }
+    private let settingsService: SettingsService
+    private let deviceKeyService: DeviceKeyService
     let bridgeService: BridgeService
     let persistence: PersistenceService?
     private let sourceService: SourceService?
@@ -21,7 +23,7 @@ final class WebViewManager: NSObject {
     private var searchService: SearchService?
 
     // Asset management
-    private let assetService = AssetService()
+    private let assetService: AssetService
     private var currentStreamIdForFileDrops: UUID?
     private var allowsListFileDrops = false
     private let hostView = NSView(frame: .zero)
@@ -29,11 +31,13 @@ final class WebViewManager: NSObject {
     private let pdfPaneController = PDFReaderPaneController()
     private var activePDFPaneStreamId: UUID?
 
-    override init() {
+    init(container: ServiceContainer) {
         let config = WKWebViewConfiguration()
         config.preferences.setValue(true, forKey: "developerExtrasEnabled")
 
-        self.bridgeService = BridgeService()
+        self.settingsService = container.settingsService
+        self.deviceKeyService = container.deviceKeyService
+        self.bridgeService = container.bridgeService
         config.userContentController.add(bridgeService, name: "bridge")
 
         // Register custom URL scheme handler for local assets
@@ -45,50 +49,15 @@ final class WebViewManager: NSObject {
         config.setURLSchemeHandler(bundleHandler, forURLScheme: "ticker-bundle")
 
         self.webView = DroppableWebView(frame: .zero, configuration: config)
-
-        // Initialize proxy service (all AI operations go through proxy in alpha)
-        let proxyService = ProxyLLMService()
-        self.proxyService = proxyService
-
-        // Initialize RAG services
-        self.embeddingService = EmbeddingService()
-        self.chunkingService = ChunkingService()
-
-        // Initialize orchestrator (proxy-only mode, no vendor provider registration)
-        self.orchestrator = AIOrchestrator(proxyService: proxyService)
-
-        do {
-            let p = try PersistenceService()
-            self.persistence = p
-
-            // Create SourceService with RAG components
-            self.sourceService = SourceService(
-                persistence: p,
-                chunkingService: chunkingService,
-                embeddingService: embeddingService
-            )
-
-            // Create RetrievalService and wire to orchestrator
-            self.retrievalService = RetrievalService(
-                persistence: p,
-                embeddingService: embeddingService
-            )
-            orchestrator.setRetrievalService(retrievalService!)
-
-            // Create SearchService for hybrid search
-            self.searchService = SearchService(
-                persistence: p,
-                retrieval: retrievalService!,
-                embedding: embeddingService
-            )
-
-        } catch {
-            DebugLog.log("[WebViewManager] Failed to initialize persistence (\(DebugLog.errorSummary(error)))")
-            self.persistence = nil
-            self.sourceService = nil
-            self.retrievalService = nil
-            self.searchService = nil
-        }
+        self.proxyService = container.proxyService
+        self.embeddingService = container.embeddingService
+        self.chunkingService = container.chunkingService
+        self.orchestrator = container.orchestrator
+        self.persistence = container.persistence
+        self.sourceService = container.sourceService
+        self.retrievalService = container.retrievalService
+        self.searchService = container.searchService
+        self.assetService = container.assetService
 
         super.init()
 
@@ -108,8 +77,9 @@ final class WebViewManager: NSObject {
         }
 
         // Initialize DeviceKeyService and wire up state change callback
-        Task {
-            await DeviceKeyService.shared.onStateChange = { [weak self] state in
+        Task { [weak self] in
+            guard let self else { return }
+            await deviceKeyService.onStateChange = { [weak self] state in
                 // Push state to Web
                 self?.bridgeService.send(BridgeMessage(
                     type: "proxyAuthState",
@@ -117,7 +87,7 @@ final class WebViewManager: NSObject {
                 ))
             }
             // Initialize and validate cached key
-            await DeviceKeyService.shared.initialize()
+            await deviceKeyService.initialize()
         }
     }
 
@@ -404,7 +374,7 @@ final class WebViewManager: NSObject {
 
         // Only load classifier if smart routing is enabled
         // Note: No vendor keys required - classifier runs locally, proxy handles routing
-        guard SettingsService.shared.smartRoutingEnabled else {
+        guard settingsService.smartRoutingEnabled else {
             DebugLog.log("MLX classifier skipped: smart routing disabled")
             classifierSkipped = true
             return
@@ -803,7 +773,7 @@ final class WebViewManager: NSObject {
             Task { [weak self] in
                 guard let self else { return }
 
-                let proxyUsable = await DeviceKeyService.shared.currentState.isUsable
+                let proxyUsable = await self.deviceKeyService.currentState.isUsable
 
                 guard proxyUsable else {
                     await MainActor.run {
@@ -913,61 +883,61 @@ final class WebViewManager: NSObject {
 
             // Save OpenAI API key if provided
             if let openaiKey = payload["openaiAPIKey"]?.value as? String {
-                SettingsService.shared.openaiAPIKey = openaiKey.isEmpty ? nil : openaiKey
+                settingsService.openaiAPIKey = openaiKey.isEmpty ? nil : openaiKey
             }
 
             // Save Anthropic API key if provided
             if let anthropicKey = payload["anthropicAPIKey"]?.value as? String {
-                SettingsService.shared.anthropicAPIKey = anthropicKey.isEmpty ? nil : anthropicKey
+                settingsService.anthropicAPIKey = anthropicKey.isEmpty ? nil : anthropicKey
             }
 
             // Save Perplexity API key if provided
             if let perplexityKey = payload["perplexityAPIKey"]?.value as? String {
-                SettingsService.shared.perplexityAPIKey = perplexityKey.isEmpty ? nil : perplexityKey
+                settingsService.perplexityAPIKey = perplexityKey.isEmpty ? nil : perplexityKey
             }
 
             // Save smart routing setting if provided
             if let smartRouting = payload["smartRoutingEnabled"]?.value as? Bool {
-                SettingsService.shared.smartRoutingEnabled = smartRouting
+                settingsService.smartRoutingEnabled = smartRouting
             }
 
             // Save default model setting if provided
             if let modelValue = payload["defaultModel"]?.value as? String,
                let model = SettingsService.DefaultModel(rawValue: modelValue) {
-                SettingsService.shared.defaultModel = model
+                settingsService.defaultModel = model
             }
 
             // Save appearance setting if provided
             if let appearanceValue = payload["appearance"]?.value as? String,
                let appearance = SettingsService.Appearance(rawValue: appearanceValue) {
-                SettingsService.shared.appearance = appearance
+                settingsService.appearance = appearance
                 // Notify AppDelegate to update window appearances
                 NotificationCenter.default.post(name: .appearanceDidChange, object: nil)
             }
 
             // Save diagnostics setting if provided
             if let diagnosticsEnabled = payload["diagnosticsEnabled"]?.value as? Bool {
-                SettingsService.shared.diagnosticsEnabled = diagnosticsEnabled
+                settingsService.diagnosticsEnabled = diagnosticsEnabled
             }
 
             // Save editor font setting if provided
             if let editorFontValue = payload["editorFont"]?.value as? String,
                let editorFont = SettingsService.EditorFont(rawValue: editorFontValue) {
-                SettingsService.shared.editorFont = editorFont
+                settingsService.editorFont = editorFont
             }
 
             // Save editor font size setting if provided
             if let editorFontSize = payload["editorFontSize"]?.value as? Double {
-                SettingsService.shared.editorFontSize = editorFontSize
+                settingsService.editorFontSize = editorFontSize
             } else if let editorFontSize = payload["editorFontSize"]?.value as? NSNumber {
-                SettingsService.shared.editorFontSize = editorFontSize.doubleValue
+                settingsService.editorFontSize = editorFontSize.doubleValue
             }
 
             // Save editor line spacing setting if provided
             if let editorLineSpacing = payload["editorLineSpacing"]?.value as? Double {
-                SettingsService.shared.editorLineSpacing = editorLineSpacing
+                settingsService.editorLineSpacing = editorLineSpacing
             } else if let editorLineSpacing = payload["editorLineSpacing"]?.value as? NSNumber {
-                SettingsService.shared.editorLineSpacing = editorLineSpacing.doubleValue
+                settingsService.editorLineSpacing = editorLineSpacing.doubleValue
             }
 
             // Send back updated settings
@@ -986,8 +956,8 @@ final class WebViewManager: NSObject {
                 return
             }
             Task {
-                let auth = await DeviceKeyService.shared.loadProxyAuth()
-                let (limits, usage) = await DeviceKeyService.shared.getLimitsAndUsage()
+                let auth = await self.deviceKeyService.loadProxyAuth()
+                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
 
                 await MainActor.run {
                     var response: [String: AnyCodable] = [
@@ -1029,8 +999,8 @@ final class WebViewManager: NSObject {
             }
             Task {
                 do {
-                    let result = try await DeviceKeyService.shared.setProxyDeviceKey(key)
-                    let newAuth = await DeviceKeyService.shared.loadProxyAuth()
+                    let result = try await self.deviceKeyService.setProxyDeviceKey(key)
+                    let newAuth = await self.deviceKeyService.loadProxyAuth()
                     await MainActor.run {
                         bridgeService.respond(to: callbackId, with: [
                             "success": AnyCodable(true),
@@ -1051,7 +1021,7 @@ final class WebViewManager: NSObject {
                         ])
                     }
                 } catch {
-                    let newAuth = await DeviceKeyService.shared.loadProxyAuth()
+                    let newAuth = await self.deviceKeyService.loadProxyAuth()
                     await MainActor.run {
                         bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
                         // Also push state change
@@ -1069,8 +1039,8 @@ final class WebViewManager: NSObject {
                 return
             }
             Task {
-                await DeviceKeyService.shared.clearProxyDeviceKey()
-                let newAuth = await DeviceKeyService.shared.loadProxyAuth()
+                await self.deviceKeyService.clearProxyDeviceKey()
+                let newAuth = await self.deviceKeyService.loadProxyAuth()
                 await MainActor.run {
                     bridgeService.respond(to: callbackId, with: [
                         "success": AnyCodable(true),
@@ -1086,9 +1056,9 @@ final class WebViewManager: NSObject {
                 return
             }
             Task {
-                await DeviceKeyService.shared.revalidate()
-                let newAuth = await DeviceKeyService.shared.loadProxyAuth()
-                let (limits, usage) = await DeviceKeyService.shared.getLimitsAndUsage()
+                await self.deviceKeyService.revalidate()
+                let newAuth = await self.deviceKeyService.loadProxyAuth()
+                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
 
                 await MainActor.run {
                     var response: [String: AnyCodable] = [
@@ -1135,7 +1105,7 @@ final class WebViewManager: NSObject {
 
             Task {
                 do {
-                    let feedbackId = try await DeviceKeyService.shared.submitFeedback(
+                    let feedbackId = try await self.deviceKeyService.submitFeedback(
                         type: feedbackType,
                         title: title,
                         description: description,
@@ -1164,7 +1134,7 @@ final class WebViewManager: NSObject {
                 return
             }
             Task {
-                let bundle = await DeviceKeyService.shared.getSupportBundle()
+                let bundle = await self.deviceKeyService.getSupportBundle()
                 await MainActor.run {
                     bridgeService.respond(to: callbackId, with: [
                         "bundle": AnyCodable(bundle)
@@ -1323,7 +1293,7 @@ final class WebViewManager: NSObject {
 
     /// Get settings enriched with classifier state
     private func settingsWithClassifierState() -> [String: Any] {
-        var settings = SettingsService.shared.allSettings()
+        var settings = settingsService.allSettings()
         if let classifier = mlxClassifier {
             settings["classifierReady"] = classifier.isReady
             settings["classifierLoading"] = classifier.isLoading

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -71,6 +71,7 @@ final class WebViewManager: NSObject {
         if let aiHandler = AIMessageHandler(container: container) {
             bridgeRouter.register(aiHandler)
         }
+        bridgeRouter.register(ProxyAuthHandler(container: container))
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
@@ -526,200 +527,15 @@ final class WebViewManager: NSObject {
                 payload: ["settings": AnyCodable(settings)]
             ))
 
-        // MARK: - Proxy Auth (canonical names per docs)
+        case "loadProxyAuth",
+             "setProxyDeviceKey",
+             "clearProxyDeviceKey",
+             "validateProxyDeviceKey",
+             "refreshProxyAuth",
+             "submitFeedback",
+             "getSupportBundle":
+            await bridgeRouter.route(message)
 
-        case "loadProxyAuth":
-            // Pure read of cached state - no network call
-            guard let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid loadProxyAuth payload")
-                return
-            }
-            Task {
-                let auth = await self.deviceKeyService.loadProxyAuth()
-                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
-
-                await MainActor.run {
-                    var response: [String: AnyCodable] = [
-                        "state": AnyCodable(auth.state.rawValue),
-                        "supportId": AnyCodable(auth.supportId as Any),
-                        "deviceId": AnyCodable(auth.deviceId)
-                    ]
-
-                    // Include limits if available
-                    if let limits = limits {
-                        response["limits"] = AnyCodable([
-                            "reqsPerMin": limits.reqsPerMin as Any,
-                            "tokensPerDay": limits.tokensPerDay as Any,
-                            "tokensPerMonth": limits.tokensPerMonth as Any
-                        ])
-                    }
-
-                    // Include usage if available
-                    if let usage = usage {
-                        response["usage"] = AnyCodable([
-                            "reqsThisMinute": usage.reqsThisMinute as Any,
-                            "tokensToday": usage.tokensToday as Any,
-                            "tokensThisMonth": usage.tokensThisMonth as Any,
-                            "dayResetAt": usage.dayResetAt as Any,
-                            "monthResetAt": usage.monthResetAt as Any
-                        ])
-                    }
-
-                    bridgeService.respond(to: callbackId, with: response)
-                }
-            }
-
-        case "setProxyDeviceKey":
-            guard let payload = message.payload,
-                  let key = payload["key"]?.value as? String,
-                  let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid setProxyDeviceKey payload")
-                return
-            }
-            Task {
-                do {
-                    let result = try await self.deviceKeyService.setProxyDeviceKey(key)
-                    let newAuth = await self.deviceKeyService.loadProxyAuth()
-                    await MainActor.run {
-                        bridgeService.respond(to: callbackId, with: [
-                            "success": AnyCodable(true),
-                            "state": AnyCodable(newAuth.state.rawValue),
-                            "supportId": AnyCodable(result.supportId),
-                            "limits": AnyCodable([
-                                "reqsPerMin": result.limits?.reqsPerMin as Any,
-                                "tokensPerDay": result.limits?.tokensPerDay as Any,
-                                "tokensPerMonth": result.limits?.tokensPerMonth as Any
-                            ]),
-                            "usage": AnyCodable([
-                                "reqsThisMinute": result.usage?.reqsThisMinute as Any,
-                                "tokensToday": result.usage?.tokensToday as Any,
-                                "tokensThisMonth": result.usage?.tokensThisMonth as Any,
-                                "dayResetAt": result.usage?.dayResetAt as Any,
-                                "monthResetAt": result.usage?.monthResetAt as Any
-                            ])
-                        ])
-                    }
-                } catch {
-                    let newAuth = await self.deviceKeyService.loadProxyAuth()
-                    await MainActor.run {
-                        bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
-                        // Also push state change
-                        bridgeService.send(BridgeMessage(
-                            type: "proxyAuthState",
-                            payload: ["state": AnyCodable(newAuth.state.rawValue)]
-                        ))
-                    }
-                }
-            }
-
-        case "clearProxyDeviceKey":
-            guard let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid clearProxyDeviceKey payload")
-                return
-            }
-            Task {
-                await self.deviceKeyService.clearProxyDeviceKey()
-                let newAuth = await self.deviceKeyService.loadProxyAuth()
-                await MainActor.run {
-                    bridgeService.respond(to: callbackId, with: [
-                        "success": AnyCodable(true),
-                        "state": AnyCodable(newAuth.state.rawValue)
-                    ])
-                }
-            }
-
-        case "validateProxyDeviceKey", "refreshProxyAuth":
-            // Re-validate cached key with server and return fresh limits/usage
-            guard let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid validateProxyDeviceKey/refreshProxyAuth payload")
-                return
-            }
-            Task {
-                await self.deviceKeyService.revalidate()
-                let newAuth = await self.deviceKeyService.loadProxyAuth()
-                let (limits, usage) = await self.deviceKeyService.getLimitsAndUsage()
-
-                await MainActor.run {
-                    var response: [String: AnyCodable] = [
-                        "state": AnyCodable(newAuth.state.rawValue),
-                        "supportId": AnyCodable(newAuth.supportId as Any),
-                        "deviceId": AnyCodable(newAuth.deviceId)
-                    ]
-
-                    if let limits = limits {
-                        response["limits"] = AnyCodable([
-                            "reqsPerMin": limits.reqsPerMin as Any,
-                            "tokensPerDay": limits.tokensPerDay as Any,
-                            "tokensPerMonth": limits.tokensPerMonth as Any
-                        ])
-                    }
-
-                    if let usage = usage {
-                        response["usage"] = AnyCodable([
-                            "reqsThisMinute": usage.reqsThisMinute as Any,
-                            "tokensToday": usage.tokensToday as Any,
-                            "tokensThisMonth": usage.tokensThisMonth as Any,
-                            "dayResetAt": usage.dayResetAt as Any,
-                            "monthResetAt": usage.monthResetAt as Any
-                        ])
-                    }
-
-                    bridgeService.respond(to: callbackId, with: response)
-                }
-            }
-
-        // MARK: - Feedback & Support Bundle (D4/D5)
-
-        case "submitFeedback":
-            guard let callbackId = message.callbackId,
-                  let payload = message.payload,
-                  let feedbackType = payload["type"]?.value as? String,
-                  let title = payload["title"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid submitFeedback payload")
-                return
-            }
-            let description = payload["description"]?.value as? String
-            let screenshotBase64 = payload["screenshot"]?.value as? String
-            let screenshotContentType = payload["screenshotContentType"]?.value as? String
-
-            Task {
-                do {
-                    let feedbackId = try await self.deviceKeyService.submitFeedback(
-                        type: feedbackType,
-                        title: title,
-                        description: description,
-                        screenshotBase64: screenshotBase64,
-                        screenshotContentType: screenshotContentType
-                    )
-                    await MainActor.run {
-                        bridgeService.respond(to: callbackId, with: [
-                            "success": AnyCodable(true),
-                            "feedbackId": AnyCodable(feedbackId)
-                        ])
-                    }
-                } catch {
-                    await MainActor.run {
-                        bridgeService.respond(to: callbackId, with: [
-                            "success": AnyCodable(false),
-                            "error": AnyCodable(error.localizedDescription)
-                        ])
-                    }
-                }
-            }
-
-        case "getSupportBundle":
-            guard let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid getSupportBundle payload")
-                return
-            }
-            Task {
-                let bundle = await self.deviceKeyService.getSupportBundle()
-                await MainActor.run {
-                    bridgeService.respond(to: callbackId, with: [
-                        "bundle": AnyCodable(bundle)
-                    ])
-                }
-            }
         case "hybridSearch":
             guard let payload = message.payload,
                   let query = payload["query"]?.value as? String,

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -72,6 +72,9 @@ final class WebViewManager: NSObject {
             bridgeRouter.register(aiHandler)
         }
         bridgeRouter.register(ProxyAuthHandler(container: container))
+        bridgeRouter.register(SettingsMessageHandler(container: container) { [weak self] in
+            self?.settingsWithClassifierState() ?? container.settingsService.allSettings()
+        })
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
@@ -448,84 +451,9 @@ final class WebViewManager: NSObject {
         case "thinkDocument":
             await bridgeRouter.route(message)
 
-        case "loadSettings":
-            let settings = settingsWithClassifierState()
-            bridgeService.send(BridgeMessage(
-                type: "settingsLoaded",
-                payload: ["settings": AnyCodable(settings)]
-            ))
-
-        case "saveSettings":
-            guard let payload = message.payload else {
-                DebugLog.log("[WebViewManager] Invalid saveSettings payload")
-                return
-            }
-
-            // Save OpenAI API key if provided
-            if let openaiKey = payload["openaiAPIKey"]?.value as? String {
-                settingsService.openaiAPIKey = openaiKey.isEmpty ? nil : openaiKey
-            }
-
-            // Save Anthropic API key if provided
-            if let anthropicKey = payload["anthropicAPIKey"]?.value as? String {
-                settingsService.anthropicAPIKey = anthropicKey.isEmpty ? nil : anthropicKey
-            }
-
-            // Save Perplexity API key if provided
-            if let perplexityKey = payload["perplexityAPIKey"]?.value as? String {
-                settingsService.perplexityAPIKey = perplexityKey.isEmpty ? nil : perplexityKey
-            }
-
-            // Save smart routing setting if provided
-            if let smartRouting = payload["smartRoutingEnabled"]?.value as? Bool {
-                settingsService.smartRoutingEnabled = smartRouting
-            }
-
-            // Save default model setting if provided
-            if let modelValue = payload["defaultModel"]?.value as? String,
-               let model = SettingsService.DefaultModel(rawValue: modelValue) {
-                settingsService.defaultModel = model
-            }
-
-            // Save appearance setting if provided
-            if let appearanceValue = payload["appearance"]?.value as? String,
-               let appearance = SettingsService.Appearance(rawValue: appearanceValue) {
-                settingsService.appearance = appearance
-                // Notify AppDelegate to update window appearances
-                NotificationCenter.default.post(name: .appearanceDidChange, object: nil)
-            }
-
-            // Save diagnostics setting if provided
-            if let diagnosticsEnabled = payload["diagnosticsEnabled"]?.value as? Bool {
-                settingsService.diagnosticsEnabled = diagnosticsEnabled
-            }
-
-            // Save editor font setting if provided
-            if let editorFontValue = payload["editorFont"]?.value as? String,
-               let editorFont = SettingsService.EditorFont(rawValue: editorFontValue) {
-                settingsService.editorFont = editorFont
-            }
-
-            // Save editor font size setting if provided
-            if let editorFontSize = payload["editorFontSize"]?.value as? Double {
-                settingsService.editorFontSize = editorFontSize
-            } else if let editorFontSize = payload["editorFontSize"]?.value as? NSNumber {
-                settingsService.editorFontSize = editorFontSize.doubleValue
-            }
-
-            // Save editor line spacing setting if provided
-            if let editorLineSpacing = payload["editorLineSpacing"]?.value as? Double {
-                settingsService.editorLineSpacing = editorLineSpacing
-            } else if let editorLineSpacing = payload["editorLineSpacing"]?.value as? NSNumber {
-                settingsService.editorLineSpacing = editorLineSpacing.doubleValue
-            }
-
-            // Send back updated settings
-            let settings = settingsWithClassifierState()
-            bridgeService.send(BridgeMessage(
-                type: "settingsLoaded",
-                payload: ["settings": AnyCodable(settings)]
-            ))
+        case "loadSettings",
+             "saveSettings":
+            await bridgeRouter.route(message)
 
         case "loadProxyAuth",
              "setProxyDeviceKey",

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -9,6 +9,7 @@ final class WebViewManager: NSObject {
     private let settingsService: SettingsService
     private let deviceKeyService: DeviceKeyService
     let bridgeService: BridgeService
+    private let bridgeRouter = BridgeRouter()
     let persistence: PersistenceService?
     private let sourceService: SourceService?
     private let proxyService: ProxyLLMService  // For proxy-mode AI operations
@@ -60,6 +61,10 @@ final class WebViewManager: NSObject {
         self.assetService = container.assetService
 
         super.init()
+
+        if let streamHandler = StreamMessageHandler(container: container, delegate: self) {
+            bridgeRouter.register(streamHandler)
+        }
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
@@ -415,91 +420,14 @@ final class WebViewManager: NSObject {
         }
 
         switch message.type {
-        case "loadStreams":
-            do {
-                let summaries = try persistence.loadStreamSummaries()
-                let payload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to load streams (\(DebugLog.errorSummary(error)))")
-            }
-
-        case "loadStream":
-            guard let payload = message.payload,
-                  let idValue = payload["id"]?.value as? String,
-                  let id = UUID(uuidString: idValue) else {
-                DebugLog.log("[WebViewManager] Invalid loadStream payload")
-                return
-            }
-            currentStreamIdForFileDrops = id
-            if let activeStreamId = activePDFPaneStreamId, activeStreamId != id {
-                await MainActor.run {
-                    pdfPaneController.setVisible(false)
-                    activePDFPaneStreamId = nil
-                }
-            }
-            do {
-                if let stream = try persistence.loadStream(id: id) {
-                    let document = try persistence.loadOrCreateStreamDocument(streamId: id)
-
-                    let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
-                }
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to load stream (\(DebugLog.errorSummary(error)))")
-            }
-
-        case "createStream":
-            let title = (message.payload?["title"]?.value as? String) ?? "Untitled"
-            do {
-                let stream = try persistence.createStream(title: title)
-                currentStreamIdForFileDrops = stream.id
-                let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
-                let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
-            }
-
-        case "updateStreamTitle":
-            guard let payload = message.payload,
-                  let idValue = payload["id"]?.value as? String,
-                  let id = UUID(uuidString: idValue),
-                  let title = payload["title"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid updateStreamTitle payload")
-                return
-            }
-            do {
-                if var stream = try persistence.loadStream(id: id) {
-                    stream.title = title
-                    try persistence.updateStream(stream)
-                    bridgeService.send(BridgeMessage(type: "streamTitleUpdated", payload: ["id": AnyCodable(id.uuidString), "title": AnyCodable(title)]))
-                }
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to update stream title (\(DebugLog.errorSummary(error)))")
-            }
-
-        case "deleteStream":
-            guard let payload = message.payload,
-                  let idValue = payload["id"]?.value as? String,
-                  let id = UUID(uuidString: idValue) else {
-                DebugLog.log("[WebViewManager] Invalid deleteStream payload")
-                return
-            }
-            do {
-                try persistence.deleteStream(id: id)
-                if currentStreamIdForFileDrops == id {
-                    currentStreamIdForFileDrops = nil
-                }
-                // Also delete stream assets (images, etc.)
-                try? assetService.deleteAssets(for: id)
-                // Reload streams list
-                let summaries = try persistence.loadStreamSummaries()
-                let summariesPayload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: summariesPayload))
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to delete stream (\(DebugLog.errorSummary(error)))")
-            }
+        case "loadStreams",
+             "loadStream",
+             "createStream",
+             "updateStreamTitle",
+             "deleteStream",
+             "saveStreamDocument",
+             "exportStream":
+            await bridgeRouter.route(message)
 
         case "setFileDropContext":
             let mode = message.payload?["mode"]?.value as? String
@@ -527,20 +455,6 @@ final class WebViewManager: NSObject {
                     pdfPaneController.setVisible(false)
                     activePDFPaneStreamId = nil
                 }
-            }
-
-        case "saveStreamDocument":
-            guard let payload = message.payload,
-                  let streamIdValue = payload["streamId"]?.value as? String,
-                  let streamId = UUID(uuidString: streamIdValue),
-                  let markdown = payload["markdown"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
-                return
-            }
-            do {
-                try persistence.saveStreamDocument(streamId: streamId, markdown: markdown)
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
             }
 
         case "addSource":
@@ -754,73 +668,6 @@ final class WebViewManager: NSObject {
                         ))
                     }
                 )
-            }
-
-        case "exportStream":
-            guard let payload = message.payload,
-                  let streamIdString = payload["streamId"]?.value as? String,
-                  let streamId = UUID(uuidString: streamIdString),
-                  let format = payload["format"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid exportStream payload")
-                return
-            }
-
-            do {
-                guard let stream = try persistence.loadStream(id: streamId) else {
-                    DebugLog.log("[WebViewManager] Stream not found for export")
-                    bridgeService.send(BridgeMessage(type: "exportError", payload: [
-                        "streamId": AnyCodable(streamIdString),
-                        "error": AnyCodable("Stream not found")
-                    ]))
-                    return
-                }
-                let document = try persistence.loadOrCreateStreamDocument(streamId: streamId)
-
-                // Convert to export format
-                let content = StreamCodec.formatStreamForExport(stream: stream, document: document, format: format)
-                let fileExtension = format == "markdown" ? ".md" : ".txt"
-                let suggestedName = StreamCodec.sanitizeFilename(stream.title) + fileExtension
-
-                // Show save panel on main thread
-                await MainActor.run {
-                    let savePanel = NSSavePanel()
-                    savePanel.nameFieldStringValue = suggestedName
-                    // Use appropriate content type for the format
-                    if format == "markdown" {
-                        savePanel.allowedContentTypes = [.init(filenameExtension: "md") ?? .plainText]
-                    } else {
-                        savePanel.allowedContentTypes = [.plainText]
-                    }
-                    savePanel.message = "Export stream as \(format == "markdown" ? "Markdown" : "Plain Text")"
-
-                    let result = savePanel.runModal()
-                    if result == .OK, let url = savePanel.url {
-                        do {
-                            try content.write(to: url, atomically: true, encoding: .utf8)
-                            bridgeService.send(BridgeMessage(type: "exportComplete", payload: [
-                                "streamId": AnyCodable(streamId.uuidString),
-                                "path": AnyCodable(url.path)
-                            ]))
-                        } catch {
-                            DebugLog.log("[WebViewManager] Failed to write export file (\(DebugLog.errorSummary(error)))")
-                            bridgeService.send(BridgeMessage(type: "exportError", payload: [
-                                "streamId": AnyCodable(streamId.uuidString),
-                                "error": AnyCodable(error.localizedDescription)
-                            ]))
-                        }
-                    } else {
-                        // User canceled - no error, just inform frontend
-                        bridgeService.send(BridgeMessage(type: "exportCanceled", payload: [
-                            "streamId": AnyCodable(streamId.uuidString)
-                        ]))
-                    }
-                }
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to load stream for export (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "exportError", payload: [
-                    "streamId": AnyCodable(streamIdString),
-                    "error": AnyCodable(error.localizedDescription)
-                ]))
             }
 
         case "loadSettings":
@@ -1215,6 +1062,27 @@ final class WebViewManager: NSObject {
         return settings
     }
 
+}
+
+extension WebViewManager: StreamMessageHandlerDelegate {
+    func setCurrentStreamIdForFileDrops(_ streamId: UUID?) {
+        currentStreamIdForFileDrops = streamId
+    }
+
+    func clearCurrentStreamIdForFileDrops(ifMatches streamId: UUID) {
+        if currentStreamIdForFileDrops == streamId {
+            currentStreamIdForFileDrops = nil
+        }
+    }
+
+    func closePDFPaneIfShowingDifferentStream(_ streamId: UUID) async {
+        if let activeStreamId = activePDFPaneStreamId, activeStreamId != streamId {
+            await MainActor.run {
+                pdfPaneController.setVisible(false)
+                activePDFPaneStreamId = nil
+            }
+        }
+    }
 }
 
 extension WebViewManager: WKNavigationDelegate {

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -68,6 +68,9 @@ final class WebViewManager: NSObject {
         if let sourceHandler = SourceMessageHandler(container: container, delegate: self) {
             bridgeRouter.register(sourceHandler)
         }
+        if let aiHandler = AIMessageHandler(container: container) {
+            bridgeRouter.register(aiHandler)
+        }
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
@@ -417,7 +420,7 @@ final class WebViewManager: NSObject {
     }
 
     private func processMessage(_ message: BridgeMessage) async {
-        guard let persistence else {
+        guard persistence != nil else {
             DebugLog.log("[WebViewManager] Persistence not available")
             return
         }
@@ -442,126 +445,7 @@ final class WebViewManager: NSObject {
             await bridgeRouter.route(message)
 
         case "thinkDocument":
-            guard let payload = message.payload,
-                  let requestId = payload["requestId"]?.value as? String,
-                  let query = payload["query"]?.value as? String else {
-                DebugLog.log("[WebViewManager] Invalid thinkDocument payload")
-                return
-            }
-
-            let imageURLs = payload["imageURLs"]?.value as? [String] ?? []
-            let imageDataURLs = assetService.assetsToDataURLs(imageURLs)
-            if !imageDataURLs.isEmpty {
-                DebugLog.log("ThinkDocument: Converting \(imageURLs.count) images to data URLs")
-            }
-
-            var streamIdForRAG: UUID? = nil
-            var sourceContext: String? = nil
-
-            if let streamIdValue = payload["streamId"]?.value as? String,
-               let streamId = UUID(uuidString: streamIdValue) {
-                streamIdForRAG = streamId
-
-                if let stream = try? persistence.loadStream(id: streamId) {
-                    let combinedText = stream.sources
-                        .compactMap { $0.extractedText }
-                        .joined(separator: "\n\n---\n\n")
-                    if !combinedText.isEmpty {
-                        sourceContext = combinedText
-                    }
-                }
-            }
-
-            var resolvedQuery = query
-            if let context = payload["context"]?.value as? String, !context.isEmpty {
-                let cleanContext = context
-                    .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-                    .replacingOccurrences(of: "&nbsp;", with: " ")
-                    .replacingOccurrences(of: "&amp;", with: "&")
-                    .replacingOccurrences(of: "&lt;", with: "<")
-                    .replacingOccurrences(of: "&gt;", with: ">")
-                    .replacingOccurrences(of: "&quot;", with: "\"")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if !cleanContext.isEmpty {
-                    resolvedQuery = "Regarding this context:\n\"\"\"\n\(cleanContext)\n\"\"\"\n\n\(resolvedQuery)"
-                }
-            }
-
-            let onChunk: (String) -> Void = { [weak self] chunk in
-                self?.bridgeService.send(BridgeMessage(
-                    type: "documentAIChunk",
-                    payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
-                ))
-            }
-            let onComplete: () -> Void = { [weak self] in
-                self?.bridgeService.send(BridgeMessage(
-                    type: "documentAIComplete",
-                    payload: ["requestId": AnyCodable(requestId)]
-                ))
-            }
-            let onError: (Error) -> Void = { [weak self] error in
-                var payload: [String: AnyCodable] = [
-                    "requestId": AnyCodable(requestId),
-                    "error": AnyCodable(error.localizedDescription)
-                ]
-
-                if let proxyError = error as? ProxyLLMError {
-                    payload["errorCode"] = AnyCodable(proxyError.errorCode)
-                    if let proxyRequestId = proxyError.requestId {
-                        payload["proxyRequestId"] = AnyCodable(proxyRequestId)
-                    }
-
-                    if case .quotaExceeded(let details) = proxyError {
-                        payload["quotaScope"] = AnyCodable(details.scope)
-                        payload["quotaLimit"] = AnyCodable(details.limit)
-                        payload["quotaUsed"] = AnyCodable(details.used)
-                        payload["quotaResetAt"] = AnyCodable(details.resetAt)
-                    }
-
-                    if case .rateLimited(let retryAfter) = proxyError {
-                        if let seconds = retryAfter {
-                            payload["retryAfter"] = AnyCodable(seconds)
-                        }
-                    }
-                }
-
-                self?.bridgeService.send(BridgeMessage(
-                    type: "documentAIError",
-                    payload: payload
-                ))
-            }
-
-            Task { [weak self] in
-                guard let self else { return }
-
-                let proxyUsable = await self.deviceKeyService.currentState.isUsable
-
-                guard proxyUsable else {
-                    await MainActor.run {
-                        onError(OrchestratorError.noProviderAvailable)
-                    }
-                    return
-                }
-
-                await self.orchestrator.route(
-                    query: resolvedQuery,
-                    queryImages: imageDataURLs,
-                    streamId: streamIdForRAG,
-                    priorCells: [],
-                    sourceContext: sourceContext,
-                    includeHeading: false,
-                    onChunk: onChunk,
-                    onComplete: onComplete,
-                    onError: onError,
-                    onModelSelected: { [weak self] modelId in
-                        self?.bridgeService.send(BridgeMessage(
-                            type: "documentModelSelected",
-                            payload: ["requestId": AnyCodable(requestId), "modelId": AnyCodable(modelId)]
-                        ))
-                    }
-                )
-            }
+            await bridgeRouter.route(message)
 
         case "loadSettings":
             let settings = settingsWithClassifierState()

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -6,7 +6,7 @@ final class WebViewManager: NSObject {
     private let settingsService: SettingsService
     private let deviceKeyService: DeviceKeyService
     let bridgeService: BridgeService
-    private let bridgeRouter = BridgeRouter()
+    private let bridgeRouter: BridgeRouter
     let persistence: PersistenceService?
     private let sourceService: SourceService?
     let orchestrator: AIOrchestrator
@@ -26,6 +26,7 @@ final class WebViewManager: NSObject {
         self.settingsService = container.settingsService
         self.deviceKeyService = container.deviceKeyService
         self.bridgeService = container.bridgeService
+        self.bridgeRouter = BridgeRouter(bridgeService: container.bridgeService)
         config.userContentController.add(bridgeService, name: "bridge")
         let schemeHandler = AssetSchemeHandler()
         config.setURLSchemeHandler(schemeHandler, forURLScheme: "ticker-asset")

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -1,8 +1,5 @@
 import WebKit
 import AppKit
-import UniformTypeIdentifiers
-
-/// Manages the WKWebView and Swift ↔ JS bridge
 final class WebViewManager: NSObject {
     let webView: DroppableWebView
     var rootView: NSView { hostView }
@@ -12,18 +9,9 @@ final class WebViewManager: NSObject {
     private let bridgeRouter = BridgeRouter()
     let persistence: PersistenceService?
     private let sourceService: SourceService?
-    private let proxyService: ProxyLLMService  // For proxy-mode AI operations
-    let orchestrator: AIOrchestrator  // Exposed for Quick Panel ephemeral AI
+    let orchestrator: AIOrchestrator
     private var mlxClassifier: MLXClassifier?
-    private var classifierSkipped = false  // True if classifier loading was intentionally skipped
-
-    // RAG services
-    private let embeddingService: EmbeddingService
-    private let chunkingService: ChunkingService
-    private var retrievalService: RetrievalService?
-    private var searchService: SearchService?
-
-    // Asset management
+    private var classifierSkipped = false
     private let assetService: AssetService
     private var currentStreamIdForFileDrops: UUID?
     private var allowsListFileDrops = false
@@ -31,7 +19,6 @@ final class WebViewManager: NSObject {
     private let editorPaneView = NSView(frame: .zero)
     private let pdfPaneController = PDFReaderPaneController()
     private var activePDFPaneStreamId: UUID?
-
     init(container: ServiceContainer) {
         let config = WKWebViewConfiguration()
         config.preferences.setValue(true, forKey: "developerExtrasEnabled")
@@ -40,28 +27,17 @@ final class WebViewManager: NSObject {
         self.deviceKeyService = container.deviceKeyService
         self.bridgeService = container.bridgeService
         config.userContentController.add(bridgeService, name: "bridge")
-
-        // Register custom URL scheme handler for local assets
         let schemeHandler = AssetSchemeHandler()
         config.setURLSchemeHandler(schemeHandler, forURLScheme: "ticker-asset")
-
-        // Register custom URL scheme handler for bundled web resources (Release mode)
         let bundleHandler = BundleSchemeHandler()
         config.setURLSchemeHandler(bundleHandler, forURLScheme: "ticker-bundle")
 
         self.webView = DroppableWebView(frame: .zero, configuration: config)
-        self.proxyService = container.proxyService
-        self.embeddingService = container.embeddingService
-        self.chunkingService = container.chunkingService
         self.orchestrator = container.orchestrator
         self.persistence = container.persistence
         self.sourceService = container.sourceService
-        self.retrievalService = container.retrievalService
-        self.searchService = container.searchService
         self.assetService = container.assetService
-
         super.init()
-
         if let streamHandler = StreamMessageHandler(container: container, delegate: self) {
             bridgeRouter.register(streamHandler)
         }
@@ -75,7 +51,7 @@ final class WebViewManager: NSObject {
         bridgeRouter.register(SettingsMessageHandler(container: container) { [weak self] in
             self?.settingsWithClassifierState() ?? container.settingsService.allSettings()
         })
-
+        bridgeRouter.register(SearchMessageHandler(container: container))
         webView.translatesAutoresizingMaskIntoConstraints = false
         configureMainLayout()
         configurePDFPaneCallbacks()
@@ -85,23 +61,18 @@ final class WebViewManager: NSObject {
         bridgeService.onMessage = { [weak self] message in
             self?.handleMessage(message)
         }
-
-        // Handle file drops from native drag-and-drop
         webView.onFilesDropped = { [weak self] urls in
             self?.handleDroppedFiles(urls)
         }
 
-        // Initialize DeviceKeyService and wire up state change callback
         Task { [weak self] in
             guard let self else { return }
             await deviceKeyService.onStateChange = { [weak self] state in
-                // Push state to Web
                 self?.bridgeService.send(BridgeMessage(
                     type: "proxyAuthState",
                     payload: ["state": AnyCodable(state.rawValue)]
                 ))
             }
-            // Initialize and validate cached key
             await deviceKeyService.initialize()
         }
     }
@@ -144,7 +115,6 @@ final class WebViewManager: NSObject {
         }
     }
 
-    /// Handle files dropped via native macOS drag-and-drop
     private func handleDroppedFiles(_ urls: [URL]) {
         guard !urls.isEmpty else { return }
 
@@ -168,8 +138,6 @@ final class WebViewManager: NSObject {
         }
     }
 
-    /// Handle drops while no stream is open (stream list/default page).
-    /// A dropped PDF creates a new stream, attaches the source, and opens the document.
     private func handleDroppedFilesFromStreamList(_ urls: [URL]) {
         guard let persistence else {
             bridgeService.send(BridgeMessage(type: "fileDropError", payload: [
@@ -206,7 +174,6 @@ final class WebViewManager: NSObject {
                 "stream": AnyCodable(streamPayload)
             ]))
 
-            // Refresh the list in the background so counts/titles stay current when user navigates back.
             let summaries = try persistence.loadStreamSummaries()
             let payload = StreamCodec.encodeSummaries(summaries)
             bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: payload))
@@ -215,12 +182,10 @@ final class WebViewManager: NSObject {
             bridgeService.send(BridgeMessage(type: "fileDropError", payload: [
                 "error": AnyCodable("Could not create stream from dropped PDF.")
             ]))
-            // Keep drop target unset when stream creation fails.
             currentStreamIdForFileDrops = nil
         }
     }
 
-    /// Check if URL points to an image file
     private func isImageFile(_ url: URL) -> Bool {
         let imageExtensions = ["png", "jpg", "jpeg", "gif", "webp", "heic", "heif", "tiff", "bmp"]
         return imageExtensions.contains(url.pathExtension.lowercased())
@@ -236,7 +201,6 @@ final class WebViewManager: NSObject {
         return try work()
     }
 
-    /// Process a dropped image - save to assets and notify frontend
     private func processDroppedImage(_ url: URL, streamId: UUID) {
         do {
             let imageData = try withSecurityScopedAccess(url) { try Data(contentsOf: url) }
@@ -246,7 +210,6 @@ final class WebViewManager: NSObject {
                 filename: url.lastPathComponent
             )
 
-            // Portable, privacy-preserving URL (no absolute user paths).
             let assetUrl = "ticker-asset:///\(relativePath)"
 
             bridgeService.send(BridgeMessage(type: "imageDropped", payload: [
@@ -262,7 +225,6 @@ final class WebViewManager: NSObject {
         }
     }
 
-    /// Process a dropped document - add as source
     private func processDroppedDocument(_ url: URL, streamId: UUID) {
         guard let sourceService else {
             bridgeService.send(BridgeMessage(type: "sourceError", payload: [
@@ -346,13 +308,11 @@ final class WebViewManager: NSObject {
         migrateExistingSourcesToRAG()
     }
 
-    /// Migrate existing sources to RAG pipeline in background
     private func migrateExistingSourcesToRAG() {
         guard !SettingsService.proxyOnlyMode else { return }
         guard let persistence, let sourceService else { return }
 
         Task {
-            // Wait 5 seconds after app launch to avoid blocking startup
             try? await Task.sleep(nanoseconds: 5_000_000_000)
 
             let migrationService = RAGMigrationService(
@@ -363,17 +323,13 @@ final class WebViewManager: NSObject {
         }
     }
 
-    /// Load the MLX classifier in the background (only if smart routing enabled)
     private func loadMLXClassifier() {
-        // Unit tests should not trigger heavyweight MLX model downloads or background loading.
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             DebugLog.log("MLX classifier skipped: running unit tests")
             classifierSkipped = true
             return
         }
 
-        // Only load classifier if smart routing is enabled
-        // Note: No vendor keys required - classifier runs locally, proxy handles routing
         guard settingsService.smartRoutingEnabled else {
             DebugLog.log("MLX classifier skipped: smart routing disabled")
             classifierSkipped = true
@@ -391,10 +347,8 @@ final class WebViewManager: NSObject {
                 DebugLog.log("MLX classifier loaded and ready")
             } catch {
                 DebugLog.log("Failed to load MLX classifier (\(DebugLog.errorSummary(error)))")
-                // App continues to work, just uses direct GPT calls
             }
 
-            // Notify frontend of classifier state change
             let settings = settingsWithClassifierState()
             bridgeService.send(BridgeMessage(
                 type: "settingsLoaded",
@@ -404,8 +358,6 @@ final class WebViewManager: NSObject {
     }
 
     private func loadWebContent() {
-        // In development, load from Vite dev server
-        // In production, load via custom scheme to avoid file:// URL issues with ES modules
         #if DEBUG
         if let url = URL(string: "http://localhost:5173") {
             webView.load(URLRequest(url: url))
@@ -418,103 +370,16 @@ final class WebViewManager: NSObject {
     }
 
     private func handleMessage(_ message: BridgeMessage) {
-        Task {
-            await processMessage(message)
+        Task { [weak self] in
+            guard let self else { return }
+            guard persistence != nil else {
+                DebugLog.log("[WebViewManager] Persistence not available")
+                return
+            }
+            await bridgeRouter.route(message)
         }
     }
 
-    private func processMessage(_ message: BridgeMessage) async {
-        guard persistence != nil else {
-            DebugLog.log("[WebViewManager] Persistence not available")
-            return
-        }
-
-        switch message.type {
-        case "loadStreams",
-             "loadStream",
-             "createStream",
-             "updateStreamTitle",
-             "deleteStream",
-             "saveStreamDocument",
-             "exportStream":
-            await bridgeRouter.route(message)
-
-        case "setFileDropContext",
-             "addSource",
-             "addSourceFromPath",
-             "removeSource",
-             "openSource",
-             "saveImage",
-             "getAssetPath":
-            await bridgeRouter.route(message)
-
-        case "thinkDocument":
-            await bridgeRouter.route(message)
-
-        case "loadSettings",
-             "saveSettings":
-            await bridgeRouter.route(message)
-
-        case "loadProxyAuth",
-             "setProxyDeviceKey",
-             "clearProxyDeviceKey",
-             "validateProxyDeviceKey",
-             "refreshProxyAuth",
-             "submitFeedback",
-             "getSupportBundle":
-            await bridgeRouter.route(message)
-
-        case "hybridSearch":
-            guard let payload = message.payload,
-                  let query = payload["query"]?.value as? String,
-                  let currentStreamIdStr = payload["currentStreamId"]?.value as? String,
-                  let currentStreamId = UUID(uuidString: currentStreamIdStr),
-                  let callbackId = message.callbackId else {
-                DebugLog.log("[WebViewManager] Invalid hybridSearch payload")
-                return
-            }
-
-            let limit = payload["limit"]?.value as? Int ?? 20
-
-            guard let searchService = searchService else {
-                Task { @MainActor in
-                    bridgeService.respondWithError(to: callbackId, error: "Search service not available")
-                }
-                return
-            }
-
-            Task {
-                do {
-                    let results = try await searchService.hybridSearch(
-                        query: query,
-                        currentStreamId: currentStreamId,
-                        limit: limit
-                    )
-
-                    // Encode results to JSON-compatible format
-                    let encoder = JSONEncoder()
-                    let data = try encoder.encode(results)
-                    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
-
-                    await MainActor.run {
-                        bridgeService.respond(to: callbackId, with: [
-                            "currentStreamResults": AnyCodable(json["currentStreamResults"]),
-                            "otherStreamResults": AnyCodable(json["otherStreamResults"])
-                        ])
-                    }
-                } catch {
-                    await MainActor.run {
-                        bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
-                    }
-                }
-            }
-
-        default:
-            DebugLog.log("[WebViewManager] Unknown message type: \(message.type)")
-        }
-    }
-
-    /// Get settings enriched with classifier state
     private func settingsWithClassifierState() -> [String: Any] {
         var settings = settingsService.allSettings()
         if let classifier = mlxClassifier {
@@ -524,11 +389,9 @@ final class WebViewManager: NSObject {
                 settings["classifierError"] = error.localizedDescription
             }
         } else if classifierSkipped {
-            // Classifier was intentionally skipped (smart routing disabled by user)
             settings["classifierReady"] = false
             settings["classifierLoading"] = false
         } else {
-            // Classifier hasn't been loaded yet
             settings["classifierReady"] = false
             settings["classifierLoading"] = true
         }
@@ -543,17 +406,14 @@ extension WebViewManager: StreamMessageHandlerDelegate {
     }
 
     func clearCurrentStreamIdForFileDrops(ifMatches streamId: UUID) {
-        if currentStreamIdForFileDrops == streamId {
-            currentStreamIdForFileDrops = nil
-        }
+        if currentStreamIdForFileDrops == streamId { currentStreamIdForFileDrops = nil }
     }
 
     func closePDFPaneIfShowingDifferentStream(_ streamId: UUID) async {
-        if let activeStreamId = activePDFPaneStreamId, activeStreamId != streamId {
-            await MainActor.run {
-                pdfPaneController.setVisible(false)
-                activePDFPaneStreamId = nil
-            }
+        guard let activeStreamId = activePDFPaneStreamId, activeStreamId != streamId else { return }
+        await MainActor.run {
+            pdfPaneController.setVisible(false)
+            activePDFPaneStreamId = nil
         }
     }
 }
@@ -576,15 +436,12 @@ extension WebViewManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         DebugLog.log("[WebViewManager] WebView started loading")
     }
-
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         DebugLog.log("[WebViewManager] WebView finished loading")
     }
-
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         DebugLog.log("[WebViewManager] WebView navigation failed (\(DebugLog.errorSummary(error)))")
     }
-
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         DebugLog.log("[WebViewManager] WebView provisional navigation failed (\(DebugLog.errorSummary(error)))")
     }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -37,17 +37,20 @@ struct StreamSummary: Identifiable, Codable {
 struct StreamDocument: Codable {
     let streamId: UUID
     var markdown: String
+    var revision: Int
     let createdAt: Date
     var updatedAt: Date
 
     init(
         streamId: UUID,
         markdown: String = "",
+        revision: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.streamId = streamId
         self.markdown = markdown
+        self.revision = revision
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -4,6 +4,13 @@ import GRDB
 struct AppendResult {
     let fragment: String
     let isNewDocument: Bool
+    let revision: Int
+}
+
+struct StreamDocumentRevisionConflict: Error {
+    let streamId: UUID
+    let markdown: String
+    let revision: Int
 }
 
 /// Manages SQLite persistence for streams, stream documents, and sources
@@ -326,6 +333,12 @@ final class PersistenceService {
             }
         }
 
+        migrator.registerMigration("v13_stream_document_revision") { db in
+            try db.alter(table: "stream_documents") { t in
+                t.add(column: "revision", .integer).notNull().defaults(to: 0)
+            }
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -525,7 +538,7 @@ final class PersistenceService {
         try dbQueue.read { db in
             guard let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) else {
                 return nil
@@ -534,6 +547,7 @@ final class PersistenceService {
             return StreamDocument(
                 streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                 markdown: row["markdown"],
+                revision: row["revision"],
                 createdAt: Date(timeIntervalSince1970: row["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: row["updated_at"])
             )
@@ -545,12 +559,13 @@ final class PersistenceService {
         try dbQueue.write { db in
             if let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) {
                 return StreamDocument(
                     streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                     markdown: row["markdown"],
+                    revision: row["revision"],
                     createdAt: Date(timeIntervalSince1970: row["created_at"]),
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"])
                 )
@@ -573,30 +588,80 @@ final class PersistenceService {
             return StreamDocument(
                 streamId: streamId,
                 markdown: markdown,
+                revision: 0,
                 createdAt: now,
                 updatedAt: now
             )
         }
     }
 
-    func saveStreamDocument(streamId: UUID, markdown: String) throws {
+    @discardableResult
+    func saveStreamDocument(streamId: UUID, markdown: String) throws -> Int {
+        let document = try loadOrCreateStreamDocument(streamId: streamId)
+        return try saveStreamDocument(streamId: streamId, markdown: markdown, baseRevision: document.revision)
+    }
+
+    @discardableResult
+    func saveStreamDocument(streamId: UUID, markdown: String, baseRevision: Int) throws -> Int {
         let now = Date().timeIntervalSince1970
-        try dbQueue.write { db in
+        return try dbQueue.write { db in
+            if let row = try Row.fetchOne(
+                db,
+                sql: "SELECT markdown, revision FROM stream_documents WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            ) {
+                let currentMarkdown: String = row["markdown"]
+                let currentRevision: Int = row["revision"]
+
+                guard baseRevision == currentRevision else {
+                    throw StreamDocumentRevisionConflict(
+                        streamId: streamId,
+                        markdown: currentMarkdown,
+                        revision: currentRevision
+                    )
+                }
+
+                let newRevision = currentRevision + 1
+                try db.execute(
+                    sql: """
+                        UPDATE stream_documents
+                        SET markdown = ?, revision = ?, updated_at = ?
+                        WHERE stream_id = ?
+                    """,
+                    arguments: [markdown, newRevision, now, streamId.uuidString]
+                )
+
+                try db.execute(
+                    sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
+                    arguments: [now, streamId.uuidString]
+                )
+
+                return newRevision
+            }
+
+            guard baseRevision == 0 else {
+                throw StreamDocumentRevisionConflict(
+                    streamId: streamId,
+                    markdown: "",
+                    revision: 0
+                )
+            }
+
+            let newRevision = 1
             try db.execute(
                 sql: """
-                    INSERT INTO stream_documents (stream_id, markdown, created_at, updated_at)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(stream_id) DO UPDATE SET
-                        markdown = excluded.markdown,
-                        updated_at = excluded.updated_at
+                    INSERT INTO stream_documents (stream_id, markdown, revision, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
                 """,
-                arguments: [streamId.uuidString, markdown, now, now]
+                arguments: [streamId.uuidString, markdown, newRevision, now, now]
             )
 
             try db.execute(
                 sql: "UPDATE streams SET updated_at = ? WHERE id = ?",
                 arguments: [now, streamId.uuidString]
             )
+
+            return newRevision
         }
     }
 
@@ -604,33 +669,38 @@ final class PersistenceService {
         try dbQueue.write { db in
             let now = Date().timeIntervalSince1970
             let existingMarkdown: String
+            let existingRevision: Int
             let isNewDocument: Bool
 
             if let row = try Row.fetchOne(
                 db,
-                sql: "SELECT markdown FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT markdown, revision FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) {
                 existingMarkdown = row["markdown"]
+                existingRevision = row["revision"]
                 isNewDocument = false
             } else {
                 existingMarkdown = ""
+                existingRevision = 0
                 isNewDocument = true
             }
 
             let markdown = existingMarkdown.isEmpty
                 ? fragment
                 : "\(existingMarkdown)\n\n\(fragment)"
+            let newRevision = existingRevision + 1
 
             try db.execute(
                 sql: """
-                    INSERT INTO stream_documents (stream_id, markdown, created_at, updated_at)
-                    VALUES (?, ?, ?, ?)
+                    INSERT INTO stream_documents (stream_id, markdown, revision, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
                     ON CONFLICT(stream_id) DO UPDATE SET
                         markdown = excluded.markdown,
+                        revision = excluded.revision,
                         updated_at = excluded.updated_at
                 """,
-                arguments: [streamId.uuidString, markdown, now, now]
+                arguments: [streamId.uuidString, markdown, newRevision, now, now]
             )
 
             try db.execute(
@@ -638,7 +708,7 @@ final class PersistenceService {
                 arguments: [now, streamId.uuidString]
             )
 
-            return AppendResult(fragment: fragment, isNewDocument: isNewDocument)
+            return AppendResult(fragment: fragment, isNewDocument: isNewDocument, revision: newRevision)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -107,6 +107,93 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_saveStreamDocumentWithCurrentRevisionIncrementsRevision() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Revision Save")
+            try service.saveStream(stream)
+
+            let initialDocument = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            XCTAssertEqual(initialDocument.revision, 0)
+
+            let firstRevision = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "First save",
+                baseRevision: initialDocument.revision
+            )
+            XCTAssertEqual(firstRevision, 1)
+
+            let firstDocument = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(firstDocument.markdown, "First save")
+            XCTAssertEqual(firstDocument.revision, 1)
+
+            let secondRevision = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Second save",
+                baseRevision: firstDocument.revision
+            )
+            XCTAssertEqual(secondRevision, 2)
+
+            let secondDocument = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(secondDocument.markdown, "Second save")
+            XCTAssertEqual(secondDocument.revision, 2)
+        }
+    }
+
+    func test_appendToStreamDocumentIncrementsRevision() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Append Revision")
+            try service.saveStream(stream)
+
+            let initialDocument = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            XCTAssertEqual(initialDocument.revision, 0)
+
+            let firstAppend = try service.appendToStreamDocument(streamId: stream.id, fragment: "First append")
+            XCTAssertEqual(firstAppend.revision, 1)
+
+            let secondAppend = try service.appendToStreamDocument(streamId: stream.id, fragment: "Second append")
+            XCTAssertEqual(secondAppend.revision, 2)
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "First append\n\nSecond append")
+            XCTAssertEqual(document.revision, 2)
+        }
+    }
+
+    func test_staleRevisionSaveDoesNotClobberInterleavedAppend() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Conflict Guard")
+            try service.saveStream(stream)
+
+            let initialDocument = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            let savedRevision = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Editor draft",
+                baseRevision: initialDocument.revision
+            )
+            XCTAssertEqual(savedRevision, 1)
+
+            let append = try service.appendToStreamDocument(streamId: stream.id, fragment: "External append")
+            XCTAssertEqual(append.revision, 2)
+
+            do {
+                _ = try service.saveStreamDocument(
+                    streamId: stream.id,
+                    markdown: "Editor stale overwrite",
+                    baseRevision: savedRevision
+                )
+                XCTFail("Expected stale revision save to throw")
+            } catch let conflict as StreamDocumentRevisionConflict {
+                XCTAssertEqual(conflict.streamId, stream.id)
+                XCTAssertEqual(conflict.revision, append.revision)
+                XCTAssertEqual(conflict.markdown, "Editor draft\n\nExternal append")
+            }
+
+            let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(document.markdown, "Editor draft\n\nExternal append")
+            XCTAssertEqual(document.revision, append.revision)
+        }
+    }
+
     func test_textSearchFindsStreamDocumentWithSnippet() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Searchable Stream")

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A1000001000000000037 /* AIMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000037 /* AIMessageHandler.swift */; };
 		A1000001000000000038 /* ProxyAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000038 /* ProxyAuthHandler.swift */; };
 		A1000001000000000039 /* SettingsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000039 /* SettingsMessageHandler.swift */; };
+		A100000100000000003A /* SearchMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000003A /* SearchMessageHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -91,6 +92,7 @@
 		B1000001000000000037 /* AIMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000038 /* ProxyAuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyAuthHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000039 /* SettingsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMessageHandler.swift; sourceTree = "<group>"; };
+		B100000100000000003A /* SearchMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				B1000001000000000037 /* AIMessageHandler.swift */,
 				B1000001000000000038 /* ProxyAuthHandler.swift */,
 				B1000001000000000039 /* SettingsMessageHandler.swift */,
+				B100000100000000003A /* SearchMessageHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -473,6 +476,7 @@
 				A1000001000000000037 /* AIMessageHandler.swift in Sources */,
 				A1000001000000000038 /* ProxyAuthHandler.swift in Sources */,
 				A1000001000000000039 /* SettingsMessageHandler.swift in Sources */,
+				A100000100000000003A /* SearchMessageHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		A1000001000000000003 /* BridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000003 /* BridgeService.swift */; };
 		A1000001000000000004 /* DroppableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000004 /* DroppableWebView.swift */; };
 		A1000001000000000032 /* ServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000032 /* ServiceContainer.swift */; };
+		A1000001000000000033 /* BridgeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000033 /* BridgeRouter.swift */; };
+		A1000001000000000034 /* StreamCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000034 /* StreamCodec.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -77,6 +79,8 @@
 		B1000001000000000003 /* BridgeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeService.swift; sourceTree = "<group>"; };
 		B1000001000000000004 /* DroppableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroppableWebView.swift; sourceTree = "<group>"; };
 		B1000001000000000032 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
+		B1000001000000000033 /* BridgeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeRouter.swift; sourceTree = "<group>"; };
+		B1000001000000000034 /* StreamCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCodec.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -188,6 +192,7 @@
 				B1000001000000000003 /* BridgeService.swift */,
 				B1000001000000000004 /* DroppableWebView.swift */,
 				B1000001000000000032 /* ServiceContainer.swift */,
+				G100000100000000000C /* Bridge */,
 				B1000001000000000005 /* WebViewManager.swift */,
 				G100000100000000000B /* PDFReader */,
 				G1000001000000000005 /* Onboarding */,
@@ -202,6 +207,15 @@
 				B1000001000000000030 /* PDFReaderPaneController.swift */,
 			);
 			path = PDFReader;
+			sourceTree = "<group>";
+		};
+		G100000100000000000C /* Bridge */ = {
+			isa = PBXGroup;
+			children = (
+				B1000001000000000033 /* BridgeRouter.swift */,
+				B1000001000000000034 /* StreamCodec.swift */,
+			);
+			path = Bridge;
 			sourceTree = "<group>";
 		};
 		G1000001000000000002 /* Design */ = {
@@ -437,6 +451,8 @@
 				A1000001000000000003 /* BridgeService.swift in Sources */,
 				A1000001000000000004 /* DroppableWebView.swift in Sources */,
 				A1000001000000000032 /* ServiceContainer.swift in Sources */,
+				A1000001000000000033 /* BridgeRouter.swift in Sources */,
+				A1000001000000000034 /* StreamCodec.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 			A100000100000000002B /* BundleSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000002B /* BundleSchemeHandler.swift */; };
 		A1000001000000000003 /* BridgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000003 /* BridgeService.swift */; };
 		A1000001000000000004 /* DroppableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000004 /* DroppableWebView.swift */; };
+		A1000001000000000032 /* ServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000032 /* ServiceContainer.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -75,6 +76,7 @@
 		B100000100000000002B /* BundleSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSchemeHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000003 /* BridgeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeService.swift; sourceTree = "<group>"; };
 		B1000001000000000004 /* DroppableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroppableWebView.swift; sourceTree = "<group>"; };
+		B1000001000000000032 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				B100000100000000002B /* BundleSchemeHandler.swift */,
 				B1000001000000000003 /* BridgeService.swift */,
 				B1000001000000000004 /* DroppableWebView.swift */,
+				B1000001000000000032 /* ServiceContainer.swift */,
 				B1000001000000000005 /* WebViewManager.swift */,
 				G100000100000000000B /* PDFReader */,
 				G1000001000000000005 /* Onboarding */,
@@ -433,6 +436,7 @@
 				A100000100000000002B /* BundleSchemeHandler.swift in Sources */,
 				A1000001000000000003 /* BridgeService.swift in Sources */,
 				A1000001000000000004 /* DroppableWebView.swift in Sources */,
+				A1000001000000000032 /* ServiceContainer.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		A1000001000000000035 /* StreamMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000035 /* StreamMessageHandler.swift */; };
 		A1000001000000000036 /* SourceMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000036 /* SourceMessageHandler.swift */; };
 		A1000001000000000037 /* AIMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000037 /* AIMessageHandler.swift */; };
+		A1000001000000000038 /* ProxyAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000038 /* ProxyAuthHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -87,6 +88,7 @@
 		B1000001000000000035 /* StreamMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000036 /* SourceMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000037 /* AIMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIMessageHandler.swift; sourceTree = "<group>"; };
+		B1000001000000000038 /* ProxyAuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyAuthHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -223,6 +225,7 @@
 				B1000001000000000035 /* StreamMessageHandler.swift */,
 				B1000001000000000036 /* SourceMessageHandler.swift */,
 				B1000001000000000037 /* AIMessageHandler.swift */,
+				B1000001000000000038 /* ProxyAuthHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				A1000001000000000035 /* StreamMessageHandler.swift in Sources */,
 				A1000001000000000036 /* SourceMessageHandler.swift in Sources */,
 				A1000001000000000037 /* AIMessageHandler.swift in Sources */,
+				A1000001000000000038 /* ProxyAuthHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A1000001000000000032 /* ServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000032 /* ServiceContainer.swift */; };
 		A1000001000000000033 /* BridgeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000033 /* BridgeRouter.swift */; };
 		A1000001000000000034 /* StreamCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000034 /* StreamCodec.swift */; };
+		A1000001000000000035 /* StreamMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000035 /* StreamMessageHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -81,6 +82,7 @@
 		B1000001000000000032 /* ServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceContainer.swift; sourceTree = "<group>"; };
 		B1000001000000000033 /* BridgeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeRouter.swift; sourceTree = "<group>"; };
 		B1000001000000000034 /* StreamCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCodec.swift; sourceTree = "<group>"; };
+		B1000001000000000035 /* StreamMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 			children = (
 				B1000001000000000033 /* BridgeRouter.swift */,
 				B1000001000000000034 /* StreamCodec.swift */,
+				B1000001000000000035 /* StreamMessageHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				A1000001000000000032 /* ServiceContainer.swift in Sources */,
 				A1000001000000000033 /* BridgeRouter.swift in Sources */,
 				A1000001000000000034 /* StreamCodec.swift in Sources */,
+				A1000001000000000035 /* StreamMessageHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A1000001000000000036 /* SourceMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000036 /* SourceMessageHandler.swift */; };
 		A1000001000000000037 /* AIMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000037 /* AIMessageHandler.swift */; };
 		A1000001000000000038 /* ProxyAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000038 /* ProxyAuthHandler.swift */; };
+		A1000001000000000039 /* SettingsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000039 /* SettingsMessageHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -89,6 +90,7 @@
 		B1000001000000000036 /* SourceMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000037 /* AIMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000038 /* ProxyAuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyAuthHandler.swift; sourceTree = "<group>"; };
+		B1000001000000000039 /* SettingsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				B1000001000000000036 /* SourceMessageHandler.swift */,
 				B1000001000000000037 /* AIMessageHandler.swift */,
 				B1000001000000000038 /* ProxyAuthHandler.swift */,
+				B1000001000000000039 /* SettingsMessageHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				A1000001000000000036 /* SourceMessageHandler.swift in Sources */,
 				A1000001000000000037 /* AIMessageHandler.swift in Sources */,
 				A1000001000000000038 /* ProxyAuthHandler.swift in Sources */,
+				A1000001000000000039 /* SettingsMessageHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A1000001000000000034 /* StreamCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000034 /* StreamCodec.swift */; };
 		A1000001000000000035 /* StreamMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000035 /* StreamMessageHandler.swift */; };
 		A1000001000000000036 /* SourceMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000036 /* SourceMessageHandler.swift */; };
+		A1000001000000000037 /* AIMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000037 /* AIMessageHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -85,6 +86,7 @@
 		B1000001000000000034 /* StreamCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCodec.swift; sourceTree = "<group>"; };
 		B1000001000000000035 /* StreamMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000036 /* SourceMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceMessageHandler.swift; sourceTree = "<group>"; };
+		B1000001000000000037 /* AIMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				B1000001000000000034 /* StreamCodec.swift */,
 				B1000001000000000035 /* StreamMessageHandler.swift */,
 				B1000001000000000036 /* SourceMessageHandler.swift */,
+				B1000001000000000037 /* AIMessageHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 				A1000001000000000034 /* StreamCodec.swift in Sources */,
 				A1000001000000000035 /* StreamMessageHandler.swift in Sources */,
 				A1000001000000000036 /* SourceMessageHandler.swift in Sources */,
+				A1000001000000000037 /* AIMessageHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A1000001000000000033 /* BridgeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000033 /* BridgeRouter.swift */; };
 		A1000001000000000034 /* StreamCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000034 /* StreamCodec.swift */; };
 		A1000001000000000035 /* StreamMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000035 /* StreamMessageHandler.swift */; };
+		A1000001000000000036 /* SourceMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000036 /* SourceMessageHandler.swift */; };
 		A1000001000000000005 /* WebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000005 /* WebViewManager.swift */; };
 		A1000001000000000030 /* PDFReaderPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000030 /* PDFReaderPaneController.swift */; };
 		A1000001000000000006 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000006 /* OnboardingView.swift */; };
@@ -83,6 +84,7 @@
 		B1000001000000000033 /* BridgeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeRouter.swift; sourceTree = "<group>"; };
 		B1000001000000000034 /* StreamCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCodec.swift; sourceTree = "<group>"; };
 		B1000001000000000035 /* StreamMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamMessageHandler.swift; sourceTree = "<group>"; };
+		B1000001000000000036 /* SourceMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceMessageHandler.swift; sourceTree = "<group>"; };
 		B1000001000000000005 /* WebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewManager.swift; sourceTree = "<group>"; };
 		B1000001000000000030 /* PDFReaderPaneController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPaneController.swift; sourceTree = "<group>"; };
 		B1000001000000000006 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 				B1000001000000000033 /* BridgeRouter.swift */,
 				B1000001000000000034 /* StreamCodec.swift */,
 				B1000001000000000035 /* StreamMessageHandler.swift */,
+				B1000001000000000036 /* SourceMessageHandler.swift */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 				A1000001000000000033 /* BridgeRouter.swift in Sources */,
 				A1000001000000000034 /* StreamCodec.swift in Sources */,
 				A1000001000000000035 /* StreamMessageHandler.swift in Sources */,
+				A1000001000000000036 /* SourceMessageHandler.swift in Sources */,
 				A1000001000000000005 /* WebViewManager.swift in Sources */,
 				A1000001000000000030 /* PDFReaderPaneController.swift in Sources */,
 				A1000001000000000006 /* OnboardingView.swift in Sources */,

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -3,6 +3,7 @@ import { bridge, Stream, StreamSummary } from './types';
 import { StreamEditor } from './components/StreamEditor';
 import { Settings } from './components/Settings';
 import { ToastStack } from './components/ToastStack';
+import { useToastStore } from './store/toastStore';
 import { debugError, debugLog } from './utils/debug';
 
 type View = 'list' | 'stream' | 'settings';
@@ -74,6 +75,7 @@ export function App() {
   const [currentStream, setCurrentStream] = useState<Stream | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingStream, setIsLoadingStream] = useState(false);
+  const addToast = useToastStore((state) => state.addToast);
   const viewRef = useRef(view);
   const currentStreamIdRef = useRef<string | null>(currentStream?.id ?? null);
 
@@ -130,6 +132,13 @@ export function App() {
     // Subscribe to bridge messages
     const unsubscribe = bridge.onMessage((message) => {
       switch (message.type) {
+        case 'bridgeError':
+          if (import.meta.env.DEV) {
+            const originalType = String(message.payload?.originalType ?? 'unknown');
+            const reason = String(message.payload?.reason ?? 'Unknown bridge error');
+            addToast(`Bridge error (${originalType}): ${reason}`, 'error', 10000);
+          }
+          break;
         case 'proxyAuthState':
           // State change pushed from Swift
           setProxyAuthState(message.payload?.state as ProxyAuthState);
@@ -180,7 +189,7 @@ export function App() {
     }, 100);
 
     return unsubscribe;
-  }, []);
+  }, [addToast]);
 
   const handleCreateStream = () => {
     bridge.send({ type: 'createStream' });

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -13,6 +13,7 @@ import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
 import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
+import { debugWarn } from '../utils/debug';
 
 interface StreamEditorProps {
   stream: Stream;
@@ -133,6 +134,8 @@ export function StreamEditor({
   const editorViewRef = useRef<EditorView | null>(null);
   const selectionActionMenuRef = useRef<HTMLDivElement>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
+  const markdownContentRef = useRef(stream.document?.markdown ?? '');
+  const revisionRef = useRef(stream.document?.revision ?? 0);
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
   const showPromptRef = useRef(showPrompt);
@@ -214,6 +217,8 @@ export function StreamEditor({
   useEffect(() => {
     setMarkdownContent(stream.document?.markdown ?? '');
     lastSavedContentRef.current = stream.document?.markdown ?? '';
+    markdownContentRef.current = stream.document?.markdown ?? '';
+    revisionRef.current = stream.document?.revision ?? 0;
     setTitle(stream.title);
     setSaveState('saved');
     setAiStatus('idle');
@@ -222,7 +227,11 @@ export function StreamEditor({
     setPromptValue('');
     promptContextRef.current = null;
     aiRequestRef.current = null;
-  }, [stream.id, stream.document?.markdown, stream.title]);
+  }, [stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
+
+  useEffect(() => {
+    markdownContentRef.current = markdownContent;
+  }, [markdownContent]);
 
   useEffect(() => {
     if (!pendingSourceId) return;
@@ -249,15 +258,28 @@ export function StreamEditor({
     setSaveState('saving');
 
     const timer = window.setTimeout(() => {
-      bridge.send({
-        type: 'saveStreamDocument',
-        payload: {
+      const contentToSave = markdownContent;
+      const baseRevision = revisionRef.current;
+
+      void bridge.sendAsync<{ revision: number }>('saveStreamDocument', {
+        streamId: stream.id,
+        markdown: contentToSave,
+        baseRevision,
+      }).then((response) => {
+        if (Number.isFinite(response.revision)) {
+          revisionRef.current = response.revision;
+        }
+        lastSavedContentRef.current = contentToSave;
+        if (markdownContentRef.current === contentToSave) {
+          setSaveState('saved');
+        }
+      }).catch((error) => {
+        debugWarn('[StreamEditor] Failed to save stream document', {
           streamId: stream.id,
-          markdown: markdownContent,
-        },
+          baseRevision,
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
-      lastSavedContentRef.current = markdownContent;
-      setSaveState('saved');
     }, 350);
 
     return () => window.clearTimeout(timer);
@@ -265,27 +287,69 @@ export function StreamEditor({
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
+      if (message.type === 'streamDocumentConflict') {
+        const payloadStreamId = message.payload?.streamId as string | undefined;
+        const markdown = message.payload?.markdown as string | undefined;
+        const revision = Number(message.payload?.revision);
+
+        if (!payloadStreamId || payloadStreamId !== stream.id || typeof markdown !== 'string' || !Number.isFinite(revision)) {
+          return;
+        }
+
+        const view = editorViewRef.current;
+        if (view) {
+          view.dispatch({
+            changes: { from: 0, to: view.state.doc.length, insert: markdown },
+          });
+        }
+
+        revisionRef.current = revision;
+        markdownContentRef.current = markdown;
+        lastSavedContentRef.current = markdown;
+        setMarkdownContent(markdown);
+        setSaveState('saved');
+
+        debugWarn('[StreamEditor] Reloaded document after revision conflict', {
+          streamId: stream.id,
+          revision,
+        });
+        return;
+      }
+
       if (message.type === 'streamDocumentAppended') {
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const fragment = message.payload?.fragment as string | undefined;
+        const revision = Number(message.payload?.revision);
 
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof fragment !== 'string' || fragment.length === 0) {
           return;
         }
 
         const view = editorViewRef.current;
-        if (!view) return;
+        const currentMarkdown = view?.state.doc.toString() ?? markdownContentRef.current;
+        const hadUnsavedChanges = currentMarkdown !== lastSavedContentRef.current;
 
-        const end = view.state.doc.length;
-        const sep = end > 0 ? '\n\n' : '';
+        const sep = currentMarkdown.length > 0 ? '\n\n' : '';
         const insert = `${sep}${fragment}`;
-        const insertedEnd = end + insert.length;
+        const nextMarkdown = `${currentMarkdown}${insert}`;
+        const insertedEnd = nextMarkdown.length;
 
-        view.dispatch({
-          changes: { from: end, insert },
-          effects: EditorView.scrollIntoView(insertedEnd, { y: 'nearest' }),
-        });
-        setMarkdownContent(view.state.doc.toString());
+        if (view) {
+          view.dispatch({
+            changes: { from: view.state.doc.length, insert },
+            effects: EditorView.scrollIntoView(insertedEnd, { y: 'nearest' }),
+          });
+        }
+
+        if (Number.isFinite(revision)) {
+          revisionRef.current = revision;
+        }
+        markdownContentRef.current = nextMarkdown;
+        if (!hadUnsavedChanges) {
+          lastSavedContentRef.current = nextMarkdown;
+          setSaveState('saved');
+        }
+        setMarkdownContent(nextMarkdown);
         return;
       }
 

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -7,6 +7,7 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
   'documentAIError',
   'documentModelSelected',
   'assetPath',
+  'bridgeError',
   'callback',
   'exportCanceled',
   'exportComplete',
@@ -31,6 +32,32 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
 
 export type SwiftToWebMessageType = (typeof SWIFT_TO_WEB_MESSAGE_TYPES)[number];
 
+export const WEB_TO_SWIFT_MESSAGE_TYPES = [
+  'addSource',
+  'clearProxyDeviceKey',
+  'createStream',
+  'deleteStream',
+  'getSupportBundle',
+  'hybridSearch',
+  'loadProxyAuth',
+  'loadSettings',
+  'loadStream',
+  'loadStreams',
+  'openSource',
+  'refreshProxyAuth',
+  'removeSource',
+  'saveImage',
+  'saveSettings',
+  'saveStreamDocument',
+  'setFileDropContext',
+  'setProxyDeviceKey',
+  'submitFeedback',
+  'thinkDocument',
+  'updateStreamTitle',
+] as const;
+
+export type WebToSwiftMessageType = (typeof WEB_TO_SWIFT_MESSAGE_TYPES)[number];
+
 export interface BridgeMessage {
   type: string;
   payload?: Record<string, unknown>;
@@ -38,14 +65,15 @@ export interface BridgeMessage {
 }
 
 export type SwiftToWebBridgeMessage = Omit<BridgeMessage, 'type'> & { type: SwiftToWebMessageType };
+export type WebToSwiftBridgeMessage = Omit<BridgeMessage, 'type'> & { type: WebToSwiftMessageType };
 
 /** Callback registry for async responses */
 type CallbackFn = (payload: Record<string, unknown>) => void;
 
 /** Bridge interface for communicating with Swift */
 export interface Bridge {
-  send: (message: BridgeMessage) => void;
-  sendAsync: <T>(type: string, payload?: Record<string, unknown>) => Promise<T>;
+  send: (message: WebToSwiftBridgeMessage) => void;
+  sendAsync: <T>(type: WebToSwiftMessageType, payload?: Record<string, unknown>) => Promise<T>;
   receive: (message: SwiftToWebBridgeMessage) => void;
   onMessage: (handler: (message: SwiftToWebBridgeMessage) => void) => () => void;
 }
@@ -61,12 +89,12 @@ function nextCallbackId(): string {
 /** Global bridge instance */
 export const bridge: Bridge = {
   /** Send a message to Swift (fire and forget) */
-  send(message: BridgeMessage): void {
+  send(message: WebToSwiftBridgeMessage): void {
     window.webkit?.messageHandlers?.bridge?.postMessage(message);
   },
 
   /** Send a message and wait for response */
-  sendAsync<T>(type: string, payload?: Record<string, unknown>): Promise<T> {
+  sendAsync<T>(type: WebToSwiftMessageType, payload?: Record<string, unknown>): Promise<T> {
     return new Promise((resolve, reject) => {
       const id = nextCallbackId();
       const timeout = setTimeout(() => {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -24,6 +24,7 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
   'sourceRemoveError',
   'sourceRemoved',
   'streamDocumentAppended',
+  'streamDocumentConflict',
   'streamLoaded',
   'streamTitleUpdated',
   'streamsChanged',

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -12,6 +12,7 @@ export interface Stream {
 export interface StreamDocument {
   streamId: string;
   markdown: string;
+  revision: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/Web/src/vite-env.d.ts
+++ b/Web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -77,7 +77,10 @@
         "requiredPayloadKeys": ["id"]
       },
       "streamDocumentAppended": {
-        "requiredPayloadKeys": ["streamId", "fragment", "isNewStream", "source"]
+        "requiredPayloadKeys": ["streamId", "fragment", "revision", "isNewStream", "source"]
+      },
+      "streamDocumentConflict": {
+        "requiredPayloadKeys": ["streamId", "markdown", "revision"]
       },
       "streamLoaded": {
         "requiredPayloadKeys": ["stream"]
@@ -158,7 +161,8 @@
         ]
       },
       "saveStreamDocument": {
-        "requiredPayloadKeys": ["streamId", "markdown"]
+        "requiredPayloadKeys": ["streamId", "markdown", "baseRevision"],
+        "requiredCallbackId": true
       },
       "setFileDropContext": {
         "requiredPayloadKeys": ["mode"],

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -6,6 +6,9 @@
       "assetPath": {
         "requiredPayloadKeys": ["relativePath", "fullPath"]
       },
+      "bridgeError": {
+        "requiredPayloadKeys": ["originalType", "reason"]
+      },
       "callback": {
         "requiredPayloadKeys": [],
         "requiredCallbackId": true
@@ -87,6 +90,95 @@
       },
       "streamsLoaded": {
         "requiredPayloadKeys": ["streams"]
+      }
+    }
+  },
+  "webToSwift": {
+    "messages": {
+      "addSource": {
+        "requiredPayloadKeys": ["streamId"]
+      },
+      "clearProxyDeviceKey": {
+        "requiredPayloadKeys": [],
+        "requiredCallbackId": true
+      },
+      "createStream": {
+        "requiredPayloadKeys": []
+      },
+      "deleteStream": {
+        "requiredPayloadKeys": ["id"]
+      },
+      "getSupportBundle": {
+        "requiredPayloadKeys": [],
+        "requiredCallbackId": true
+      },
+      "hybridSearch": {
+        "requiredPayloadKeys": ["query", "currentStreamId", "limit"],
+        "requiredCallbackId": true
+      },
+      "loadProxyAuth": {
+        "requiredPayloadKeys": [],
+        "requiredCallbackId": true
+      },
+      "loadSettings": {
+        "requiredPayloadKeys": []
+      },
+      "loadStream": {
+        "requiredPayloadKeys": ["id"]
+      },
+      "loadStreams": {
+        "requiredPayloadKeys": []
+      },
+      "openSource": {
+        "requiredPayloadKeys": ["sourceId"]
+      },
+      "refreshProxyAuth": {
+        "requiredPayloadKeys": [],
+        "requiredCallbackId": true
+      },
+      "removeSource": {
+        "requiredPayloadKeys": ["id"]
+      },
+      "saveImage": {
+        "requiredPayloadKeys": ["streamId", "data", "requestId"]
+      },
+      "saveSettings": {
+        "requiredPayloadKeys": [],
+        "optionalPayloadKeys": [
+          "openaiAPIKey",
+          "anthropicAPIKey",
+          "perplexityAPIKey",
+          "smartRoutingEnabled",
+          "defaultModel",
+          "appearance",
+          "diagnosticsEnabled",
+          "editorFont",
+          "editorFontSize",
+          "editorLineSpacing"
+        ]
+      },
+      "saveStreamDocument": {
+        "requiredPayloadKeys": ["streamId", "markdown"]
+      },
+      "setFileDropContext": {
+        "requiredPayloadKeys": ["mode"],
+        "optionalPayloadKeys": ["streamId"]
+      },
+      "setProxyDeviceKey": {
+        "requiredPayloadKeys": ["key"],
+        "requiredCallbackId": true
+      },
+      "submitFeedback": {
+        "requiredPayloadKeys": ["type", "title"],
+        "optionalPayloadKeys": ["description", "screenshot", "screenshotContentType"],
+        "requiredCallbackId": true
+      },
+      "thinkDocument": {
+        "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
+        "optionalPayloadKeys": ["context"]
+      },
+      "updateStreamTitle": {
+        "requiredPayloadKeys": ["id", "title"]
       }
     }
   }

--- a/tools/contracts/check_bridge_contract.mjs
+++ b/tools/contracts/check_bridge_contract.mjs
@@ -445,6 +445,206 @@ function extractWebSwiftToWebTypes(webBridgeText) {
   return types;
 }
 
+function extractWebToSwiftTypes(webBridgeText) {
+  const match = webBridgeText.match(/WEB_TO_SWIFT_MESSAGE_TYPES\s*=\s*\[(?<body>[\s\S]*?)\]\s*as\s*const/);
+  if (!match || !match.groups?.body) {
+    return null;
+  }
+
+  const body = match.groups.body;
+  const types = new Set();
+  for (const entry of body.matchAll(/['"]([^'"]+)['"]/g)) {
+    types.add(entry[1]);
+  }
+  return types;
+}
+
+function parseWebStringLiteral(expr) {
+  const trimmed = expr.trim();
+  const quote = trimmed[0];
+  if (quote !== '"' && quote !== "'") return null;
+
+  let out = '';
+  let escaped = false;
+  for (let index = 1; index < trimmed.length; index += 1) {
+    const ch = trimmed[index];
+    if (escaped) {
+      out += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === quote) {
+      const rest = trimmed.slice(index + 1).trim();
+      if (rest.length > 0) return null;
+      return out;
+    }
+    out += ch;
+  }
+  return null;
+}
+
+function parseWebObjectKey(expr) {
+  const trimmed = expr.trim();
+  const literal = parseWebStringLiteral(trimmed);
+  if (literal) return literal;
+
+  const ident = trimmed.match(/^([A-Za-z_$][A-Za-z0-9_$]*)$/);
+  return ident ? ident[1] : null;
+}
+
+function extractWebObjectProperties(expr) {
+  const trimmed = expr.trim();
+  if (!trimmed.startsWith('{')) return null;
+
+  const endIndex = scanBalanced(trimmed, 0, '{', '}');
+  const inner = trimmed.slice(1, endIndex);
+  const properties = new Map();
+
+  for (const entry of splitTopLevel(inner, ',')) {
+    const trimmedEntry = entry.trim();
+    if (trimmedEntry.length === 0 || trimmedEntry.startsWith('...')) continue;
+
+    const colonIndex = findTopLevelColon(trimmedEntry);
+    if (colonIndex === -1) {
+      const shorthand = parseWebObjectKey(trimmedEntry);
+      if (shorthand) properties.set(shorthand, trimmedEntry);
+      continue;
+    }
+
+    const key = parseWebObjectKey(trimmedEntry.slice(0, colonIndex));
+    if (!key) continue;
+    properties.set(key, trimmedEntry.slice(colonIndex + 1).trim());
+  }
+
+  return properties;
+}
+
+function extractWebObjectLiteralKeys(expr) {
+  const properties = extractWebObjectProperties(expr);
+  return properties ? new Set(properties.keys()) : null;
+}
+
+function parseWebBridgeSendCalls(webText, filePath) {
+  const calls = [];
+  let index = 0;
+
+  while (true) {
+    const found = webText.indexOf('bridge.send(', index);
+    if (found === -1) break;
+
+    const openIndex = found + 'bridge.send'.length;
+    const closeIndex = scanBalanced(webText, openIndex, '(', ')');
+    const argsText = webText.slice(openIndex + 1, closeIndex);
+    const args = splitTopLevel(argsText, ',').map((part) => part.trim()).filter(Boolean);
+    const messageExpr = args[0];
+    const properties = messageExpr ? extractWebObjectProperties(messageExpr) : null;
+    const typeExpr = properties?.get('type');
+    const typeLiteral = typeExpr ? parseWebStringLiteral(typeExpr) : null;
+
+    if (typeLiteral) {
+      calls.push({
+        filePath,
+        startIndex: found,
+        endIndex: closeIndex + 1,
+        type: typeLiteral,
+        payloadExpr: properties.get('payload') ?? null,
+        callbackRequired: false,
+      });
+    }
+
+    index = closeIndex + 1;
+  }
+
+  index = 0;
+  while (true) {
+    const found = webText.indexOf('bridge.sendAsync', index);
+    if (found === -1) break;
+
+    let openIndex = found + 'bridge.sendAsync'.length;
+    while (/\s/.test(webText[openIndex] ?? '')) openIndex += 1;
+
+    if (webText[openIndex] === '<') {
+      let angleDepth = 0;
+      for (; openIndex < webText.length; openIndex += 1) {
+        const ch = webText[openIndex];
+        if (ch === '<') angleDepth += 1;
+        else if (ch === '>') {
+          angleDepth -= 1;
+          if (angleDepth === 0) {
+            openIndex += 1;
+            break;
+          }
+        }
+      }
+      while (/\s/.test(webText[openIndex] ?? '')) openIndex += 1;
+    }
+
+    if (webText[openIndex] !== '(') {
+      index = found + 1;
+      continue;
+    }
+
+    const closeIndex = scanBalanced(webText, openIndex, '(', ')');
+    const argsText = webText.slice(openIndex + 1, closeIndex);
+    const args = splitTopLevel(argsText, ',').map((part) => part.trim()).filter(Boolean);
+    const typeLiteral = args[0] ? parseWebStringLiteral(args[0]) : null;
+
+    if (typeLiteral) {
+      calls.push({
+        filePath,
+        startIndex: found,
+        endIndex: closeIndex + 1,
+        type: typeLiteral,
+        payloadExpr: args[1] ?? null,
+        callbackRequired: true,
+      });
+    }
+
+    index = closeIndex + 1;
+  }
+
+  return calls;
+}
+
+function resolveWebPayloadKeys(call) {
+  const payloadExpr = call.payloadExpr;
+  if (!payloadExpr) return { keys: new Set(), unresolved: false };
+
+  const trimmed = payloadExpr.trim();
+  if (trimmed === 'undefined' || trimmed === 'null') return { keys: new Set(), unresolved: false };
+
+  const literalKeys = extractWebObjectLiteralKeys(trimmed);
+  if (literalKeys) return { keys: literalKeys, unresolved: false };
+
+  return { keys: new Set(), unresolved: true };
+}
+
+function extractSwiftHandledTypes(swiftText) {
+  const types = new Set();
+  const handledTypesPattern = /handledTypes\s*:\s*Set<String>\s*=\s*\[/g;
+
+  for (const match of swiftText.matchAll(handledTypesPattern)) {
+    const startIndex = (match.index ?? 0) + match[0].length - 1;
+    const endIndex = scanBalanced(swiftText, startIndex, '[', ']');
+    const literalText = swiftText.slice(startIndex, endIndex + 1);
+    for (const entry of literalText.matchAll(/"([^"]+)"/g)) {
+      types.add(entry[1]);
+    }
+  }
+
+  if (swiftText.includes('switch message.type')) {
+    for (const entry of swiftText.matchAll(/case\s+"([^"]+)"/g)) {
+      types.add(entry[1]);
+    }
+  }
+
+  return types;
+}
+
 function setDiff(a, b) {
   const onlyA = [];
   for (const value of a) if (!b.has(value)) onlyA.push(value);
@@ -463,6 +663,7 @@ function main() {
     path.join(repoRoot, 'docs', 'contracts', 'bridge.v2.json'),
   ].filter((p) => fs.existsSync(p));
   const webBridgePath = path.join(repoRoot, 'Web', 'src', 'types', 'bridge.ts');
+  const webSrcDir = path.join(repoRoot, 'Web', 'src');
   const sourcesDir = path.join(repoRoot, 'Sources');
 
   if (contractPaths.length === 0) {
@@ -470,11 +671,16 @@ function main() {
   }
 
   const messages = {};
+  const webToSwiftMessages = {};
   for (const contractPath of contractPaths) {
     const contract = readJson(contractPath);
     const contractMessages = contract?.swiftToWeb?.messages;
     if (!contractMessages || typeof contractMessages !== 'object') {
       throw new Error(`Contract missing swiftToWeb.messages: ${contractPath}`);
+    }
+    const inboundMessages = contract?.webToSwift?.messages;
+    if (!inboundMessages || typeof inboundMessages !== 'object') {
+      throw new Error(`Contract missing webToSwift.messages: ${contractPath}`);
     }
 
     for (const [type, spec] of Object.entries(contractMessages)) {
@@ -484,9 +690,18 @@ function main() {
       }
       messages[type] = spec;
     }
+
+    for (const [type, spec] of Object.entries(inboundMessages)) {
+      if (webToSwiftMessages[type]) {
+        fail(`Duplicate webToSwift bridge message "${type}" across contracts.`);
+        continue;
+      }
+      webToSwiftMessages[type] = spec;
+    }
   }
 
   const contractTypes = new Set(Object.keys(messages));
+  const webToSwiftContractTypes = new Set(Object.keys(webToSwiftMessages));
   if (!contractTypes.has('callback')) {
     fail('Contract must include "callback" message type.');
   }
@@ -499,6 +714,18 @@ function main() {
     const diff = setDiff(contractTypes, webTypes);
     if (diff.onlyA.length > 0 || diff.onlyB.length > 0) {
       fail(`Web SWIFT_TO_WEB_MESSAGE_TYPES does not match contract:`);
+      if (diff.onlyA.length > 0) fail(`  Missing in Web: ${diff.onlyA.join(', ')}`);
+      if (diff.onlyB.length > 0) fail(`  Extra in Web: ${diff.onlyB.join(', ')}`);
+    }
+  }
+
+  const webToSwiftTypes = extractWebToSwiftTypes(webBridgeText);
+  if (!webToSwiftTypes) {
+    fail(`Web bridge is missing WEB_TO_SWIFT_MESSAGE_TYPES (required for contract tests): ${webBridgePath}`);
+  } else {
+    const diff = setDiff(webToSwiftContractTypes, webToSwiftTypes);
+    if (diff.onlyA.length > 0 || diff.onlyB.length > 0) {
+      fail(`Web WEB_TO_SWIFT_MESSAGE_TYPES does not match contract:`);
       if (diff.onlyA.length > 0) fail(`  Missing in Web: ${diff.onlyA.join(', ')}`);
       if (diff.onlyB.length > 0) fail(`  Extra in Web: ${diff.onlyB.join(', ')}`);
     }
@@ -583,6 +810,91 @@ function main() {
     if (missingOptional.length > 0) {
       fail(`Swift BridgeMessage("${type}") missing optional payload keys referenced by contract: ${missingOptional.join(', ')}`);
     }
+  }
+
+  const webFiles = walkFiles(webSrcDir, (p) => p.endsWith('.ts') || p.endsWith('.tsx'));
+  const webCalls = [];
+  for (const filePath of webFiles) {
+    const text = readText(filePath);
+    webCalls.push(...parseWebBridgeSendCalls(text, path.relative(repoRoot, filePath)));
+  }
+
+  const webSenderTypes = new Set(webCalls.map((c) => c.type));
+  const webSenderDiff = setDiff(webToSwiftContractTypes, webSenderTypes);
+  if (webSenderDiff.onlyA.length > 0 || webSenderDiff.onlyB.length > 0) {
+    fail(`Web bridge sender types do not match webToSwift contract:`);
+    if (webSenderDiff.onlyA.length > 0) fail(`  Missing in Web senders: ${webSenderDiff.onlyA.join(', ')}`);
+    if (webSenderDiff.onlyB.length > 0) fail(`  Missing in contract: ${webSenderDiff.onlyB.join(', ')}`);
+  }
+
+  const webCallsByType = new Map();
+  for (const call of webCalls) {
+    const list = webCallsByType.get(call.type) ?? [];
+    list.push(call);
+    webCallsByType.set(call.type, list);
+  }
+
+  for (const type of sorted(webToSwiftContractTypes)) {
+    const spec = webToSwiftMessages[type];
+    if (!spec || typeof spec !== 'object') {
+      fail(`webToSwift contract entry for "${type}" must be an object.`);
+      continue;
+    }
+
+    const requiredKeys = Array.isArray(spec.requiredPayloadKeys) ? spec.requiredPayloadKeys : null;
+    const requiresCallbackId = spec.requiredCallbackId === true;
+
+    if (!requiredKeys) {
+      fail(`webToSwift contract entry for "${type}" missing requiredPayloadKeys array.`);
+      continue;
+    }
+
+    const typeCalls = webCallsByType.get(type) ?? [];
+    if (typeCalls.length === 0) {
+      fail(`No Web bridge sender call sites found for webToSwift contract type "${type}".`);
+      continue;
+    }
+
+    for (const call of typeCalls) {
+      const resolved = resolveWebPayloadKeys(call);
+      const missingRequired = requiredKeys.filter((key) => !resolved.keys.has(key));
+      if (missingRequired.length > 0) {
+        fail(
+          `Web bridge sender "${type}" missing required payload keys: ${missingRequired.join(
+            ', '
+          )} (${call.filePath})`
+        );
+      }
+
+      if (resolved.unresolved && requiredKeys.length > 0) {
+        fail(
+          `Web bridge sender "${type}" payload could not be statically analyzed (expected object literal): (${call.filePath})`
+        );
+      }
+
+      if (requiresCallbackId && !call.callbackRequired) {
+        fail(`Web bridge sender "${type}" must use sendAsync for callback correlation (${call.filePath})`);
+      }
+
+      if (!requiresCallbackId && call.callbackRequired) {
+        fail(`Web bridge sender "${type}" uses sendAsync but contract does not require callbackId (${call.filePath})`);
+      }
+    }
+  }
+
+  const handlerFiles = [
+    ...walkFiles(path.join(repoRoot, 'Sources', 'Ticker', 'App', 'Bridge'), (p) => p.endsWith('.swift')),
+    path.join(repoRoot, 'Sources', 'Ticker', 'App', 'WebViewManager.swift'),
+  ].filter((p) => fs.existsSync(p));
+  const swiftHandlerTypes = new Set();
+  for (const filePath of handlerFiles) {
+    const handledTypes = extractSwiftHandledTypes(readText(filePath));
+    for (const type of handledTypes) swiftHandlerTypes.add(type);
+  }
+
+  const missingSwiftHandlers = sorted(webToSwiftContractTypes).filter((type) => !swiftHandlerTypes.has(type));
+  if (missingSwiftHandlers.length > 0) {
+    fail(`webToSwift contract types missing Swift handlers: ${missingSwiftHandlers.join(', ')}`);
   }
 }
 


### PR DESCRIPTION
Structural debt payoff per docs/PRODUCTION_READINESS_PLAN.md Phase 4. Stacked on #26.

- **ServiceContainer** composition root; one service graph shared by WebViewManager and QuickPanelManager.
- **BridgeRouter + six feature handlers** (Stream/Source/AI/ProxyAuth/Settings/Search) + StreamCodec: the 1,250-line `processMessage` switch is gone. **WebViewManager: 2,498 → 450 lines** since this effort began. One behavior-preserving commit per handler.
- **Bridge hardening:** AnyCodable Int/Double accessors (fixes silent `as? Double` failures), uniform `requestId` correlation, **bidirectional contract** — bridge.v2.json now covers all 21 Web→Swift messages, and the checker validates web senders AND cross-checks every inbound type against registered Swift handlers; malformed/unknown messages emit `bridgeError` (dev-build toasts) instead of vanishing.
- **Revision-checked saves (v13):** autosave carries `baseRevision`; stale saves are rejected with `streamDocumentConflict` (editor reloads DB state) instead of clobbering external appends. Closes the last data-loss hole in the capture pipeline.

Verification: 19/19 Swift tests, web typecheck/build, bidirectional contract checker (negative-tested), all re-run independently; live smoke through the new router (boot → open stream → local edit + quick capture → real-proxy AI round-trip) with revision bookkeeping confirmed in SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)