### PR TITLE
PDF link lifecycle: crosshair feedback, orphaned-marker GC, centered navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- PDF anchor picking now shows a crosshair cursor, and deleting PDF links removes their saved markers.
 - Restored window dragging from the transparent titlebar strip.
 - Source access now recovers refreshed bookmarks when possible, PDF stream links keep accent styling, and PDF anchor picking cancels on outside click.
 - Recovered quick-capture notes that previously didn't appear in streams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- PDF highlight navigation now centers the target marker or highlight in the pane.
 - PDF anchor picking now shows a crosshair cursor, and deleting PDF links removes their saved markers.
 - Restored window dragging from the transparent titlebar strip.
 - Source access now recovers refreshed bookmarks when possible, PDF stream links keep accent styling, and PDF anchor picking cancels on outside click.

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -5,6 +5,40 @@ protocol StreamMessageHandlerDelegate: AnyObject {
     func setCurrentStreamIdForFileDrops(_ streamId: UUID?)
     func clearCurrentStreamIdForFileDrops(ifMatches streamId: UUID)
     func closePDFPaneIfShowingDifferentStream(_ streamId: UUID) async
+    func removePDFHighlightAnnotations(ids: [String], sourceIds: [UUID]) async
+}
+
+enum PDFHighlightLinkReferenceExtractor {
+    private static let tickerPDFURLPattern = #"ticker-pdf://[^\s<>"'\)\]]+"#
+
+    static func highlightIds(in markdown: String) -> Set<String> {
+        guard let regex = try? NSRegularExpression(pattern: tickerPDFURLPattern, options: [.caseInsensitive]) else {
+            return []
+        }
+
+        let range = NSRange(markdown.startIndex..<markdown.endIndex, in: markdown)
+        var ids = Set<String>()
+
+        regex.enumerateMatches(in: markdown, range: range) { match, _, _ in
+            guard let match,
+                  let urlRange = Range(match.range, in: markdown) else {
+                return
+            }
+
+            let rawURL = String(markdown[urlRange])
+            guard let components = URLComponents(string: rawURL),
+                  let highlightValue = components.queryItems?.first(where: {
+                      $0.name.caseInsensitiveCompare("highlight") == .orderedSame
+                  })?.value,
+                  let id = UUID(uuidString: highlightValue) else {
+                return
+            }
+
+            ids.insert(id.uuidString)
+        }
+
+        return ids
+    }
 }
 
 final class StreamMessageHandler: BridgeMessageHandler {
@@ -136,6 +170,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     markdown: markdown,
                     baseRevision: baseRevision
                 )
+                await pruneUnreferencedPDFHighlights(streamId: streamId, markdown: markdown)
                 await bridgeService.respond(to: callbackId, with: [
                     "revision": AnyCodable(revision)
                 ])
@@ -221,6 +256,21 @@ final class StreamMessageHandler: BridgeMessageHandler {
 
         default:
             DebugLog.log("[StreamMessageHandler] Unknown message type: \(message.type)")
+        }
+    }
+
+    private func pruneUnreferencedPDFHighlights(streamId: UUID, markdown: String) async {
+        do {
+            let referencedHighlightIds = PDFHighlightLinkReferenceExtractor.highlightIds(in: markdown)
+            let sourceIds = try persistence.loadStream(id: streamId)?.sources.map(\.id) ?? []
+            let deletedHighlightIds = try persistence.deletePDFHighlights(
+                sourceIds: sourceIds,
+                excludingIds: Array(referencedHighlightIds)
+            )
+            // ponytail: undoing a deleted link after GC restores the markdown only; revive-on-undo would need soft-delete metadata.
+            await delegate?.removePDFHighlightAnnotations(ids: deletedHighlightIds, sourceIds: sourceIds)
+        } catch {
+            DebugLog.log("[StreamMessageHandler] Failed to prune PDF highlights (\(DebugLog.errorSummary(error)))")
         }
     }
 }

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -106,6 +106,8 @@ final class PDFReaderPaneController: NSViewController {
     private var isAnchorPickMode = false
     private var anchorPickMouseMonitor: Any?
     private var anchorPickKeyMonitor: Any?
+    private var anchorPickCursorMonitor: Any?
+    private var anchorPickPreviousAcceptsMouseMovedEvents: Bool?
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -172,6 +174,12 @@ final class PDFReaderPaneController: NSViewController {
         updatePDFPaneStatus()
         pdfPanePDFView.enclosingScrollView?.documentCursor = .crosshair
 
+        anchorPickPreviousAcceptsMouseMovedEvents = view.window?.acceptsMouseMovedEvents
+        view.window?.acceptsMouseMovedEvents = true
+        anchorPickCursorMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            self?.enforceAnchorPickCursor(for: event)
+            return event
+        }
         anchorPickMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
             self?.handleAnchorPickMouseDown(event) ?? event
         }
@@ -207,6 +215,32 @@ final class PDFReaderPaneController: NSViewController {
         }
 
         navigate(toPageNumber: pageNumber)
+    }
+
+    func removeHighlightAnnotations(ids: [String]) {
+        guard !ids.isEmpty,
+              let document = pdfPanePDFView.document else {
+            return
+        }
+
+        let tags = Set(ids.map { id in
+            let normalizedId = UUID(uuidString: id)?.uuidString ?? id
+            return "\(PDFHighlightAnnotationStyle.contentsPrefix)\(normalizedId)"
+        })
+        var didRemove = false
+
+        for index in 0..<document.pageCount {
+            guard let page = document.page(at: index) else { continue }
+            let annotations = page.annotations
+            for annotation in annotations where annotation.contents.map(tags.contains) == true {
+                page.removeAnnotation(annotation)
+                didRemove = true
+            }
+        }
+
+        if didRemove {
+            pdfPanePDFView.needsDisplay = true
+        }
     }
 
     @discardableResult
@@ -772,6 +806,13 @@ final class PDFReaderPaneController: NSViewController {
         ))
     }
 
+    private func enforceAnchorPickCursor(for event: NSEvent) {
+        guard isAnchorPickMode else { return }
+        let pointInPDFView = pdfPanePDFView.convert(event.locationInWindow, from: nil)
+        guard pdfPanePDFView.bounds.contains(pointInPDFView) else { return }
+        NSCursor.crosshair.set()
+    }
+
     private func markerBounds(centeredAt point: CGPoint, on page: PDFPage) -> CGRect {
         let size = PDFHighlightAnnotationStyle.markerSize
         let pageBounds = page.bounds(for: .mediaBox)
@@ -783,9 +824,19 @@ final class PDFReaderPaneController: NSViewController {
     }
 
     private func exitAnchorPickMode(notifyCancelled: Bool) {
-        guard isAnchorPickMode || anchorPickMouseMonitor != nil || anchorPickKeyMonitor != nil else { return }
+        guard isAnchorPickMode ||
+            anchorPickMouseMonitor != nil ||
+            anchorPickKeyMonitor != nil ||
+            anchorPickCursorMonitor != nil ||
+            anchorPickPreviousAcceptsMouseMovedEvents != nil else {
+            return
+        }
         let streamId = activePDFContext?.streamId
 
+        if let anchorPickCursorMonitor {
+            NSEvent.removeMonitor(anchorPickCursorMonitor)
+            self.anchorPickCursorMonitor = nil
+        }
         if let anchorPickMouseMonitor {
             NSEvent.removeMonitor(anchorPickMouseMonitor)
             self.anchorPickMouseMonitor = nil
@@ -795,6 +846,10 @@ final class PDFReaderPaneController: NSViewController {
             self.anchorPickKeyMonitor = nil
         }
 
+        if let previousAcceptsMouseMovedEvents = anchorPickPreviousAcceptsMouseMovedEvents {
+            view.window?.acceptsMouseMovedEvents = previousAcceptsMouseMovedEvents
+            anchorPickPreviousAcceptsMouseMovedEvents = nil
+        }
         isAnchorPickMode = false
         pdfPanePDFView.enclosingScrollView?.documentCursor = nil
         if let context = activePDFContext {

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -716,7 +716,22 @@ final class PDFReaderPaneController: NSViewController {
     }
 
     private func navigate(to rect: CGRect, on page: PDFPage) {
-        let destination = PDFDestination(page: page, at: CGPoint(x: rect.minX, y: rect.maxY))
+        let visibleHeight = pdfPanePDFView.convert(pdfPanePDFView.bounds, to: page).height
+        let pageBounds = page.bounds(for: .mediaBox)
+        let destinationY: CGFloat
+
+        if visibleHeight.isFinite,
+           visibleHeight > 0,
+           pageBounds.minY.isFinite,
+           pageBounds.maxY.isFinite,
+           pageBounds.minY < pageBounds.maxY {
+            let centeredY = rect.midY + visibleHeight / 2
+            destinationY = min(max(centeredY, pageBounds.minY), pageBounds.maxY)
+        } else {
+            destinationY = rect.maxY
+        }
+
+        let destination = PDFDestination(page: page, at: CGPoint(x: rect.minX, y: destinationY))
         pdfPanePDFView.go(to: destination)
     }
 
@@ -729,7 +744,8 @@ final class PDFReaderPaneController: NSViewController {
         let clampedPage = max(1, min(pageNumber ?? 1, document.pageCount))
         guard let page = document.page(at: clampedPage - 1) else { return }
         let bounds = page.bounds(for: .mediaBox)
-        navigate(to: bounds, on: page)
+        let destination = PDFDestination(page: page, at: CGPoint(x: bounds.minX, y: bounds.maxY))
+        pdfPanePDFView.go(to: destination)
     }
 
     private func pulseAnnotations(_ annotations: [PDFAnnotation]) {

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -559,6 +559,14 @@ extension WebViewManager: StreamMessageHandlerDelegate {
             sendPDFPaneStateChanged(visible: false)
         }
     }
+
+    func removePDFHighlightAnnotations(ids: [String], sourceIds: [UUID]) async {
+        guard !ids.isEmpty else { return }
+        await MainActor.run {
+            guard sourceIds.contains(where: { pdfPaneController.isPresenting(sourceId: $0) }) else { return }
+            pdfPaneController.removeHighlightAnnotations(ids: ids)
+        }
+    }
 }
 
 extension WebViewManager: SourceMessageHandlerDelegate {

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -887,6 +887,46 @@ final class PersistenceService {
         }
     }
 
+    @discardableResult
+    func deletePDFHighlights(sourceIds: [UUID], excludingIds: [String]) throws -> [String] {
+        var seenSourceIds = Set<UUID>()
+        let scopedSourceIds = sourceIds.filter { seenSourceIds.insert($0).inserted }
+        guard !scopedSourceIds.isEmpty else { return [] }
+
+        let normalizedExcludingIds = Set(excludingIds.compactMap { UUID(uuidString: $0)?.uuidString })
+
+        return try dbQueue.write { db in
+            var deletedIds: [String] = []
+
+            for sourceId in scopedSourceIds {
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT id
+                        FROM pdf_highlights
+                        WHERE source_id = ?
+                        ORDER BY created_at ASC
+                    """,
+                    arguments: [sourceId.uuidString]
+                )
+
+                for row in rows {
+                    let id: String = row["id"]
+                    let normalizedId = UUID(uuidString: id)?.uuidString ?? id
+                    guard !normalizedExcludingIds.contains(normalizedId) else { continue }
+
+                    try db.execute(
+                        sql: "DELETE FROM pdf_highlights WHERE source_id = ? AND id = ?",
+                        arguments: [sourceId.uuidString, id]
+                    )
+                    deletedIds.append(normalizedId)
+                }
+            }
+
+            return deletedIds
+        }
+    }
+
     private func decodePDFHighlight(_ row: Row) throws -> PDFHighlightRecord {
         let rectsJSON: String = row["rects_json"]
         guard let rectsData = rectsJSON.data(using: .utf8) else {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -186,6 +186,90 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_deletePDFHighlightsKeepsReferencedRowsAndDeletesUnreferencedRows() throws {
+        try withTempPersistenceService { service in
+            let source = try savePDFSource(in: service)
+            let referenced = PDFHighlightRecord(
+                id: UUID(),
+                sourceId: source.id,
+                page: 2,
+                rects: [PDFHighlightRect(page: 2, x: 10, y: 20, w: 30, h: 12)],
+                quote: "Keep this",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+            let unreferenced = PDFHighlightRecord(
+                id: UUID(),
+                sourceId: source.id,
+                page: 4,
+                rects: [PDFHighlightRect(page: 4, x: 42, y: 84, w: 14, h: 14)],
+                quote: "",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_100)
+            )
+
+            try service.savePDFHighlight(referenced)
+            try service.savePDFHighlight(unreferenced)
+
+            let deletedIds = try service.deletePDFHighlights(
+                sourceIds: [source.id],
+                excludingIds: [referenced.id.uuidString.lowercased()]
+            )
+
+            XCTAssertEqual(deletedIds, [unreferenced.id.uuidString])
+            XCTAssertEqual(try service.loadPDFHighlights(sourceId: source.id), [referenced])
+        }
+    }
+
+    func test_deletePDFHighlightsIsScopedToSavedStreamSources() throws {
+        try withTempPersistenceService { service in
+            let source = try savePDFSource(in: service)
+            let otherStreamSource = try savePDFSource(in: service)
+            let sourceHighlight = PDFHighlightRecord(
+                id: UUID(),
+                sourceId: source.id,
+                page: 1,
+                rects: [PDFHighlightRect(page: 1, x: 1, y: 2, w: 3, h: 4)],
+                quote: "Remove only this stream",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+            let otherStreamHighlight = PDFHighlightRecord(
+                id: UUID(),
+                sourceId: otherStreamSource.id,
+                page: 1,
+                rects: [PDFHighlightRect(page: 1, x: 5, y: 6, w: 7, h: 8)],
+                quote: "Must survive",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_100)
+            )
+
+            try service.savePDFHighlight(sourceHighlight)
+            try service.savePDFHighlight(otherStreamHighlight)
+
+            let deletedIds = try service.deletePDFHighlights(sourceIds: [source.id], excludingIds: [])
+
+            XCTAssertEqual(deletedIds, [sourceHighlight.id.uuidString])
+            XCTAssertEqual(try service.loadPDFHighlights(sourceId: source.id), [])
+            XCTAssertEqual(try service.loadPDFHighlights(sourceId: otherStreamSource.id), [otherStreamHighlight])
+        }
+    }
+
+    func test_pdfHighlightLinkReferenceExtractorFindsValidTickerPDFHighlightIds() throws {
+        let sourceId = UUID()
+        let firstHighlightId = UUID()
+        let secondHighlightId = UUID()
+        let markdown = """
+        Intro [quoted text](ticker-pdf://\(sourceId.uuidString)?highlight=\(firstHighlightId.uuidString)&page=4)
+
+        Another saved link: <ticker-pdf://\(sourceId.uuidString)?page=7&HIGHLIGHT=\(secondHighlightId.uuidString.lowercased())>
+
+        Ignore malformed links:
+        [bad](ticker-pdf://\(sourceId.uuidString)?highlight=76C2D82A-not-a-uuid&page=3)
+        [external](https://example.com?highlight=\(UUID().uuidString))
+        """
+
+        let ids = PDFHighlightLinkReferenceExtractor.highlightIds(in: markdown)
+
+        XCTAssertEqual(ids, Set([firstHighlightId.uuidString, secondHighlightId.uuidString]))
+    }
+
     func test_appendToStreamDocument_createsDocumentWithExactlyFragmentWhenMissing() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "New Document")


### PR DESCRIPTION
Three user-reported refinements to PDF linking:

- **Pick-mode crosshair actually shows.** PDFView overrides `documentCursor`, so the crosshair set in pick mode never appeared. A `.mouseMoved` local monitor now enforces `NSCursor.crosshair` while the pointer is over the PDF during pick mode (torn down with the other pick-mode monitors; `acceptsMouseMovedEvents` restored).
- **Breaking a link removes its PDF marker.** After each successful revision-checked editor save, highlight IDs referenced in the markdown (parsed via URLComponents) are diffed against stored `pdf_highlights` for that stream's sources; unreferenced rows are deleted and their annotations removed live from the open pane. Covers both quote highlights and point anchors. Accepted edge (ponytail-commented): undo after GC restores link text only — it falls back to page navigation.
- **Follow-link centers the target.** Navigation destinations are offset by half the visible height in page coordinates and clamped to the media box, so highlights land mid-viewport instead of at the top edge.

Swift tests cover GC delete/keep, per-stream scoping, and markdown ID extraction. All gates green (build, swift-test, web typecheck/test/build, contract checker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)