### PR TITLE
UX polish: AI progress feedback, quick panel mechanics, selection-context regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable user-facing changes to Ticker are documented here.
 
 ### Added
 - PDF pane with continuous scrolling and stream links back to selected highlights.
+- Quick Panel ephemeral chats can save individual messages and clear the in-memory conversation.
 - Quick Panel Save and AI + Save now append directly to stream documents, including live inserts into an open editor.
 - Live markdown concealment and image widgets for a calmer document-writing surface.
 - Revision-aware stream document saves to protect external appends from stale autosaves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable user-facing changes to Ticker are documented here.
 
 ### Fixed
 - Recovered quick-capture notes that previously didn't appear in streams.
+- Restored Quick Panel selected-text context preview and blockquote saves.
 - Stopped embedded stream images from flickering or refetching while editing nearby text, and made cursor movement skip image tokens atomically.
 - Restored the stream editor selection action menu using CodeMirror selection state.
 - Made Quick Panel dismissal consistent, stabilized stream picking, and added visible save feedback.

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -61,6 +61,8 @@ enum StreamCodec {
                     "title": summary.title,
                     "sourceCount": summary.sourceCount,
                     "cellCount": summary.cellCount,
+                    "charCount": summary.charCount,
+                    "imageCount": summary.imageCount,
                     "updatedAt": formatter.string(from: summary.updatedAt)
                 ]
                 if let previewText = summary.previewText {

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -45,6 +45,7 @@ final class QuickPanelManager: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var error: String?
     @Published var statusMessage: String?  // Temporary feedback (success/info messages)
+    @Published private(set) var isShowingSaveFeedback: Bool = false
     @Published var ephemeralConversation = EphemeralConversation()
 
     // Stream selection
@@ -80,6 +81,7 @@ final class QuickPanelManager: ObservableObject {
     private var hostingView: NSHostingView<QuickPanelView>?
     private var currentAppearance: NSAppearance?  // Stored to apply when panel is created
     private var suppressedClipboardImageChangeCount: Int?
+    private var presentationGeneration: Int = 0
 
     // MARK: - Initialization
 
@@ -201,6 +203,8 @@ final class QuickPanelManager: ObservableObject {
 
     /// Show the quick panel with specific context
     private func show(with capturedContext: QuickPanelContext, showAccessibilityWarning: Bool) {
+        presentationGeneration += 1
+        cancelFeedbackTasks()
         self.context = capturedContext
         resetState()
 
@@ -220,11 +224,15 @@ final class QuickPanelManager: ObservableObject {
 
         guard let panel = panel else { return }
 
+        heightDebounceTimer?.invalidate()
+        targetHeight = QuickPanelWindow.minHeight
+        panel.resetToMinHeight()
+
         // Position at captured location
         panel.position(at: capturedContext.panelPosition)
 
         // Show panel without bringing main window forward
-        panel.orderFrontRegardless()
+        panel.fadeIn()
         panel.makeKey()
 
         isVisible = true
@@ -237,14 +245,27 @@ final class QuickPanelManager: ObservableObject {
 
     /// Hide the quick panel
     func hide() {
+        presentationGeneration += 1
+        let generation = presentationGeneration
         cancelFeedbackTasks()
         // Cancel any in-flight streaming to avoid orphan AI calls
         cancelStreaming()
 
-        panel?.orderOut(nil)
         isVisible = false
-        resetState()
-        statusMessage = nil
+
+        let finishHide = { [weak self] in
+            guard let self, generation == self.presentationGeneration else { return }
+            self.resetState()
+            self.context = nil
+            self.statusMessage = nil
+        }
+
+        guard let panel, panel.isVisible else {
+            finishHide()
+            return
+        }
+
+        panel.fadeOut(completion: finishHide)
         // Note: ephemeralConversation is intentionally preserved so user can re-reference
     }
 
@@ -262,6 +283,7 @@ final class QuickPanelManager: ObservableObject {
         isLoading = false
         error = nil
         statusMessage = nil
+        isShowingSaveFeedback = false
     }
 
     private func cancelFeedbackTasks() {
@@ -273,6 +295,7 @@ final class QuickPanelManager: ObservableObject {
 
     private func showTimedStatusMessage(_ message: String, durationNanoseconds: UInt64) {
         statusClearTask?.cancel()
+        isShowingSaveFeedback = false
         statusMessage = message
 
         statusClearTask = Task { [weak self] in
@@ -290,6 +313,7 @@ final class QuickPanelManager: ObservableObject {
         statusClearTask?.cancel()
         statusClearTask = nil
         saveFeedbackTask?.cancel()
+        isShowingSaveFeedback = true
         statusMessage = message
 
         saveFeedbackTask = Task { [weak self] in
@@ -421,6 +445,11 @@ final class QuickPanelManager: ObservableObject {
             return
         }
 
+        if isShowingSaveFeedback {
+            hide()
+            return
+        }
+
         // Second: clear input/context
         if !inputText.isEmpty || context?.hasContent == true {
             suppressDismissedClipboardImageIfNeeded()
@@ -518,8 +547,6 @@ final class QuickPanelManager: ObservableObject {
                 }
             }
 
-            inputText = ""
-            context = nil
             isLoading = false
             let feedbackMessage = triggerDocumentAI
                 ? "Saved to \(streamTitle) — asking AI…"

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -46,6 +46,7 @@ final class QuickPanelManager: ObservableObject {
     @Published var error: String?
     @Published var statusMessage: String?  // Temporary feedback (success/info messages)
     @Published private(set) var isShowingSaveFeedback: Bool = false
+    @Published private(set) var isInputSaveFeedbackActive: Bool = false
     @Published var ephemeralConversation = EphemeralConversation()
 
     // Stream selection
@@ -284,6 +285,7 @@ final class QuickPanelManager: ObservableObject {
         error = nil
         statusMessage = nil
         isShowingSaveFeedback = false
+        isInputSaveFeedbackActive = false
     }
 
     private func cancelFeedbackTasks() {
@@ -296,6 +298,7 @@ final class QuickPanelManager: ObservableObject {
     private func showTimedStatusMessage(_ message: String, durationNanoseconds: UInt64) {
         statusClearTask?.cancel()
         isShowingSaveFeedback = false
+        isInputSaveFeedbackActive = false
         statusMessage = message
 
         statusClearTask = Task { [weak self] in
@@ -314,6 +317,7 @@ final class QuickPanelManager: ObservableObject {
         statusClearTask = nil
         saveFeedbackTask?.cancel()
         isShowingSaveFeedback = true
+        isInputSaveFeedbackActive = true
         statusMessage = message
 
         saveFeedbackTask = Task { [weak self] in
@@ -322,6 +326,27 @@ final class QuickPanelManager: ObservableObject {
             await MainActor.run {
                 guard let self, self.statusMessage == message else { return }
                 self.hide()
+            }
+        }
+    }
+
+    private func showSaveFeedbackPill(_ message: String, durationNanoseconds: UInt64 = 1_400_000_000) {
+        statusClearTask?.cancel()
+        statusClearTask = nil
+        isShowingSaveFeedback = true
+        isInputSaveFeedbackActive = false
+        statusMessage = message
+
+        statusClearTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: durationNanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self,
+                      self.statusMessage == message,
+                      !self.isInputSaveFeedbackActive else { return }
+                self.statusMessage = nil
+                self.isShowingSaveFeedback = false
+                self.statusClearTask = nil
             }
         }
     }
@@ -445,7 +470,7 @@ final class QuickPanelManager: ObservableObject {
             return
         }
 
-        if isShowingSaveFeedback {
+        if isInputSaveFeedbackActive {
             hide()
             return
         }
@@ -466,6 +491,11 @@ final class QuickPanelManager: ObservableObject {
     func clearContext() {
         suppressDismissedClipboardImageIfNeeded()
         context = nil
+    }
+
+    func clearEphemeralConversation() {
+        cancelStreaming()
+        ephemeralConversation.clear()
     }
 
     /// Suppress reattaching the current clipboard image on Cmd+L until clipboard changes.
@@ -578,6 +608,31 @@ final class QuickPanelManager: ObservableObject {
         }
 
         isLoading = false
+    }
+
+    func saveConversationMessage(_ message: String) {
+        guard let persistence = persistence else {
+            error = "Persistence not configured"
+            return
+        }
+
+        guard let fragment = nonEmptyTrimmed(message) else { return }
+
+        do {
+            let (streamId, isNewStream) = try getTargetStreamId()
+            let streamTitle = displayTitle(for: streamId, persistence: persistence)
+            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
+            notifyFrontend(
+                streamId: streamId,
+                fragment: result.fragment,
+                revision: result.revision,
+                isNewStream: isNewStream
+            )
+            showSaveFeedbackPill("Saved to \(streamTitle)")
+        } catch {
+            self.error = error.localizedDescription
+            DebugLog.log("[QuickPanel] Error saving conversation message (\(DebugLog.errorSummary(error)))")
+        }
     }
 
     /// Load available streams for the picker

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -130,6 +130,7 @@ final class QuickPanelManager: ObservableObject {
     func toggle() {
         // Capture context BEFORE we steal focus
         let capturedContext = contextRespectingDismissedClipboardImage(selectionService.buildContext())
+        logCapturedContext(capturedContext)
 
         if isVisible {
             // Check if there's a new selection
@@ -208,7 +209,7 @@ final class QuickPanelManager: ObservableObject {
 
         // If Accessibility isn't granted, just show a soft warning (don't prompt).
         // Onboarding is responsible for prompting; repeated system prompts here are jarring.
-        if showAccessibilityWarning && !cursorService.hasAccessibilityPermission && !capturedContext.hasContent {
+        if showAccessibilityWarning && !cursorService.hasAccessibilityPermission && !capturedContext.hasSelection {
             statusMessage = "Grant Accessibility permission to capture text selections"
         }
 
@@ -299,6 +300,20 @@ final class QuickPanelManager: ObservableObject {
                 self.hide()
             }
         }
+    }
+
+    private func logCapturedContext(_ capturedContext: QuickPanelContext) {
+        let selectedLength = capturedContext.selectedText?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .count ?? 0
+        DebugLog.log(
+            "[QuickPanel] toggle captured context " +
+            "axTrusted=\(cursorService.hasAccessibilityPermission) " +
+            "hasSelection=\(capturedContext.hasSelection) " +
+            "selectedLength=\(selectedLength) " +
+            "hasImage=\(capturedContext.hasImage) " +
+            "activeApp=\(capturedContext.activeApp ?? "unknown")"
+        )
     }
 
     /// Update panel appearance (light/dark mode)
@@ -597,48 +612,21 @@ final class QuickPanelManager: ObservableObject {
     }
 
     private func buildMarkdownFragment(streamId: UUID) throws -> String {
-        var blocks: [String] = []
-
-        if let ctx = context {
-            if let selectedText = nonEmptyTrimmed(ctx.selectedText) {
-                blocks.append(markdownBlockquote(selectedText))
-
-                if let sourceApp = nonEmptyTrimmed(ctx.activeApp) {
-                    blocks.append("*— \(escapeMarkdownEmphasis(sourceApp))*")
-                }
+        try QuickPanelMarkdownFormatter.buildFragment(
+            context: context,
+            inputText: inputText
+        ) { imageData in
+            guard let assetService = assetService else {
+                throw QuickPanelError.assetServiceNotConfigured
             }
 
-            if let imageData = ctx.clipboardImage {
-                guard let assetService = assetService else {
-                    throw QuickPanelError.assetServiceNotConfigured
-                }
-
-                let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
-                blocks.append("![capture](ticker-asset:///\(relativePath))")
-            }
+            let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
+            return "![capture](ticker-asset:///\(relativePath))"
         }
-
-        if let input = nonEmptyTrimmed(inputText) {
-            blocks.append(input)
-        }
-
-        return blocks.joined(separator: "\n\n")
-    }
-
-    private func markdownBlockquote(_ text: String) -> String {
-        text.components(separatedBy: CharacterSet.newlines)
-            .map { line in
-                line.isEmpty ? ">" : "> \(line)"
-            }
-            .joined(separator: "\n")
     }
 
     private func nonEmptyTrimmed(_ text: String?) -> String? {
-        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
+        QuickPanelMarkdownFormatter.nonEmptyTrimmed(text)
     }
 
     private func displayTitle(for streamId: UUID, persistence: PersistenceService) -> String {
@@ -653,13 +641,6 @@ final class QuickPanelManager: ObservableObject {
         }
 
         return "Untitled"
-    }
-
-    private func escapeMarkdownEmphasis(_ text: String) -> String {
-        text
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "*", with: "\\*")
-            .replacingOccurrences(of: "_", with: "\\_")
     }
 
     private func startDocumentAI(
@@ -743,7 +724,7 @@ final class QuickPanelManager: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let fallback = compact.isEmpty ? "Unknown error" : compact
         let shortened = fallback.count > 180 ? "\(fallback.prefix(177))..." : fallback
-        return "*AI request failed: \(escapeMarkdownEmphasis(shortened))*"
+        return "*AI request failed: \(QuickPanelMarkdownFormatter.escapeMarkdownEmphasis(shortened))*"
     }
 
     /// Notify the React frontend about document appends.
@@ -841,6 +822,80 @@ final class QuickPanelManager: ObservableObject {
                 self.applyHeightUpdate()
             }
         }
+    }
+}
+
+enum QuickPanelMarkdownFormatter {
+    static func buildFragment(
+        context: QuickPanelContext?,
+        inputText: String,
+        imageMarkdown: (Data) throws -> String
+    ) throws -> String {
+        var blocks: [String] = []
+
+        if let context {
+            if let selectedText = nonEmptyTrimmed(context.selectedText) {
+                blocks.append(markdownBlockquote(selectedText))
+
+                if let source = sourceAttribution(for: context) {
+                    blocks.append("*— \(escapeMarkdownEmphasis(source))*")
+                }
+            }
+
+            if let imageData = context.clipboardImage {
+                blocks.append(try imageMarkdown(imageData))
+            }
+        }
+
+        if let input = nonEmptyTrimmed(inputText) {
+            blocks.append(input)
+        }
+
+        return blocks.joined(separator: "\n\n")
+    }
+
+    static func nonEmptyTrimmed(_ text: String?) -> String? {
+        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    static func escapeMarkdownEmphasis(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "*", with: "\\*")
+            .replacingOccurrences(of: "_", with: "\\_")
+    }
+
+    private static func markdownBlockquote(_ text: String) -> String {
+        text.components(separatedBy: CharacterSet.newlines)
+            .map { line in
+                line.isEmpty ? ">" : "> \(line)"
+            }
+            .joined(separator: "\n")
+    }
+
+    private static func sourceAttribution(for context: QuickPanelContext) -> String? {
+        let app = nonEmptyTrimmed(context.activeApp)
+        let title = nonEmptyTrimmed(context.windowTitle).map { truncate($0, maxLength: 60) }
+
+        switch (app, title) {
+        case let (app?, title?):
+            return "\(app) — \(title)"
+        case let (app?, nil):
+            return app
+        case let (nil, title?):
+            return title
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    private static func truncate(_ text: String, maxLength: Int) -> String {
+        guard text.count > maxLength else { return text }
+        return "\(text.prefix(maxLength - 3))..."
     }
 }
 

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -102,8 +102,8 @@ struct QuickPanelView: View {
                 statusView(status)
             }
 
-            // Stream destination picker
-            streamDestinationPicker
+            // Stream destination picker and active-conversation controls
+            headerRow
 
             // Context badge (if text/image was captured)
             if let context = manager.context, context.hasContent {
@@ -245,7 +245,7 @@ struct QuickPanelView: View {
                 .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
         }
         .buttonStyle(.plain)
-        .disabled(manager.isShowingSaveFeedback)
+        .disabled(manager.isInputSaveFeedbackActive)
         .help("Clear context")
     }
 
@@ -289,6 +289,34 @@ struct QuickPanelView: View {
     }
 
     // MARK: - Stream Destination Picker
+
+    private var headerRow: some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            streamDestinationPicker
+
+            Spacer(minLength: Spacing.sm)
+
+            if manager.ephemeralConversation.isActive {
+                clearConversationButton
+                    .padding(.top, 1)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: manager.ephemeralConversation.isActive)
+    }
+
+    private var clearConversationButton: some View {
+        Button(action: { manager.clearEphemeralConversation() }) {
+            Image(systemName: "xmark.circle")
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize, weight: .semibold))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.72))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Clear conversation")
+        .accessibilityLabel("Clear conversation")
+    }
 
     private var streamDestinationPicker: some View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -434,24 +462,43 @@ struct QuickPanelView: View {
     }
 
     private func turnView(_ turn: ConversationTurn, id: Int) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            // Role indicator
-            Text(turn.role == .user ? "You" : "AI")
-                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
-                .foregroundColor(QuickPanelStyle.textSubtle)
+        HStack(alignment: .top, spacing: Spacing.xs) {
+            VStack(alignment: .leading, spacing: 2) {
+                // Role indicator
+                Text(turn.role == .user ? "You" : "AI")
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
+                    .foregroundColor(QuickPanelStyle.textSubtle)
 
-            // Content - render markdown for AI responses
-            if turn.role == .assistant {
-                MarkdownContentView(content: turn.content)
-            } else {
-                Text(turn.content)
-                    .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
-                    .foregroundColor(QuickPanelStyle.textMuted)
-                    .textSelection(.enabled)
+                // Content - render markdown for AI responses
+                if turn.role == .assistant {
+                    MarkdownContentView(content: turn.content)
+                } else {
+                    Text(turn.content)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
+                        .foregroundColor(QuickPanelStyle.textMuted)
+                        .textSelection(.enabled)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            saveConversationMessageButton(content: turn.content)
         }
         .padding(.vertical, Spacing.xs)
         .id(id)
+    }
+
+    private func saveConversationMessageButton(content: String) -> some View {
+        Button(action: { manager.saveConversationMessage(content) }) {
+            Image(systemName: "tray.and.arrow.down")
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize, weight: .semibold))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.64))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Save message to stream")
+        .accessibilityLabel("Save message to stream")
+        .disabled(content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
     private var streamingResponseView: some View {
@@ -488,14 +535,14 @@ struct QuickPanelView: View {
     private var inputField: some View {
         let isInputDisabled = manager.isLoading ||
             manager.ephemeralConversation.isStreaming ||
-            manager.isShowingSaveFeedback
+            manager.isInputSaveFeedbackActive
 
         return HStack(spacing: Spacing.sm) {
             QuickPanelInputField(
                 text: $manager.inputText,
                 placeholder: placeholderText,
                 isLoading: isInputDisabled,
-                isShimmering: manager.isShowingSaveFeedback,
+                isShimmering: manager.isInputSaveFeedbackActive,
                 onSubmit: handleSubmit,
                 onCancel: { manager.handleEscape() },
                 onCmdEnter: handleCmdSubmit,
@@ -513,7 +560,7 @@ struct QuickPanelView: View {
                         .foregroundColor(canSubmit ? QuickPanelStyle.accent : QuickPanelStyle.textSubtle.opacity(0.5))
                 }
                 .buttonStyle(.plain)
-                .disabled(!canSubmit || manager.isShowingSaveFeedback)
+                .disabled(!canSubmit || manager.isInputSaveFeedbackActive)
             }
         }
         .padding(.horizontal, Spacing.md)
@@ -599,14 +646,14 @@ struct QuickPanelView: View {
     // MARK: - Actions
 
     private func handleSubmit() {
-        guard canSubmit, !manager.isLoading, !manager.isShowingSaveFeedback else { return }
+        guard canSubmit, !manager.isLoading, !manager.isInputSaveFeedbackActive else { return }
         Task {
             await manager.handleEnter()
         }
     }
 
     private func handleCmdSubmit() {
-        guard canSubmit, !manager.isLoading, !manager.isShowingSaveFeedback else { return }
+        guard canSubmit, !manager.isLoading, !manager.isInputSaveFeedbackActive else { return }
         Task {
             await manager.handleCmdEnter()
         }
@@ -617,7 +664,7 @@ struct QuickPanelView: View {
         guard hasInput,
               !manager.isLoading,
               !manager.ephemeralConversation.isStreaming,
-              !manager.isShowingSaveFeedback else { return }
+              !manager.isInputSaveFeedbackActive else { return }
         Task {
             await manager.handleOptionEnter()
         }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -98,7 +98,7 @@ struct QuickPanelView: View {
             }
 
             // Status message (info/success feedback)
-            if let status = manager.statusMessage {
+            if let status = manager.statusMessage, !manager.isShowingSaveFeedback {
                 statusView(status)
             }
 
@@ -136,6 +136,16 @@ struct QuickPanelView: View {
             RoundedRectangle(cornerRadius: QuickPanelStyle.radius)
                 .stroke(Color.clear, lineWidth: 1)
         )
+        .overlay(alignment: .bottomTrailing) {
+            if manager.isShowingSaveFeedback, let status = manager.statusMessage {
+                statusView(status, compact: true)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .padding(.trailing, Spacing.lg)
+                    .padding(.bottom, Spacing.lg)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: manager.isShowingSaveFeedback)
         .onReceive(NotificationCenter.default.publisher(for: .quickPanelDidShow)) { _ in
             isInputFocused = true
             isPickerExpanded = false
@@ -235,6 +245,7 @@ struct QuickPanelView: View {
                 .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
         }
         .buttonStyle(.plain)
+        .disabled(manager.isShowingSaveFeedback)
         .help("Clear context")
     }
 
@@ -475,11 +486,16 @@ struct QuickPanelView: View {
     // MARK: - Input Field
 
     private var inputField: some View {
-        HStack(spacing: Spacing.sm) {
+        let isInputDisabled = manager.isLoading ||
+            manager.ephemeralConversation.isStreaming ||
+            manager.isShowingSaveFeedback
+
+        return HStack(spacing: Spacing.sm) {
             QuickPanelInputField(
                 text: $manager.inputText,
                 placeholder: placeholderText,
-                isLoading: manager.isLoading || manager.ephemeralConversation.isStreaming,
+                isLoading: isInputDisabled,
+                isShimmering: manager.isShowingSaveFeedback,
                 onSubmit: handleSubmit,
                 onCancel: { manager.handleEscape() },
                 onCmdEnter: handleCmdSubmit,
@@ -497,7 +513,7 @@ struct QuickPanelView: View {
                         .foregroundColor(canSubmit ? QuickPanelStyle.accent : QuickPanelStyle.textSubtle.opacity(0.5))
                 }
                 .buttonStyle(.plain)
-                .disabled(!canSubmit)
+                .disabled(!canSubmit || manager.isShowingSaveFeedback)
             }
         }
         .padding(.horizontal, Spacing.md)
@@ -560,7 +576,7 @@ struct QuickPanelView: View {
 
     // MARK: - Status View
 
-    private func statusView(_ status: String) -> some View {
+    private func statusView(_ status: String, compact: Bool = false) -> some View {
         let isWarning = status.contains("permission") || status.contains("Permission")
         let icon = isWarning ? "info.circle" : "checkmark.circle"
         let color = isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.success
@@ -573,7 +589,7 @@ struct QuickPanelView: View {
             Text(status)
                 .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
                 .foregroundColor(isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.text)
-                .lineLimit(2)
+                .lineLimit(compact ? 1 : 2)
         }
         .padding(Spacing.sm)
         .background(color.opacity(0.1))
@@ -583,14 +599,14 @@ struct QuickPanelView: View {
     // MARK: - Actions
 
     private func handleSubmit() {
-        guard canSubmit, !manager.isLoading else { return }
+        guard canSubmit, !manager.isLoading, !manager.isShowingSaveFeedback else { return }
         Task {
             await manager.handleEnter()
         }
     }
 
     private func handleCmdSubmit() {
-        guard canSubmit, !manager.isLoading else { return }
+        guard canSubmit, !manager.isLoading, !manager.isShowingSaveFeedback else { return }
         Task {
             await manager.handleCmdEnter()
         }
@@ -598,7 +614,10 @@ struct QuickPanelView: View {
 
     private func handleOptionSubmit() {
         let hasInput = !manager.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        guard hasInput, !manager.isLoading, !manager.ephemeralConversation.isStreaming else { return }
+        guard hasInput,
+              !manager.isLoading,
+              !manager.ephemeralConversation.isStreaming,
+              !manager.isShowingSaveFeedback else { return }
         Task {
             await manager.handleOptionEnter()
         }
@@ -611,6 +630,7 @@ struct QuickPanelInputField: NSViewRepresentable {
     @Binding var text: String
     var placeholder: String
     var isLoading: Bool
+    var isShimmering: Bool
     var onSubmit: () -> Void
     var onCancel: () -> Void
     var onCmdEnter: (() -> Void)?
@@ -641,6 +661,7 @@ struct QuickPanelInputField: NSViewRepresentable {
         textView.drawsBackground = false
         textView.font = NSFont.systemFont(ofSize: QuickPanelStyle.inputSize, weight: .regular)
         textView.textColor = NSColor(QuickPanelStyle.text)
+        textView.placeholder = placeholder
 
         // Text container - enable word wrapping
         textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
@@ -661,17 +682,12 @@ struct QuickPanelInputField: NSViewRepresentable {
         textView.delegate = context.coordinator
         context.coordinator.textView = textView
         context.coordinator.scrollView = scrollView
-        context.coordinator.placeholder = placeholder
 
         scrollView.documentView = textView
 
-        // Set initial placeholder
-        if text.isEmpty {
-            context.coordinator.showPlaceholder()
-        }
-
         // Calculate initial height
         DispatchQueue.main.async {
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
             context.coordinator.updateScrollViewHeight()
             textView.window?.makeFirstResponder(textView)
         }
@@ -682,52 +698,33 @@ struct QuickPanelInputField: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? QuickPanelTextView else { return }
 
-        context.coordinator.placeholder = placeholder
         context.coordinator.isLoading = isLoading
+        textView.placeholder = placeholder
+        textView.setShimmering(isShimmering)
 
         // Update text if changed externally
-        if !context.coordinator.isShowingPlaceholder && textView.string != text {
+        if textView.string != text {
             textView.string = text
+            if text.isEmpty {
+                textView.setSelectedRange(NSRange(location: 0, length: 0))
+            }
             DispatchQueue.main.async {
                 context.coordinator.updateScrollViewHeight()
             }
         }
 
-        // Handle placeholder visibility
-        if text.isEmpty {
-            if let firstResponder = textView.window?.firstResponder,
-               !firstResponder.isEqual(textView) {
-                context.coordinator.showPlaceholder()
-            }
-        }
-
         textView.isEditable = !isLoading
+        textView.needsDisplay = true
     }
 
     class Coordinator: NSObject, NSTextViewDelegate {
         var parent: QuickPanelInputField
-        weak var textView: NSTextView?
+        weak var textView: QuickPanelTextView?
         weak var scrollView: NSScrollView?
-        var placeholder: String = ""
         var isLoading: Bool = false
-        var isShowingPlaceholder: Bool = false
 
         init(_ parent: QuickPanelInputField) {
             self.parent = parent
-        }
-
-        func showPlaceholder() {
-            guard let textView = textView, parent.text.isEmpty else { return }
-            isShowingPlaceholder = true
-            textView.string = placeholder
-            textView.textColor = NSColor(QuickPanelStyle.textSubtle)
-        }
-
-        func hidePlaceholder() {
-            guard let textView = textView, isShowingPlaceholder else { return }
-            isShowingPlaceholder = false
-            textView.string = ""
-            textView.textColor = NSColor(QuickPanelStyle.text)
         }
 
         func updateScrollViewHeight() {
@@ -739,10 +736,12 @@ struct QuickPanelInputField: NSViewRepresentable {
 
             layoutManager.ensureLayout(for: textContainer)
 
-            var height = layoutManager.usedRect(for: textContainer).height
+            let lineHeight = ceil(layoutManager.defaultLineHeight(for: textView.font ?? NSFont.systemFont(ofSize: QuickPanelStyle.inputSize)))
+            let usedHeight = ceil(layoutManager.usedRect(for: textContainer).height)
+            var height = max(usedHeight, lineHeight)
 
-            if layoutManager.extraLineFragmentTextContainer != nil {
-                height += layoutManager.extraLineFragmentRect.height
+            if !textView.string.isEmpty && textView.string.hasSuffix("\n") {
+                height += lineHeight
             }
 
             let paddedHeight = height + QuickPanelStyle.inputHeightPadding
@@ -764,21 +763,18 @@ struct QuickPanelInputField: NSViewRepresentable {
         }
 
         func textDidBeginEditing(_ notification: Notification) {
-            hidePlaceholder()
+            textView?.needsDisplay = true
         }
 
         func textDidEndEditing(_ notification: Notification) {
-            if parent.text.isEmpty {
-                showPlaceholder()
-            }
+            textView?.needsDisplay = true
         }
 
         func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
+            guard let textView = notification.object as? QuickPanelTextView else { return }
 
-            if !isShowingPlaceholder {
-                parent.text = textView.string
-            }
+            parent.text = textView.string
+            textView.needsDisplay = true
 
             updateScrollViewHeight()
         }
@@ -789,16 +785,93 @@ struct QuickPanelInputField: NSViewRepresentable {
 
 class QuickPanelTextView: NSTextView {
     weak var coordinator: QuickPanelInputField.Coordinator?
+    var placeholder: String = "" {
+        didSet { needsDisplay = true }
+    }
+    private var shimmerTimer: Timer?
+    private var shimmerStartedAt: Date?
 
-    override func keyDown(with event: NSEvent) {
-        // Clear placeholder on any typing
-        if coordinator?.isShowingPlaceholder == true {
-            if let chars = event.characters, !chars.isEmpty,
-               event.keyCode != 53 && event.keyCode != 36 && event.keyCode != 126 && event.keyCode != 125 {
-                coordinator?.hidePlaceholder()
+    deinit {
+        stopShimmer()
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow == nil {
+            stopShimmer()
+        }
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard string.isEmpty, !placeholder.isEmpty else { return }
+
+        let placeholderAttributes: [NSAttributedString.Key: Any] = [
+            .font: font ?? NSFont.systemFont(ofSize: QuickPanelStyle.inputSize),
+            .foregroundColor: NSColor(QuickPanelStyle.textSubtle)
+        ]
+        let origin = NSPoint(
+            x: textContainerInset.width + (textContainer?.lineFragmentPadding ?? 0),
+            y: textContainerInset.height
+        )
+        placeholder.draw(at: origin, withAttributes: placeholderAttributes)
+    }
+
+    func setShimmering(_ enabled: Bool) {
+        if enabled {
+            startShimmer()
+        } else {
+            stopShimmer()
+        }
+    }
+
+    private func startShimmer() {
+        guard shimmerTimer == nil else { return }
+        shimmerStartedAt = Date()
+
+        let timer = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] timer in
+            guard let self, let startedAt = self.shimmerStartedAt else {
+                timer.invalidate()
+                return
+            }
+
+            let progress = min(Date().timeIntervalSince(startedAt) / 0.7, 1)
+            let pulse = CGFloat(sin(progress * .pi))
+            self.applyTextColor(self.shimmerColor(pulse: pulse))
+
+            if progress >= 1 {
+                self.stopShimmer()
             }
         }
 
+        shimmerTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func stopShimmer() {
+        shimmerTimer?.invalidate()
+        shimmerTimer = nil
+        shimmerStartedAt = nil
+        applyTextColor(NSColor(QuickPanelStyle.text))
+    }
+
+    private func shimmerColor(pulse: CGFloat) -> NSColor {
+        let base = NSColor(QuickPanelStyle.text)
+        let highlight = NSColor(QuickPanelStyle.textMuted)
+        return base.blended(withFraction: 0.35 * pulse, of: highlight) ?? base
+    }
+
+    private func applyTextColor(_ color: NSColor) {
+        textColor = color
+        typingAttributes[.foregroundColor] = color
+
+        let length = (string as NSString).length
+        guard length > 0 else { return }
+        textStorage?.addAttribute(.foregroundColor, value: color, range: NSRange(location: 0, length: length))
+    }
+
+    override func keyDown(with event: NSEvent) {
         // Escape - cancel
         if event.keyCode == 53 {
             coordinator?.parent.onCancel()

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -142,9 +142,54 @@ struct QuickPanelView: View {
         }
     }
 
-    // MARK: - Context Badge
+    // MARK: - Context Preview
 
+    @ViewBuilder
     private func contextBadge(context: QuickPanelContext) -> some View {
+        if let selectedText = context.trimmedSelectedText {
+            selectedTextContextPreview(context: context, selectedText: selectedText)
+        } else {
+            attachmentContextBadge(context: context)
+        }
+    }
+
+    private func selectedTextContextPreview(context: QuickPanelContext, selectedText: String) -> some View {
+        HStack(alignment: .top, spacing: Spacing.sm) {
+            Image(systemName: "text.quote")
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize, weight: .medium))
+                .foregroundColor(QuickPanelStyle.accent)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(selectedText)
+                    .font(QuickPanelStyle.font(size: QuickPanelStyle.bodySize))
+                    .foregroundColor(QuickPanelStyle.text)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let source = contextSourceLabel(context) {
+                    Text(source)
+                        .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize))
+                        .foregroundColor(QuickPanelStyle.textMuted)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: Spacing.sm)
+
+            clearContextButton
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.sm)
+        .background(QuickPanelStyle.accent.opacity(0.1))
+        .overlay(
+            RoundedRectangle(cornerRadius: QuickPanelStyle.radius)
+                .stroke(QuickPanelStyle.accent.opacity(0.16), lineWidth: 1)
+        )
+        .cornerRadius(QuickPanelStyle.radius)
+    }
+
+    private func attachmentContextBadge(context: QuickPanelContext) -> some View {
         let isScreenshot = context.isScreenshot
         let accentColor = isScreenshot ? QuickPanelStyle.success : QuickPanelStyle.textMuted
         let backgroundColor = isScreenshot ? QuickPanelStyle.success.opacity(0.15) : QuickPanelStyle.accent.opacity(0.1)
@@ -171,14 +216,7 @@ struct QuickPanelView: View {
                     .cornerRadius(QuickPanelStyle.radius)
             }
 
-            // Dismiss button
-            Button(action: { manager.clearContext() }) {
-                Image(systemName: "xmark")
-                    .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .semibold))
-                    .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
-            }
-            .buttonStyle(.plain)
-            .help("Clear context")
+            clearContextButton
         }
         .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.xs)
@@ -190,21 +228,53 @@ struct QuickPanelView: View {
         .cornerRadius(QuickPanelStyle.radius)
     }
 
+    private var clearContextButton: some View {
+        Button(action: { manager.clearContext() }) {
+            Image(systemName: "xmark")
+                .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .semibold))
+                .foregroundColor(QuickPanelStyle.textMuted.opacity(0.6))
+        }
+        .buttonStyle(.plain)
+        .help("Clear context")
+    }
+
     private func contextPreview(_ context: QuickPanelContext) -> String {
         if context.isScreenshot {
             return "Screenshot attached"
         }
-        if let text = context.selectedText {
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.count > 40 {
-                return String(trimmed.prefix(37)) + "..."
+        if let text = context.trimmedSelectedText {
+            if text.count > 40 {
+                return String(text.prefix(37)) + "..."
             }
-            return trimmed
+            return text
         }
         if context.hasImage {
             return "Image attached"
         }
         return "Context attached"
+    }
+
+    private func contextSourceLabel(_ context: QuickPanelContext) -> String? {
+        let app = context.activeApp?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = context.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sourceApp = app?.isEmpty == false ? app : nil
+        let sourceTitle = title?.isEmpty == false ? title : nil
+
+        switch (sourceApp, sourceTitle) {
+        case let (sourceApp?, sourceTitle?):
+            return "\(sourceApp) — \(truncate(sourceTitle, maxLength: 60))"
+        case let (sourceApp?, nil):
+            return sourceApp
+        case let (nil, sourceTitle?):
+            return truncate(sourceTitle, maxLength: 60)
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    private func truncate(_ text: String, maxLength: Int) -> String {
+        guard text.count > maxLength else { return text }
+        return "\(text.prefix(maxLength - 3))..."
     }
 
     // MARK: - Stream Destination Picker

--- a/Sources/Ticker/App/QuickPanel/QuickPanelWindow.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelWindow.swift
@@ -15,6 +15,8 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
     var onDismiss: (() -> Void)?
     /// Callback for Escape so all focus states use the same graduated handling.
     var onEscape: (() -> Void)?
+    private var fadeGeneration: Int = 0
+    private var isProgrammaticHide = false
 
     // MARK: - NSPanel Overrides
 
@@ -39,6 +41,7 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
     // MARK: - NSWindowDelegate (Blur Dismissal)
 
     func windowDidResignKey(_ notification: Notification) {
+        guard !isProgrammaticHide else { return }
         // Auto-dismiss when user clicks outside the panel
         onDismiss?()
     }
@@ -96,6 +99,42 @@ final class QuickPanelWindow: NSPanel, NSWindowDelegate {
     /// Position the panel at a specific point (bottom-left origin)
     func position(at point: CGPoint) {
         setFrameOrigin(point)
+    }
+
+    /// Show with a short opacity fade. Movement/scale stay fixed to avoid visual churn.
+    func fadeIn(duration: TimeInterval = 0.12) {
+        fadeGeneration += 1
+        let generation = fadeGeneration
+        alphaValue = 0
+        orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            animator().alphaValue = 1
+        } completionHandler: { [weak self] in
+            guard let self, generation == self.fadeGeneration else { return }
+            self.alphaValue = 1
+        }
+    }
+
+    /// Hide with a short opacity fade. Completion is ignored if a newer show/hide starts.
+    func fadeOut(duration: TimeInterval = 0.12, completion: (() -> Void)? = nil) {
+        fadeGeneration += 1
+        let generation = fadeGeneration
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            guard let self, generation == self.fadeGeneration else { return }
+            self.isProgrammaticHide = true
+            self.orderOut(nil)
+            self.isProgrammaticHide = false
+            self.alphaValue = 1
+            completion?()
+        }
     }
 
     /// Reset panel to initial minimum height

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -29,6 +29,8 @@ struct StreamSummary: Identifiable, Codable {
     let title: String
     let sourceCount: Int
     let cellCount: Int
+    let charCount: Int
+    let imageCount: Int
     let updatedAt: Date
     let previewText: String?
 }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -26,6 +26,16 @@ final class PersistenceService {
 #endif
     }
 
+    private static func countMarkdownImageTokens(in markdown: String) -> Int {
+        var count = 0
+        var searchStart = markdown.startIndex
+        while let range = markdown.range(of: "![", range: searchStart..<markdown.endIndex) {
+            count += 1
+            searchStart = range.upperBound
+        }
+        return count
+    }
+
     init(databaseURL: URL? = nil, fileManager: FileManager = .default) throws {
         let databaseURL = databaseURL ?? Self.databaseURL(fileManager: fileManager)
         self.databaseURL = databaseURL
@@ -418,6 +428,7 @@ final class PersistenceService {
                     s.id, s.title, s.updated_at,
                     (SELECT COUNT(*) FROM sources WHERE stream_id = s.id) as source_count,
                     (SELECT COUNT(*) FROM cells WHERE stream_id = s.id) as cell_count,
+                    (SELECT markdown FROM stream_documents WHERE stream_id = s.id) as document_markdown,
                     COALESCE(
                         (SELECT markdown FROM stream_documents WHERE stream_id = s.id),
                         (SELECT content FROM cells WHERE stream_id = s.id ORDER BY position LIMIT 1)
@@ -426,11 +437,17 @@ final class PersistenceService {
                 ORDER BY s.updated_at DESC
             """
             return try Row.fetchAll(db, sql: sql).map { row in
-                StreamSummary(
+                let documentMarkdown: String = row["document_markdown"] ?? ""
+                // ponytail: raw markdown counts are the ceiling here; upgrade to parser-backed rendered-text/image metrics if list metadata needs semantic precision.
+                let charCount = documentMarkdown.count
+                let imageCount = Self.countMarkdownImageTokens(in: documentMarkdown)
+                return StreamSummary(
                     id: UUID(uuidString: row["id"])!,
                     title: row["title"],
                     sourceCount: row["source_count"],
                     cellCount: row["cell_count"],
+                    charCount: charCount,
+                    imageCount: imageCount,
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"]),
                     previewText: row["preview_text"]
                 )

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -235,6 +235,9 @@ final class SelectionReaderService {
     /// Build a context from available selection, app info, and position
     /// Captures everything at once BEFORE focus changes
     func buildContext() -> QuickPanelContext {
+        let axTrusted = cursorService.hasAccessibilityPermission
+        DebugLog.log("[SelectionReader] buildContext axTrusted=\(axTrusted)")
+
         // Capture position first (uses selection bounds if available, else mouse)
         let panelSize = CGSize(width: 350, height: 80)  // Default panel size
         let position = cursorService.calculatePanelPosition(panelSize: panelSize)
@@ -247,7 +250,7 @@ final class SelectionReaderService {
             clipboardImageData = getRecentClipboardImage()
         }
 
-        return QuickPanelContext(
+        let context = QuickPanelContext(
             selectedText: selectedText,
             activeApp: getActiveApp(),
             windowTitle: getActiveWindowTitle(),
@@ -255,6 +258,14 @@ final class SelectionReaderService {
             clipboardImage: clipboardImageData,
             isScreenshot: false
         )
+        DebugLog.log(
+            "[SelectionReader] buildContext result " +
+            "hasSelection=\(context.hasSelection) " +
+            "selectedLength=\(context.trimmedSelectedText?.count ?? 0) " +
+            "hasImage=\(context.hasImage) " +
+            "activeApp=\(context.activeApp ?? "unknown")"
+        )
+        return context
     }
 
     /// Get clipboard image if it was copied recently (within threshold)
@@ -285,8 +296,16 @@ struct QuickPanelContext {
     /// Clipboard-derived images should keep this false.
     let isScreenshot: Bool
 
+    var trimmedSelectedText: String? {
+        guard let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
     var hasSelection: Bool {
-        selectedText != nil && !(selectedText?.isEmpty ?? true)
+        trimmedSelectedText != nil
     }
 
     var hasImage: Bool {
@@ -299,7 +318,7 @@ struct QuickPanelContext {
 
     /// Truncated preview of selected text for display
     var selectionPreview: String? {
-        guard let text = selectedText else { return nil }
+        guard let text = trimmedSelectedText else { return nil }
         if text.count <= 100 {
             return text
         }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1,8 +1,39 @@
+import CoreGraphics
 import Foundation
 import GRDB
 import XCTest
 
 @testable import Ticker
+
+final class QuickPanelMarkdownFormatterTests: XCTestCase {
+    func test_buildFragment_includesSelectedTextAsBlockquoteWithAttribution() throws {
+        let context = QuickPanelContext(
+            selectedText: " First line\nSecond line ",
+            activeApp: "Safari",
+            windowTitle: "Article *Title*",
+            panelPosition: CGPoint(x: 0, y: 0),
+            clipboardImage: nil,
+            isScreenshot: false
+        )
+
+        let fragment = try QuickPanelMarkdownFormatter.buildFragment(
+            context: context,
+            inputText: "Saved note"
+        ) { _ in
+            XCTFail("Image formatter should not run for text-only context")
+            return ""
+        }
+
+        XCTAssertEqual(fragment, """
+        > First line
+        > Second line
+
+        *— Safari — Article \\*Title\\**
+
+        Saved note
+        """)
+    }
+}
 
 final class StreamDocumentTests: XCTestCase {
     func test_appendToStreamDocument_createsDocumentWithExactlyFragmentWhenMissing() throws {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -232,14 +232,23 @@ final class StreamDocumentTests: XCTestCase {
             try service.saveStream(olderStream)
             try service.saveStream(newerStream)
 
+            let olderMarkdown = "# Older Notes\n\nThe older document preview comes from markdown."
+            let newerMarkdown = """
+            Newer document preview
+
+            ![diagram](ticker-asset://stream/diagram.png)
+            ![photo](https://example.com/photo.jpg)
+
+            Second paragraph.
+            """
             _ = try service.saveStreamDocument(
                 streamId: olderStream.id,
-                markdown: "# Older Notes\n\nThe older document preview comes from markdown."
+                markdown: olderMarkdown
             )
             Thread.sleep(forTimeInterval: 0.01)
             _ = try service.saveStreamDocument(
                 streamId: newerStream.id,
-                markdown: "Newer document preview\n\nSecond paragraph."
+                markdown: newerMarkdown
             )
 
             let summaries = try service.loadStreamSummaries()
@@ -251,10 +260,14 @@ final class StreamDocumentTests: XCTestCase {
             )
 
             let newerSummary = try XCTUnwrap(summaries.first { $0.id == newerStream.id })
-            XCTAssertEqual(newerSummary.previewText, "Newer document preview\n\nSecond paragraph.")
+            XCTAssertEqual(newerSummary.previewText, newerMarkdown)
+            XCTAssertEqual(newerSummary.charCount, newerMarkdown.count)
+            XCTAssertEqual(newerSummary.imageCount, 2)
 
             let olderSummary = try XCTUnwrap(summaries.first { $0.id == olderStream.id })
-            XCTAssertEqual(olderSummary.previewText, "# Older Notes\n\nThe older document preview comes from markdown.")
+            XCTAssertEqual(olderSummary.previewText, olderMarkdown)
+            XCTAssertEqual(olderSummary.charCount, olderMarkdown.count)
+            XCTAssertEqual(olderSummary.imageCount, 0)
         }
     }
 

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -315,6 +315,29 @@ function formatRelativeTime(dateString: string): string {
   return date.toLocaleDateString();
 }
 
+function formatCompactCount(count: number): string {
+  if (count < 1000) {
+    return new Intl.NumberFormat().format(count);
+  }
+  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(count / 1000)}k`;
+}
+
+function formatStreamMetadata(stream: StreamSummary): string {
+  const segments = [formatRelativeTime(stream.updatedAt)];
+
+  if (stream.sourceCount > 0) {
+    segments.push(`${stream.sourceCount} ${stream.sourceCount === 1 ? 'source' : 'sources'}`);
+  }
+  if (stream.charCount > 0) {
+    segments.push(`${formatCompactCount(stream.charCount)} chars`);
+  }
+  if (stream.imageCount > 0) {
+    segments.push(`${stream.imageCount} ${stream.imageCount === 1 ? 'image' : 'images'}`);
+  }
+
+  return segments.join(' · ');
+}
+
 function StreamListView({ streams, isLoading, isLoadingStream, onSelect, onCreate, onSettings }: StreamListViewProps) {
   // Sort streams by updatedAt (most recent first)
   const sortedStreams = [...streams].sort((a, b) =>
@@ -355,7 +378,7 @@ function StreamListView({ streams, isLoading, isLoadingStream, onSelect, onCreat
             >
               <span className="stream-title">{stream.title}</span>
               <span className="stream-meta">
-                {formatRelativeTime(stream.updatedAt)} · {stream.sourceCount} {stream.sourceCount === 1 ? 'source' : 'sources'}
+                {formatStreamMetadata(stream)}
               </span>
             </button>
           ))

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -4,6 +4,7 @@ import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { Transaction, type Extension } from '@codemirror/state';
+import { isolateHistory } from '@codemirror/commands';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { bridge, Stream, SourceReference } from '../types';
@@ -11,6 +12,7 @@ import { SidePanel } from './SidePanel';
 import { SearchModal } from './SearchModal';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
+import { AI_HISTORY_USER_EVENT, aiWritingExtension, getAiWritingRange, setAiWritingRangeEffect } from '../extensions/AIWritingState';
 import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
 import { computeAppendInsertion } from '../utils/appendInsertion';
@@ -41,7 +43,49 @@ interface FloatingMenuState {
   top: number;
 }
 
+interface AiFeedbackState {
+  visible: boolean;
+  kind: 'writing' | 'error';
+  message: string;
+}
+
 const SELECTION_MENU_DELAY_MS = 180;
+const AI_ERROR_FEEDBACK_MS = 2200;
+
+function focusEditorAtDocumentEnd(view: EditorView) {
+  const end = view.state.doc.length;
+  view.dispatch({
+    selection: { anchor: end },
+    effects: EditorView.scrollIntoView(end, { y: 'nearest' }),
+    userEvent: 'select',
+  });
+  view.focus();
+}
+
+const clickToDocumentEndExtension: Extension = EditorView.domEventHandlers({
+  mousedown: (event, view) => {
+    if (event.button !== 0 || event.defaultPrevented) return false;
+    if (!(event.target instanceof Node) || !view.scrollDOM.contains(event.target)) return false;
+
+    const endCoords = view.coordsAtPos(view.state.doc.length, 1);
+    if (!endCoords) return false;
+
+    const scrollerRect = view.scrollDOM.getBoundingClientRect();
+    const isBelowLastLine = event.clientY > endCoords.bottom + 6 && event.clientY <= scrollerRect.bottom;
+    if (!isBelowLastLine) return false;
+
+    event.preventDefault();
+    focusEditorAtDocumentEnd(view);
+    return true;
+  },
+});
+
+function dispatchAiRangeClear(view: EditorView) {
+  view.dispatch({
+    effects: setAiWritingRangeEffect.of(null),
+    annotations: Transaction.addToHistory.of(false),
+  });
+}
 
 const markdownHighlightStyle = HighlightStyle.define([
   {
@@ -126,6 +170,11 @@ export function StreamEditor({
     left: 0,
     top: 0,
   });
+  const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
+    visible: false,
+    kind: 'writing',
+    message: 'AI is writing',
+  });
 
   const titleInputRef = useRef<HTMLInputElement>(null);
   const editorShellRef = useRef<HTMLDivElement>(null);
@@ -136,14 +185,15 @@ export function StreamEditor({
   const revisionRef = useRef(stream.document?.revision ?? 0);
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
+  const aiFeedbackTimerRef = useRef<number | null>(null);
   const showPromptRef = useRef(showPrompt);
   const isAiThinkingRef = useRef(false);
   const aiRequestRef = useRef<{
     id: string;
     buffer: string;
-    from: number;
-    to: number;
     mode: 'replace' | 'after';
+    originalText: string;
+    prefix: string;
   } | null>(null);
 
   const insertImageAtCursor = useCallback((imageUrl: string, altText = 'image') => {
@@ -212,6 +262,40 @@ export function StreamEditor({
     return shell.contains(active);
   }, []);
 
+  const clearAiFeedbackTimer = useCallback(() => {
+    if (aiFeedbackTimerRef.current !== null) {
+      window.clearTimeout(aiFeedbackTimerRef.current);
+      aiFeedbackTimerRef.current = null;
+    }
+  }, []);
+
+  const showAiWritingFeedback = useCallback(() => {
+    clearAiFeedbackTimer();
+    setAiFeedback({
+      visible: true,
+      kind: 'writing',
+      message: 'AI is writing',
+    });
+  }, [clearAiFeedbackTimer]);
+
+  const hideAiFeedback = useCallback(() => {
+    clearAiFeedbackTimer();
+    setAiFeedback((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+  }, [clearAiFeedbackTimer]);
+
+  const showAiErrorFeedback = useCallback((message: string) => {
+    clearAiFeedbackTimer();
+    setAiFeedback({
+      visible: true,
+      kind: 'error',
+      message,
+    });
+    aiFeedbackTimerRef.current = window.setTimeout(() => {
+      aiFeedbackTimerRef.current = null;
+      setAiFeedback((previous) => (previous.kind === 'error' ? { ...previous, visible: false } : previous));
+    }, AI_ERROR_FEEDBACK_MS);
+  }, [clearAiFeedbackTimer]);
+
   useEffect(() => {
     setMarkdownContent(stream.document?.markdown ?? '');
     lastSavedContentRef.current = stream.document?.markdown ?? '';
@@ -220,12 +304,28 @@ export function StreamEditor({
     setTitle(stream.title);
     setSaveState('saved');
     setAiStatus('idle');
+    hideAiFeedback();
     setFloatingMenu({ visible: false, left: 0, top: 0 });
     setShowPrompt(false);
     setPromptValue('');
     promptContextRef.current = null;
     aiRequestRef.current = null;
-  }, [stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
+    const view = editorViewRef.current;
+    if (view) {
+      dispatchAiRangeClear(view);
+    }
+  }, [hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const view = editorViewRef.current;
+      if (view) {
+        focusEditorAtDocumentEnd(view);
+      }
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [stream.id]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -358,6 +458,16 @@ export function StreamEditor({
         const chunk = message.payload?.chunk as string | undefined;
         if (!requestId || requestId !== active.id || !chunk) return;
         active.buffer += chunk;
+
+        const view = editorViewRef.current;
+        const range = view ? getAiWritingRange(view.state) : null;
+        if (view && range) {
+          view.dispatch({
+            changes: { from: range.to, insert: chunk },
+            effects: setAiWritingRangeEffect.of({ from: range.from, to: range.to + chunk.length }),
+            annotations: Transaction.addToHistory.of(false),
+          });
+        }
         return;
       }
 
@@ -402,8 +512,23 @@ export function StreamEditor({
           }
         }
 
+        const view = editorViewRef.current;
+        const range = view ? getAiWritingRange(view.state) : null;
+        if (view && range) {
+          view.dispatch({
+            changes: { from: range.from, to: range.to, insert: active.originalText },
+            selection: { anchor: range.from + active.originalText.length },
+            effects: setAiWritingRangeEffect.of(null),
+            annotations: Transaction.addToHistory.of(false),
+          });
+          view.focus();
+        } else if (view) {
+          dispatchAiRangeClear(view);
+        }
+
         setAiStatus('idle');
         aiRequestRef.current = null;
+        showAiErrorFeedback(displayError);
         addToast(displayError, 'error');
         return;
       }
@@ -416,48 +541,70 @@ export function StreamEditor({
         if (!view) {
           setAiStatus('idle');
           aiRequestRef.current = null;
+          hideAiFeedback();
           return;
         }
 
         const rawOutput = active.buffer.trim();
         if (!rawOutput) {
+          const range = getAiWritingRange(view.state);
+          if (range) {
+            view.dispatch({
+              changes: { from: range.from, to: range.to, insert: active.originalText },
+              selection: { anchor: range.from + active.originalText.length },
+              effects: setAiWritingRangeEffect.of(null),
+              annotations: Transaction.addToHistory.of(false),
+            });
+          } else {
+            dispatchAiRangeClear(view);
+          }
+          view.focus();
           setAiStatus('idle');
           aiRequestRef.current = null;
+          showAiErrorFeedback('AI returned empty output.');
           addToast('AI returned empty output.', 'warning');
           return;
         }
 
-        let insertText = rawOutput;
-        let from = active.from;
-        let to = active.to;
-
-        if (active.mode === 'after') {
-          const doc = view.state.doc;
-          const before = doc.sliceString(Math.max(0, active.to - 2), active.to);
-          const needsBlankLine = !before.endsWith('\n\n');
-          const needsSingleBreak = before.endsWith('\n') && !before.endsWith('\n\n');
-          const prefix = needsBlankLine ? '\n\n' : needsSingleBreak ? '\n' : '';
-          const suffix = insertText.endsWith('\n') ? '' : '\n';
-          insertText = `${prefix}${insertText}${suffix}`;
-          from = active.to;
-          to = active.to;
+        const range = getAiWritingRange(view.state);
+        if (!range) {
+          setAiStatus('idle');
+          aiRequestRef.current = null;
+          hideAiFeedback();
+          return;
         }
 
+        const suffix = active.mode === 'after' && !rawOutput.endsWith('\n') ? '\n' : '';
+        const insertText = `${active.prefix}${rawOutput}${suffix}`;
+        const finalFrom = range.from;
+        const originalTo = finalFrom + active.originalText.length;
+
         view.dispatch({
-          changes: { from, to, insert: insertText },
-          selection: { anchor: from + insertText.length },
-          annotations: Transaction.addToHistory.of(true),
+          changes: { from: range.from, to: range.to, insert: active.originalText },
+          annotations: Transaction.addToHistory.of(false),
+        });
+
+        view.dispatch({
+          changes: { from: finalFrom, to: originalTo, insert: insertText },
+          selection: { anchor: finalFrom + insertText.length },
+          effects: setAiWritingRangeEffect.of(null),
+          annotations: [
+            Transaction.addToHistory.of(true),
+            Transaction.userEvent.of(AI_HISTORY_USER_EVENT),
+            isolateHistory.of('full'),
+          ],
         });
         view.focus();
 
         setAiStatus('idle');
         aiRequestRef.current = null;
+        hideAiFeedback();
         return;
       }
     });
 
     return () => unsubscribe();
-  }, [addToast, stream.id]);
+  }, [addToast, hideAiFeedback, showAiErrorFeedback, stream.id]);
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
@@ -763,15 +910,60 @@ export function StreamEditor({
       return;
     }
 
+    const view = editorViewRef.current;
+    if (!view) {
+      addToast('Editor is not ready yet.', 'warning');
+      return;
+    }
+
+    const docLength = view.state.doc.length;
+    const from = Math.max(0, Math.min(options.from, docLength));
+    const to = Math.max(from, Math.min(options.to, docLength));
+    const originalText = options.mode === 'replace' ? view.state.doc.sliceString(from, to) : '';
+    let rangeFrom = from;
+    let rangeTo = from;
+    let prefix = '';
+
+    if (options.mode === 'after') {
+      rangeFrom = to;
+      rangeTo = to;
+      const before = view.state.doc.sliceString(Math.max(0, to - 2), to);
+      const needsBlankLine = !before.endsWith('\n\n');
+      const needsSingleBreak = before.endsWith('\n') && !before.endsWith('\n\n');
+      prefix = needsBlankLine ? '\n\n' : needsSingleBreak ? '\n' : '';
+      rangeTo += prefix.length;
+    }
+
+    const initialChange = options.mode === 'replace'
+      ? { from, to, insert: '' }
+      : prefix
+        ? { from: to, insert: prefix }
+        : null;
+
+    view.dispatch({
+      changes: initialChange ?? undefined,
+      selection: { anchor: rangeTo },
+      effects: [
+        setAiWritingRangeEffect.of({ from: rangeFrom, to: rangeTo }),
+        EditorView.scrollIntoView(rangeTo, { y: 'nearest' }),
+      ],
+      annotations: [
+        Transaction.addToHistory.of(false),
+        isolateHistory.of('before'),
+      ],
+    });
+    view.focus();
+
     const requestId = crypto.randomUUID();
     aiRequestRef.current = {
       id: requestId,
       buffer: '',
-      from: options.from,
-      to: options.to,
       mode: options.mode,
+      originalText,
+      prefix,
     };
     setAiStatus('thinking');
+    showAiWritingFeedback();
 
     bridge.send({
       type: 'thinkDocument',
@@ -783,7 +975,7 @@ export function StreamEditor({
         imageURLs: options.imageUrls ?? [],
       },
     });
-  }, [addToast, isAiThinking, stream.id]);
+  }, [addToast, isAiThinking, showAiWritingFeedback, stream.id]);
 
   const handleSend = useCallback(() => {
     const context = getSelectionContext(true);
@@ -902,6 +1094,10 @@ export function StreamEditor({
   useEffect(() => {
     return () => clearSelectionMenuTimer();
   }, [clearSelectionMenuTimer]);
+
+  useEffect(() => {
+    return () => clearAiFeedbackTimer();
+  }, [clearAiFeedbackTimer]);
 
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
@@ -1125,8 +1321,9 @@ export function StreamEditor({
                   autocomplete: 'on',
                   autocorrect: 'on',
                 }),
-                EditorView.editable.of(!isAiThinking),
                 selectionMenuExtension,
+                clickToDocumentEndExtension,
+                aiWritingExtension,
                 markdown({ base: markdownLanguage, codeLanguages: languages }),
                 syntaxHighlighting(markdownHighlightStyle),
                 markdownConcealExtension,
@@ -1134,12 +1331,27 @@ export function StreamEditor({
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
+                window.setTimeout(() => {
+                  if (editorViewRef.current === view) {
+                    focusEditorAtDocumentEnd(view);
+                  }
+                }, 0);
               }}
               onChange={(value) => {
                 setMarkdownContent(value);
               }}
               className="document-editor-codemirror"
             />
+            {aiFeedback.visible && (
+              <div
+                className={`document-ai-status-pill document-ai-status-pill--${aiFeedback.kind}`}
+                role="status"
+                aria-live="polite"
+              >
+                <span className="document-ai-status-dot" aria-hidden="true" />
+                <span>{aiFeedback.message}</span>
+              </div>
+            )}
           </div>
         </div>
         {hasPdfSources && (

--- a/Web/src/extensions/AIWritingState.test.ts
+++ b/Web/src/extensions/AIWritingState.test.ts
@@ -1,0 +1,99 @@
+import { EditorState, Transaction } from '@codemirror/state';
+import { history, isolateHistory, undo } from '@codemirror/commands';
+import { describe, expect, it } from 'vitest';
+import {
+  AI_HISTORY_USER_EVENT,
+  aiWritingExtension,
+  getAiWritingRange,
+  setAiWritingRangeEffect,
+} from './AIWritingState';
+
+describe('aiWritingExtension', () => {
+  it('maps the active AI writing range through document edits', () => {
+    let state = EditorState.create({
+      doc: 'Hello world',
+      extensions: [aiWritingExtension],
+    });
+
+    state = state.update({
+      effects: setAiWritingRangeEffect.of({ from: 6, to: 11 }),
+    }).state;
+
+    state = state.update({
+      changes: { from: 0, insert: 'Say: ' },
+    }).state;
+
+    expect(getAiWritingRange(state)).toEqual({ from: 11, to: 16 });
+
+    state = state.update({
+      changes: { from: 16, insert: '!' },
+    }).state;
+
+    expect(getAiWritingRange(state)).toEqual({ from: 11, to: 17 });
+  });
+
+  it('clears the active range explicitly', () => {
+    let state = EditorState.create({
+      doc: 'Draft',
+      extensions: [aiWritingExtension],
+    });
+
+    state = state.update({
+      effects: setAiWritingRangeEffect.of({ from: 0, to: 5 }),
+    }).state;
+    state = state.update({
+      effects: setAiWritingRangeEffect.of(null),
+    }).state;
+
+    expect(getAiWritingRange(state)).toBeNull();
+  });
+
+  it('keeps streamed partials out of history and records final AI text as one undo step', () => {
+    let state = EditorState.create({
+      doc: 'Hello world\n\nTail',
+      extensions: [history(), aiWritingExtension],
+    });
+    const dispatch = (transaction: Transaction) => {
+      state = transaction.state;
+    };
+
+    state = state.update({
+      changes: { from: 6, to: 11, insert: '' },
+      effects: setAiWritingRangeEffect.of({ from: 6, to: 6 }),
+      annotations: Transaction.addToHistory.of(false),
+    }).state;
+    state = state.update({
+      changes: { from: 6, insert: 'AI draft' },
+      effects: setAiWritingRangeEffect.of({ from: 6, to: 14 }),
+      annotations: Transaction.addToHistory.of(false),
+    }).state;
+    state = state.update({
+      changes: { from: state.doc.length, insert: ' note' },
+      annotations: [
+        Transaction.addToHistory.of(true),
+        Transaction.userEvent.of('input.type'),
+      ],
+    }).state;
+
+    const range = getAiWritingRange(state);
+    expect(range).toEqual({ from: 6, to: 14 });
+
+    state = state.update({
+      changes: { from: range!.from, to: range!.to, insert: 'world' },
+      annotations: Transaction.addToHistory.of(false),
+    }).state;
+    state = state.update({
+      changes: { from: range!.from, to: range!.from + 'world'.length, insert: 'AI final' },
+      effects: setAiWritingRangeEffect.of(null),
+      annotations: [
+        Transaction.addToHistory.of(true),
+        Transaction.userEvent.of(AI_HISTORY_USER_EVENT),
+        isolateHistory.of('full'),
+      ],
+    }).state;
+
+    expect(state.doc.toString()).toBe('Hello AI final\n\nTail note');
+    expect(undo({ state, dispatch })).toBe(true);
+    expect(state.doc.toString()).toBe('Hello world\n\nTail note');
+  });
+});

--- a/Web/src/extensions/AIWritingState.ts
+++ b/Web/src/extensions/AIWritingState.ts
@@ -1,0 +1,45 @@
+import { EditorState, StateEffect, StateField, type Extension } from '@codemirror/state';
+import { Decoration, EditorView } from '@codemirror/view';
+
+export interface AiWritingRange {
+  from: number;
+  to: number;
+}
+
+export const AI_HISTORY_USER_EVENT = 'input.type.ai';
+
+export const setAiWritingRangeEffect = StateEffect.define<AiWritingRange | null>();
+
+export const aiWritingRangeField = StateField.define<AiWritingRange | null>({
+  create: () => null,
+  update(range, transaction) {
+    let nextRange = range;
+
+    if (nextRange && transaction.docChanged) {
+      nextRange = {
+        from: transaction.changes.mapPos(nextRange.from, -1),
+        to: transaction.changes.mapPos(nextRange.to, 1),
+      };
+    }
+
+    for (const effect of transaction.effects) {
+      if (effect.is(setAiWritingRangeEffect)) {
+        nextRange = effect.value;
+      }
+    }
+
+    return nextRange;
+  },
+  provide: (field) => EditorView.decorations.from(field, (range) => {
+    if (!range || range.to <= range.from) return Decoration.none;
+    return Decoration.set([
+      Decoration.mark({ class: 'cm-ai-writing-range' }).range(range.from, range.to),
+    ]);
+  }),
+});
+
+export const aiWritingExtension: Extension = aiWritingRangeField;
+
+export function getAiWritingRange(state: EditorState): AiWritingRange | null {
+  return state.field(aiWritingRangeField, false) ?? null;
+}

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -753,6 +753,7 @@ body {
 }
 
 .document-editor-shell {
+  position: relative;
   width: 100%;
   max-width: none;
   min-height: calc(100vh - 200px);
@@ -781,6 +782,7 @@ body {
 
 .document-editor-codemirror .cm-scroller {
   font-family: var(--editor-font-family);
+  min-height: inherit;
   padding: clamp(var(--space-5), 3.6vw, var(--space-7)) clamp(var(--space-5), 4.6vw, var(--space-8)) clamp(220px, 30vh, 360px);
   overflow-x: hidden;
   overflow-y: visible;
@@ -788,8 +790,15 @@ body {
 
 .document-editor-codemirror .cm-content {
   max-width: 68ch;
+  min-height: inherit;
   margin: 0 auto;
-  caret-color: var(--color-text);
+  caret-color: var(--text);
+}
+
+.document-editor-codemirror .cm-cursor,
+.document-editor-codemirror .cm-dropCursor {
+  border-left-color: var(--text) !important;
+  border-left-width: 2px;
 }
 
 .document-editor-codemirror .cm-focused {
@@ -806,6 +815,96 @@ body {
   padding-left: var(--space-3);
   border-left: 2px solid var(--border);
   color: var(--color-text-secondary);
+}
+
+.document-editor-codemirror .cm-ai-writing-range {
+  color: var(--color-text-secondary);
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    var(--accent-soft) 42%,
+    var(--border-subtle) 58%,
+    transparent 100%
+  );
+  background-size: 220% 100%;
+  border-radius: 2px;
+  animation: ai-writing-shimmer 1.15s ease-in-out infinite;
+}
+
+@keyframes ai-writing-shimmer {
+  0% {
+    background-position: 130% 0;
+  }
+
+  100% {
+    background-position: -80% 0;
+  }
+}
+
+.document-ai-status-pill {
+  position: fixed;
+  right: var(--space-5);
+  bottom: var(--space-5);
+  z-index: 930;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 32px;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--overlay-shadow);
+  color: var(--color-text-secondary);
+  font-size: var(--type-ui-small);
+  line-height: 1;
+  pointer-events: none;
+  backdrop-filter: var(--overlay-backdrop);
+  animation: ai-status-enter 0.12s ease-out;
+}
+
+.document-ai-status-pill--error {
+  color: var(--danger);
+  border-color: var(--danger-border);
+  background: var(--surface-raised);
+}
+
+.document-ai-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.68;
+  animation: ai-status-pulse 0.9s ease-in-out infinite;
+}
+
+.document-ai-status-pill--error .document-ai-status-dot {
+  animation: none;
+}
+
+@keyframes ai-status-enter {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ai-status-pulse {
+  0%,
+  100% {
+    transform: scale(0.8);
+    opacity: 0.45;
+  }
+
+  50% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
 }
 
 .document-editor-codemirror .cm-md-image-widget {

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -23,6 +23,8 @@ export interface StreamSummary {
   title: string;
   sourceCount: number;
   cellCount: number;
+  charCount: number;
+  imageCount: number;
   updatedAt: string;
   previewText: string | null;
 }


### PR DESCRIPTION
Surgical fixes from hands-on review. Stacked on #28.

- **Regression fix (verified live):** quick-panel selection context is back — external highlight → ⌘L shows the quoted context card with attribution; ↵ persists blockquote + `*— App*`. Added DEBUG diagnostics that distinguish capture failures from lost Accessibility grants.
- **Editor AI feedback:** removed the editable-lock that froze the editor during generation; chunks now stream live into a change-mapped insertion range with a subtle shimmer; "AI is writing" pill (bottom-right, surface tokens); editing continues during generation; AI apply remains one ⌘Z.
- **Quick panel mechanics:** caret at position 0 (placeholder is now drawn, not real text — also the root cause of the long-standing empty-focused height jump, fixed); saved-pill moved to bottom-right; fast window fade in/out; saved text stays put and shimmers instead of vanishing (no multiline resize jump).
- **Conversation upgrades:** per-message save icons (right gutter, low opacity) appending via the standard capture path; clear-conversation button aligned right of the picker, visible only mid-conversation.
- **Editor cursor:** caret visible in dark mode (2px, token color); click below the last line places caret at doc end; streams open focused with caret at end.
- **Stream list:** rows show `time · sources · chars · images` with zero-segments hidden and locale-aware k-formatting.

Verification: 23 Swift + 11 web tests, typecheck/build, bidirectional contract checker all green; regression + panel caret/height verified in the live app. Deferred per request: unique Untitled-N naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)