### PR TITLE
Field fixes: capture ladder, Sequoia AX fallback, resize, toolbar clamp, diagnostics, debug identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
             -derivedDataPath .build/ci-xcode \
             CODE_SIGNING_ALLOWED=NO \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
-            PRODUCT_BUNDLE_IDENTIFIER=io.ticker.next \
-            INFOPLIST_KEY_CFBundleDisplayName="Ticker Next" \
             -quiet
 
       - name: Swift tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Quick Panel external text capture now falls back through app AX hinting and clipboard-safe Copy for Chromium/Electron selections.
 - Formatting toggles now keep selection-edge whitespace outside inline markdown markers, including multi-line selections.
 - Stream editor markdown decorations now settle on the initial viewport faster and image widgets report stable heights while scrolling.
 - Stream editor find now uses a compact input/count/arrows panel instead of the stock search UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Debug builds now use a distinct bundle id and display name so they do not share the release app's macOS permission identity.
 - Bug report support bundles now include recent metadata logs, crash evidence, uptime, and prior-crash detection.
 - Selection action menus now re-clamp after measuring so they stay inside the editor shell.
 - PDF pane dividers can now resize both directions from the opening split.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Quick panel now detects a stale Accessibility grant (permission shown as on but revoked by macOS) and says exactly how to fix it.
 - Sources can now be marked Private so their contents stay out of AI context while remaining locally searchable and readable.
 - Stream editor headers now keep long titles to one calm ellipsized line without crowding actions or document content.
 - Document AI citation links can now carry exact evidence quotes so PDF flashes target the quoted support instead of a chunk lead sentence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- PDF pane dividers can now resize both directions from the opening split.
 - Quick Panel external text capture now falls back through app AX hinting and clipboard-safe Copy for Chromium/Electron selections.
 - Formatting toggles now keep selection-edge whitespace outside inline markdown markers, including multi-line selections.
 - Stream editor markdown decorations now settle on the initial viewport faster and image widgets report stable heights while scrolling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Bug report support bundles now include recent metadata logs, crash evidence, uptime, and prior-crash detection.
 - Selection action menus now re-clamp after measuring so they stay inside the editor shell.
 - PDF pane dividers can now resize both directions from the opening split.
 - Quick Panel external text capture now falls back through app AX hinting and clipboard-safe Copy for Chromium/Electron selections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Selection action menus now re-clamp after measuring so they stay inside the editor shell.
 - PDF pane dividers can now resize both directions from the opening split.
 - Quick Panel external text capture now falls back through app AX hinting and clipboard-safe Copy for Chromium/Electron selections.
 - Formatting toggles now keep selection-edge whitespace outside inline markdown markers, including multi-line selections.

--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -44,6 +44,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     )
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        CrashSessionSentinel.markLaunch()
         setupStatusItem()
         setupMenuBar()
         setupAppearanceObserver()
@@ -170,6 +171,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        CrashSessionSentinel.markCleanTermination()
         if let pdfFindKeyMonitor {
             NSEvent.removeMonitor(pdfFindKeyMonitor)
             self.pdfFindKeyMonitor = nil

--- a/Sources/Ticker/App/Onboarding/OnboardingView.swift
+++ b/Sources/Ticker/App/Onboarding/OnboardingView.swift
@@ -2,6 +2,20 @@ import SwiftUI
 import AppKit
 import ApplicationServices
 
+enum SystemSettingsPrivacyPane: String {
+    case accessibility = "Privacy_Accessibility"
+}
+
+enum SystemSettingsOpener {
+    /// Open System Settings directly to avoid cross-talk/ordering issues between permission prompts.
+    static func openPrivacyPane(_ pane: SystemSettingsPrivacyPane) -> Bool {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane.rawValue)") else {
+            return false
+        }
+        return NSWorkspace.shared.open(url)
+    }
+}
+
 /// Onboarding view shown on first launch
 struct OnboardingView: View {
     @State private var step: OnboardingStep = .welcome
@@ -216,21 +230,8 @@ struct OnboardingView: View {
         hasAccessibility = AXIsProcessTrusted()
     }
 
-    private enum SystemSettingsPrivacyPane: String {
-        case accessibility = "Privacy_Accessibility"
-    }
-
-    /// Open System Settings directly to avoid cross-talk/ordering issues between permission prompts.
-    /// Falls back to the OS prompt-based APIs if deep-linking fails for any reason.
-    private func openSystemSettingsPrivacyPane(_ pane: SystemSettingsPrivacyPane) -> Bool {
-        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(pane.rawValue)") else {
-            return false
-        }
-        return NSWorkspace.shared.open(url)
-    }
-
     private func grantAccessibilityAccess() {
-        if !openSystemSettingsPrivacyPane(.accessibility) {
+        if !SystemSettingsOpener.openPrivacyPane(.accessibility) {
             requestAccessibility()
         } else {
             // Poll so the UI updates when the user toggles the permission.

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -162,6 +162,36 @@ struct PDFPaneOpeningLayout: Equatable {
     }
 }
 
+enum PDFPaneWidthPolicy {
+    static let minimumPDFPaneWidth: CGFloat = 320
+    static let minimumEditorPaneWidth: CGFloat = 400
+
+    static func maxAllowedPDFPaneWidth(
+        hostWidth: CGFloat,
+        minimumPDFPaneWidth: CGFloat = Self.minimumPDFPaneWidth,
+        minimumEditorPaneWidth: CGFloat = Self.minimumEditorPaneWidth
+    ) -> CGFloat {
+        let boundedHostWidth = max(0, hostWidth)
+        let editorPreservingCap = max(0, boundedHostWidth - minimumEditorPaneWidth)
+        return min(boundedHostWidth, max(minimumPDFPaneWidth, editorPreservingCap))
+    }
+
+    static func clampPDFPaneWidth(
+        _ proposed: CGFloat,
+        hostWidth: CGFloat,
+        minimumPDFPaneWidth: CGFloat = Self.minimumPDFPaneWidth,
+        minimumEditorPaneWidth: CGFloat = Self.minimumEditorPaneWidth
+    ) -> CGFloat {
+        let maxValue = maxAllowedPDFPaneWidth(
+            hostWidth: hostWidth,
+            minimumPDFPaneWidth: minimumPDFPaneWidth,
+            minimumEditorPaneWidth: minimumEditorPaneWidth
+        )
+        let minValue = min(minimumPDFPaneWidth, maxValue)
+        return min(max(proposed, minValue), maxValue)
+    }
+}
+
 enum PDFPaneWindowRestore {
     static func targetFrame(savedFrame: CGRect?, isNativeFullscreen: Bool) -> CGRect? {
         isNativeFullscreen ? nil : savedFrame
@@ -378,8 +408,8 @@ final class PDFReaderPaneController: NSViewController {
     private var pdfPaneStatusHintLeadingConstraint: NSLayoutConstraint?
     private var isPDFPaneVisible = false
     private let preferredPDFPaneWidth: CGFloat = 520
-    private let minimumPDFPaneWidth: CGFloat = 320
-    private let minimumEditorPaneWidth: CGFloat = 440
+    private let minimumPDFPaneWidth = PDFPaneWidthPolicy.minimumPDFPaneWidth
+    private let minimumEditorPaneWidth = PDFPaneWidthPolicy.minimumEditorPaneWidth
     private var pdfPaneResizeStartWidth: CGFloat = 0
     private var prePDFPaneWindowFrame: CGRect?
     private var activePDFContext: (streamId: UUID, sourceId: UUID, sourceName: String, fileURL: URL)?
@@ -1159,21 +1189,22 @@ final class PDFReaderPaneController: NSViewController {
     }
 
     private func maxAllowedPDFPaneWidth() -> CGFloat {
-        let screenWidth = view.window?.screen?.visibleFrame.width
-            ?? NSScreen.main?.visibleFrame.width
-            ?? preferredPDFPaneWidth
-        let screenCap = floor(screenWidth * 0.5)
         let hostWidth = view.superview?.bounds.width ?? view.bounds.width
-        let localCap = max(0, hostWidth - minimumEditorPaneWidth)
-        return max(minimumPDFPaneWidth, min(screenCap, localCap))
+        return PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(
+            hostWidth: hostWidth,
+            minimumPDFPaneWidth: minimumPDFPaneWidth,
+            minimumEditorPaneWidth: minimumEditorPaneWidth
+        )
     }
 
     private func clampPDFPaneWidth(_ proposed: CGFloat) -> CGFloat {
-        let hardMax = maxAllowedPDFPaneWidth()
         let hostWidth = view.superview?.bounds.width ?? view.bounds.width
-        let hostCap = max(0, hostWidth - minimumEditorPaneWidth)
-        let maxValue = max(minimumPDFPaneWidth, min(hardMax, hostCap))
-        return max(minimumPDFPaneWidth, min(proposed, maxValue))
+        return PDFPaneWidthPolicy.clampPDFPaneWidth(
+            proposed,
+            hostWidth: hostWidth,
+            minimumPDFPaneWidth: minimumPDFPaneWidth,
+            minimumEditorPaneWidth: minimumEditorPaneWidth
+        )
     }
 
     private func makePDFPaneHeader(_ raw: String) -> String {

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -54,6 +54,51 @@ struct QuickPanelLocalSelectionProvider {
     }
 }
 
+enum QuickPanelStatusAction: Equatable {
+    case openAccessibilitySettings
+}
+
+struct QuickPanelStatus: Equatable {
+    enum Tone: Equatable {
+        case info
+        case success
+        case warning
+    }
+
+    let message: String
+    let tone: Tone
+    let action: QuickPanelStatusAction?
+
+    static func selectionCaptureStatus(
+        for outcome: SelectionCaptureOutcome,
+        activeApp: String?
+    ) -> QuickPanelStatus? {
+        switch outcome {
+        case .noPermission:
+            return QuickPanelStatus(
+                message: "Grant Accessibility permission to capture text selections",
+                tone: .warning,
+                action: .openAccessibilitySettings
+            )
+        case .emptyExternal:
+            let appName = activeApp?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message: String
+            if let appName, !appName.isEmpty {
+                message = "No text selected in \(appName)"
+            } else {
+                message = "No text selected"
+            }
+            return QuickPanelStatus(
+                message: message,
+                tone: .info,
+                action: nil
+            )
+        case .notAttempted, .internalApp, .ax, .axHinted, .clipboard:
+            return nil
+        }
+    }
+}
+
 /// Manages the Quick Panel lifecycle, positioning, and state
 /// Coordinates between services (cursor, selection) and the panel window
 @MainActor
@@ -66,7 +111,7 @@ final class QuickPanelManager: ObservableObject {
     @Published var inputText: String = ""
     @Published var isLoading: Bool = false
     @Published var error: String?
-    @Published var statusMessage: String?  // Temporary feedback (success/info messages)
+    @Published var status: QuickPanelStatus?  // Temporary feedback and capture status.
     @Published private(set) var isInputSaveFeedbackActive: Bool = false
     @Published private(set) var isStreamPickerSaveFeedbackActive: Bool = false
     @Published var ephemeralConversation = EphemeralConversation()
@@ -191,19 +236,20 @@ final class QuickPanelManager: ObservableObject {
     private func buildContextForQuickPanelToggle() async -> QuickPanelContext {
         let activeBundleId = selectionService.getActiveAppBundleId()
         let appBundleId = Bundle.main.bundleIdentifier
-        let selectedText = await SelectionReaderService.resolveSelectedText(
+        let selectionResult = await SelectionReaderService.resolveSelectedTextWithOutcome(
             activeBundleId: activeBundleId,
             currentBundleId: appBundleId,
             localSelection: { [localSelectionProvider] in
                 await localSelectionProvider.selectedText()
             },
-            axSelection: { [selectionService] in
-                selectionService.getSelectedText()
+            externalSelection: { [selectionService] in
+                selectionService.captureSelectedText()
             }
         )
 
         return selectionService.buildContext(
-            selectedText: selectedText,
+            selectedText: selectionResult.text,
+            selectionCaptureOutcome: selectionResult.outcome,
             readSelectionFromAX: false,
             panelSize: currentPanelSizeForPositioning()
         )
@@ -224,7 +270,8 @@ final class QuickPanelManager: ObservableObject {
                 windowTitle: capturedContext.windowTitle,
                 panelPosition: capturedContext.panelPosition,
                 clipboardImage: imageData,
-                isScreenshot: true
+                isScreenshot: true,
+                selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
             )
             // New explicit screenshot capture should always attach, even if a prior clipboard image
             // was manually dismissed from context.
@@ -249,7 +296,8 @@ final class QuickPanelManager: ObservableObject {
             windowTitle: capturedContext.windowTitle,
             panelPosition: capturedContext.panelPosition,
             clipboardImage: nil,
-            isScreenshot: false
+            isScreenshot: false,
+            selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
         )
 
         show(with: contextWithoutClipboard, showAccessibilityWarning: false)
@@ -266,10 +314,11 @@ final class QuickPanelManager: ObservableObject {
         // Load available streams for picker
         loadAvailableStreams()
 
-        // If Accessibility isn't granted, just show a soft warning (don't prompt).
-        // Onboarding is responsible for prompting; repeated system prompts here are jarring.
-        if showAccessibilityWarning && !cursorService.hasAccessibilityPermission && !capturedContext.hasSelection {
-            statusMessage = "Grant Accessibility permission to capture text selections"
+        if showAccessibilityWarning && !capturedContext.hasSelection {
+            status = QuickPanelStatus.selectionCaptureStatus(
+                for: capturedContext.selectionCaptureOutcome,
+                activeApp: capturedContext.activeApp
+            )
         }
 
         // Create panel if needed
@@ -316,7 +365,7 @@ final class QuickPanelManager: ObservableObject {
             guard let self, generation == self.presentationGeneration else { return }
             self.resetState()
             self.context = nil
-            self.statusMessage = nil
+            self.status = nil
         }
 
         guard let panel, panel.isVisible else {
@@ -341,7 +390,7 @@ final class QuickPanelManager: ObservableObject {
         inputText = ""
         isLoading = false
         error = nil
-        statusMessage = nil
+        status = nil
         isInputSaveFeedbackActive = false
         isStreamPickerSaveFeedbackActive = false
     }
@@ -357,14 +406,15 @@ final class QuickPanelManager: ObservableObject {
         statusClearTask?.cancel()
         isInputSaveFeedbackActive = false
         isStreamPickerSaveFeedbackActive = false
-        statusMessage = message
+        let timedStatus = QuickPanelStatus(message: message, tone: .info, action: nil)
+        status = timedStatus
 
         statusClearTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: durationNanoseconds)
             guard !Task.isCancelled else { return }
             await MainActor.run {
-                guard let self, self.statusMessage == message else { return }
-                self.statusMessage = nil
+                guard let self, self.status == timedStatus else { return }
+                self.status = nil
                 self.statusClearTask = nil
             }
         }
@@ -376,7 +426,7 @@ final class QuickPanelManager: ObservableObject {
         saveFeedbackTask?.cancel()
         isInputSaveFeedbackActive = true
         isStreamPickerSaveFeedbackActive = true
-        statusMessage = nil
+        status = nil
 
         saveFeedbackTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 600_000_000)
@@ -393,7 +443,7 @@ final class QuickPanelManager: ObservableObject {
         statusClearTask = nil
         isInputSaveFeedbackActive = false
         isStreamPickerSaveFeedbackActive = true
-        statusMessage = nil
+        status = nil
 
         statusClearTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: durationNanoseconds)
@@ -548,6 +598,15 @@ final class QuickPanelManager: ObservableObject {
         context = nil
     }
 
+    func performStatusAction(_ action: QuickPanelStatusAction) {
+        switch action {
+        case .openAccessibilitySettings:
+            if !SystemSettingsOpener.openPrivacyPane(.accessibility) {
+                cursorService.requestAccessibilityPermission()
+            }
+        }
+    }
+
     func clearEphemeralConversation() {
         cancelStreaming()
         ephemeralConversation.clear()
@@ -579,7 +638,8 @@ final class QuickPanelManager: ObservableObject {
             windowTitle: capturedContext.windowTitle,
             panelPosition: capturedContext.panelPosition,
             clipboardImage: nil,
-            isScreenshot: false
+            isScreenshot: false,
+            selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
         )
     }
 

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -80,6 +80,12 @@ struct QuickPanelStatus: Equatable {
                 tone: .warning,
                 action: .openAccessibilitySettings
             )
+        case .stalePermission:
+            return QuickPanelStatus(
+                message: "Accessibility permission is stale — remove Ticker from the list and re-add it",
+                tone: .warning,
+                action: .openAccessibilitySettings
+            )
         case .emptyExternal:
             let appName = activeApp?.trimmingCharacters(in: .whitespacesAndNewlines)
             let message: String

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -98,7 +98,7 @@ struct QuickPanelView: View {
             }
 
             // Status message (info/success feedback)
-            if let status = manager.statusMessage {
+            if let status = manager.status {
                 statusView(status)
             }
 
@@ -626,20 +626,56 @@ struct QuickPanelView: View {
 
     // MARK: - Status View
 
-    private func statusView(_ status: String) -> some View {
-        let isWarning = status.contains("permission") || status.contains("Permission")
-        let icon = isWarning ? "info.circle" : "checkmark.circle"
-        let color = isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.success
+    private func statusView(_ status: QuickPanelStatus) -> some View {
+        let icon: String
+        let color: Color
+        let textColor: Color
+
+        switch status.tone {
+        case .warning:
+            icon = "info.circle"
+            color = QuickPanelStyle.textMuted
+            textColor = QuickPanelStyle.textMuted
+        case .info:
+            icon = "info.circle"
+            color = QuickPanelStyle.textMuted
+            textColor = QuickPanelStyle.text
+        case .success:
+            icon = "checkmark.circle"
+            color = QuickPanelStyle.success
+            textColor = QuickPanelStyle.text
+        }
 
         return HStack(spacing: Spacing.xs) {
             Image(systemName: icon)
                 .font(QuickPanelStyle.font(size: QuickPanelStyle.iconSize))
                 .foregroundColor(color)
 
-            Text(status)
+            Text(status.message)
                 .font(QuickPanelStyle.font(size: QuickPanelStyle.captionSize))
-                .foregroundColor(isWarning ? QuickPanelStyle.textMuted : QuickPanelStyle.text)
+                .foregroundColor(textColor)
                 .lineLimit(2)
+
+            Spacer(minLength: Spacing.xs)
+
+            if let action = status.action {
+                Button(action: { manager.performStatusAction(action) }) {
+                    HStack(spacing: QuickPanelStyle.badgeVerticalPadding) {
+                        Image(systemName: "gearshape")
+                            .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .semibold))
+                        Text("Open Settings")
+                            .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
+                    }
+                    .foregroundColor(QuickPanelStyle.accent)
+                    .padding(.horizontal, Spacing.xs)
+                    .padding(.vertical, QuickPanelStyle.badgeVerticalPadding)
+                    .background(QuickPanelStyle.surfaceRaised)
+                    .cornerRadius(QuickPanelStyle.radius)
+                }
+                .buttonStyle(.plain)
+                .help("Open Accessibility settings")
+                .accessibilityLabel("Open Accessibility settings")
+            }
         }
         .padding(Spacing.sm)
         .background(color.opacity(0.1))

--- a/Sources/Ticker/Info.plist
+++ b/Sources/Ticker/Info.plist
@@ -10,6 +10,8 @@
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Ticker/Services/DebugLog.swift
+++ b/Sources/Ticker/Services/DebugLog.swift
@@ -1,23 +1,152 @@
 import Foundation
 
-/// Debug-only logging helper.
+final class LogRing {
+    private let capacity: Int
+    private let lock = NSLock()
+    private var lines: [String] = []
+    private let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    init(capacity: Int) {
+        self.capacity = max(0, capacity)
+    }
+
+    func append(_ message: String, date: Date = Date()) {
+        guard capacity > 0 else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        let line = "\(formatter.string(from: date)) \(message)"
+        lines.append(line)
+        if lines.count > capacity {
+            lines.removeFirst(lines.count - capacity)
+        }
+    }
+
+    func snapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return lines
+    }
+
+    func joined(maxBytes: Int) -> String {
+        let joined = snapshot().joined(separator: "\n")
+        let bytes = Data(joined.utf8)
+        guard maxBytes > 0, bytes.count > maxBytes else {
+            return joined
+        }
+        return String(decoding: bytes.suffix(maxBytes), as: UTF8.self)
+    }
+}
+
+enum CrashSessionSentinel {
+    struct LaunchResult: Equatable {
+        let lastSessionCrashed: Bool
+        let markerWriteSucceeded: Bool
+    }
+
+    private static let lock = NSLock()
+    private static var storedLastSessionCrashed = false
+
+    static var lastSessionCrashed: Bool {
+        lock.lock()
+        let value = storedLastSessionCrashed
+        lock.unlock()
+        return value
+    }
+
+    static func evaluateLaunch(markerExisted: Bool, markerWriteSucceeded: Bool) -> LaunchResult {
+        LaunchResult(
+            lastSessionCrashed: markerExisted,
+            markerWriteSucceeded: markerWriteSucceeded
+        )
+    }
+
+    static func defaultMarkerURL(fileManager: FileManager = .default) -> URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        return appSupport
+            .appendingPathComponent("Ticker-Next", isDirectory: true)
+            .appendingPathComponent("session.lock")
+    }
+
+    @discardableResult
+    static func markLaunch(markerURL: URL = defaultMarkerURL(), fileManager: FileManager = .default) -> LaunchResult {
+        let markerExisted = fileManager.fileExists(atPath: markerURL.path)
+        var markerWriteSucceeded = false
+
+        do {
+            let markerDirectory = markerURL.deletingLastPathComponent()
+            try fileManager.createDirectory(
+                at: markerDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: markerDirectory.path)
+            let payload = "pid=\(ProcessInfo.processInfo.processIdentifier) started_at=\(ISO8601DateFormatter().string(from: Date()))"
+            try payload.write(to: markerURL, atomically: true, encoding: .utf8)
+            markerWriteSucceeded = true
+        } catch {
+            markerWriteSucceeded = false
+        }
+
+        let result = evaluateLaunch(
+            markerExisted: markerExisted,
+            markerWriteSucceeded: markerWriteSucceeded
+        )
+        setLastSessionCrashed(result.lastSessionCrashed)
+
+        if result.lastSessionCrashed {
+            DebugLog.log("[Ticker] Previous session marker found lastSessionCrashed=true")
+        }
+
+        return result
+    }
+
+    static func markCleanTermination(markerURL: URL = defaultMarkerURL(), fileManager: FileManager = .default) {
+        try? fileManager.removeItem(at: markerURL)
+        setLastSessionCrashed(false)
+    }
+
+    static func setLastSessionCrashedForTesting(_ crashed: Bool) {
+        setLastSessionCrashed(crashed)
+    }
+
+    private static func setLastSessionCrashed(_ crashed: Bool) {
+        lock.lock()
+        storedLastSessionCrashed = crashed
+        lock.unlock()
+    }
+}
+
+/// Metadata-only diagnostics helper.
 ///
 /// Policy:
-/// - Do not log user content/prompts in Release builds.
-/// - Prefer user-visible errors (toasts/alerts) + support bundle, not console logs.
+/// - Log metadata only: counts, ids, flags, states, error domains/codes, and timings.
+/// - Never log document text, selected text, prompts, device keys, screenshots, or file contents.
+/// - Prefer user-visible errors (toasts/alerts) plus support bundles, not console logs.
 enum DebugLog {
+    private static let ring = LogRing(capacity: 300)
+
     static func log(_ message: @autoclosure () -> String) {
+        let rendered = message()
+        ring.append(rendered)
 #if DEBUG
-        print(message())
+        print(rendered)
 #endif
     }
 
     static func errorSummary(_ error: Error) -> String {
-#if DEBUG
         let nsError = error as NSError
         return "\(type(of: error)) domain=\(nsError.domain) code=\(nsError.code)"
-#else
-        return ""
-#endif
+    }
+
+    static func recentLines(maxBytes: Int = 16 * 1024) -> String {
+        ring.joined(maxBytes: maxBytes)
     }
 }

--- a/Sources/Ticker/Services/DeviceKeyService.swift
+++ b/Sources/Ticker/Services/DeviceKeyService.swift
@@ -188,6 +188,74 @@ struct RequestIdEntry {
     let endpoint: String  // "llm", "feedback", "auth", etc.
 }
 
+enum SupportDiagnostics {
+    static let recentLogsMaxBytes = 16 * 1024
+    static let recentCrashMaxBytes = 32 * 1024
+    static let recentCrashMaxAge: TimeInterval = 7 * 24 * 60 * 60
+
+    static func defaultDiagnosticReportsDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+    }
+
+    static func newestTickerCrashReport(
+        in directoryURL: URL,
+        now: Date = Date(),
+        fileManager: FileManager = .default,
+        maxAge: TimeInterval = recentCrashMaxAge,
+        maxBytes: Int = recentCrashMaxBytes
+    ) -> String? {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        let cutoff = now.addingTimeInterval(-maxAge)
+        let newestCrash = entries.compactMap { url -> (url: URL, modifiedAt: Date)? in
+            guard url.lastPathComponent.hasPrefix("TickerNext-"),
+                  url.pathExtension == "ips" else {
+                return nil
+            }
+
+            let resourceValues = try? url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey])
+            if resourceValues?.isRegularFile == false {
+                return nil
+            }
+
+            guard let modifiedAt = resourceValues?.contentModificationDate,
+                  modifiedAt >= cutoff else {
+                return nil
+            }
+
+            return (url, modifiedAt)
+        }
+        .max { lhs, rhs in
+            lhs.modifiedAt < rhs.modifiedAt
+        }
+
+        guard let newestCrash else {
+            return nil
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: newestCrash.url) else {
+            return nil
+        }
+        defer {
+            try? handle.close()
+        }
+
+        guard let data = try? handle.read(upToCount: maxBytes),
+              !data.isEmpty else {
+            return nil
+        }
+
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
 // MARK: - Feedback Response Types
 
 /// Response from proxy `/v1/feedback` endpoint
@@ -231,6 +299,11 @@ actor DeviceKeyService {
 
     private let fileManager: FileManager
     private let fileURL: URL
+    private let diagnosticReportsDirectoryURL: URL
+    private let launchDate: Date
+    private let nowProvider: @Sendable () -> Date
+    private let recentLogsProvider: @Sendable () -> String
+    private let lastSessionCrashedProvider: @Sendable () -> Bool
 
     private var cachedData: DeviceKeyData?
     private(set) var currentState: ProxyAuthState = .unregistered
@@ -266,9 +339,27 @@ actor DeviceKeyService {
         return "https://ticker-proxy.fly.dev"
     }
 
-    init(fileURL: URL? = nil, fileManager: FileManager = .default) {
+    init(
+        fileURL: URL? = nil,
+        fileManager: FileManager = .default,
+        diagnosticReportsDirectoryURL: URL? = nil,
+        launchDate: Date = Date(),
+        nowProvider: @escaping @Sendable () -> Date = { Date() },
+        recentLogsProvider: @escaping @Sendable () -> String = {
+            DebugLog.recentLines(maxBytes: SupportDiagnostics.recentLogsMaxBytes)
+        },
+        lastSessionCrashedProvider: @escaping @Sendable () -> Bool = {
+            CrashSessionSentinel.lastSessionCrashed
+        }
+    ) {
         self.fileManager = fileManager
         self.fileURL = fileURL ?? Self.defaultFileURL(fileManager: fileManager)
+        self.diagnosticReportsDirectoryURL = diagnosticReportsDirectoryURL
+            ?? SupportDiagnostics.defaultDiagnosticReportsDirectory(fileManager: fileManager)
+        self.launchDate = launchDate
+        self.nowProvider = nowProvider
+        self.recentLogsProvider = recentLogsProvider
+        self.lastSessionCrashedProvider = lastSessionCrashedProvider
     }
 
     private static func defaultFileURL(fileManager: FileManager) -> URL {
@@ -541,9 +632,9 @@ actor DeviceKeyService {
     func getSupportBundle() -> [String: Any] {
         let data = loadOrCreate()
         let formatter = ISO8601DateFormatter()
-
-        return [
-            "generated_at": formatter.string(from: Date()),
+        let now = nowProvider()
+        var bundle: [String: Any] = [
+            "generated_at": formatter.string(from: now),
             "app_version": appVersion(),
             "build_number": Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
             "os_version": osVersion(),
@@ -551,6 +642,9 @@ actor DeviceKeyService {
             "support_id": data.supportId ?? "none",
             "auth_state": currentState.rawValue,
             "diagnostics_enabled": SettingsService.shared.diagnosticsEnabled,
+            "uptime_seconds": max(0, Int(now.timeIntervalSince(launchDate))),
+            "last_session_crashed": lastSessionCrashedProvider(),
+            "recent_logs": recentLogsProvider(),
             "recent_request_ids": recentRequestIds.map { entry in
                 [
                     "request_id": entry.requestId,
@@ -563,6 +657,16 @@ actor DeviceKeyService {
                 "tokens_this_month": cachedUsage?.tokensThisMonth ?? 0
             ]
         ]
+
+        if let recentCrash = SupportDiagnostics.newestTickerCrashReport(
+            in: diagnosticReportsDirectoryURL,
+            now: now,
+            fileManager: fileManager
+        ) {
+            bundle["recent_crash"] = recentCrash
+        }
+
+        return bundle
     }
 
     // MARK: - Feedback Submission (D5)

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -291,12 +291,12 @@ final class ProxyLLMService {
                 }
                 await MainActor.run { onError(ProxyLLMError.timeout(seconds: timeoutSeconds)) }
             } else {
-                debugLog("Proxy stream failed: \(urlError.localizedDescription)")
+                debugLog("Proxy stream failed (\(DebugLog.errorSummary(urlError)))")
                 await MainActor.run { onError(ProxyLLMError.unreachable) }
             }
         } catch {
             headerWatchdog.cancel()
-            debugLog("Proxy stream failed: \(error.localizedDescription)")
+            debugLog("Proxy stream failed (\(DebugLog.errorSummary(error)))")
             await MainActor.run {
                 onError(ProxyLLMError.unreachable)
             }
@@ -391,7 +391,7 @@ final class ProxyLLMService {
             return trimmed
 
         } catch {
-            debugLog("Restatement failed: \(error.localizedDescription)")
+            debugLog("Restatement failed (\(DebugLog.errorSummary(error)))")
             return nil
         }
     }
@@ -527,7 +527,12 @@ final class ProxyLLMService {
                 let details = errorObj["details"] as? [String: Any]
                 let detailsKeys = details.map { $0.keys.sorted().joined(separator: ",") } ?? "nil"
                 let reason = (details?["reason"] as? String) ?? "nil"
-                debugLog("Error event received code=\(code) message=\(message) detailsKeys=\(detailsKeys) reason=\(reason)")
+                debugLog(
+                    "Error event received code=\(code) " +
+                    "messageLength=\(message.count) " +
+                    "detailsKeys=\(detailsKeys) " +
+                    "reasonLength=\(reason == "nil" ? 0 : reason.count)"
+                )
                 let error = mapProxyError(
                     statusCode: 0,
                     code: code,

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -1,6 +1,81 @@
 import AppKit
 import ApplicationServices
 
+enum SelectionCaptureOutcome: Equatable {
+    case notAttempted
+    case internalApp
+    case noPermission
+    case ax
+    case axHinted
+    case clipboard
+    case emptyExternal
+
+    var telemetryRung: String {
+        switch self {
+        case .ax:
+            return "ax"
+        case .axHinted:
+            return "ax-hinted"
+        case .clipboard:
+            return "clipboard"
+        case .notAttempted, .internalApp, .noPermission, .emptyExternal:
+            return "none"
+        }
+    }
+}
+
+struct SelectionCaptureResult: Equatable {
+    let text: String?
+    let outcome: SelectionCaptureOutcome
+}
+
+struct PasteboardSnapshot: Equatable {
+    struct Item: Equatable {
+        struct Entry: Equatable {
+            let type: NSPasteboard.PasteboardType
+            let data: Data
+        }
+
+        let entries: [Entry]
+    }
+
+    let changeCount: Int
+    let items: [Item]
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.changeCount = pasteboard.changeCount
+        self.items = (pasteboard.pasteboardItems ?? []).map { item in
+            Item(entries: item.types.compactMap { type in
+                guard let data = item.data(forType: type) else {
+                    return nil
+                }
+                return Item.Entry(type: type, data: data)
+            })
+        }
+    }
+
+    func restore(to pasteboard: NSPasteboard = .general) {
+        pasteboard.clearContents()
+
+        let restoredItems: [NSPasteboardItem] = items.compactMap { snapshotItem in
+            let pasteboardItem = NSPasteboardItem()
+            var restoredAnyType = false
+
+            for entry in snapshotItem.entries {
+                if pasteboardItem.setData(entry.data, forType: entry.type) {
+                    restoredAnyType = true
+                }
+            }
+
+            return restoredAnyType ? pasteboardItem : nil
+        }
+
+        if !restoredItems.isEmpty {
+            pasteboard.writeObjects(restoredItems)
+        }
+    }
+}
+
 /// Service for reading selected text and active application information
 /// Uses Accessibility APIs when available, with graceful fallbacks
 final class SelectionReaderService {
@@ -8,6 +83,15 @@ final class SelectionReaderService {
     private let cursorService: CursorPositionService
     private let maxSelectionReadAttempts = 2
     private let selectionReadRetryDelay: TimeInterval = 0.02
+    private let hintedSelectionReadAttempts = 6
+    private let hintedSelectionReadRetryDelay: TimeInterval = 0.05
+    private let clipboardPollAttempts = 15
+    private let clipboardPollDelay: TimeInterval = 0.02
+    private var hintedApplicationPIDs = Set<pid_t>()
+
+    private static let axEnhancedUserInterfaceAttribute = "AXEnhancedUserInterface" as CFString
+    private static let axManualAccessibilityAttribute = "AXManualAccessibility" as CFString
+    private static let copyKeyCode = CGKeyCode(8)
 
     init(cursorService: CursorPositionService? = nil) {
         self.cursorService = cursorService ?? CursorPositionService()
@@ -31,6 +115,50 @@ final class SelectionReaderService {
         }
 
         return axSelection()
+    }
+
+    static func resolveSelectedTextWithOutcome(
+        activeBundleId: String?,
+        currentBundleId: String?,
+        localSelection: @MainActor () async -> String?,
+        externalSelection: () -> SelectionCaptureResult
+    ) async -> SelectionCaptureResult {
+        if isCurrentAppBundle(activeBundleId: activeBundleId, currentBundleId: currentBundleId) {
+            return SelectionCaptureResult(
+                text: await localSelection(),
+                outcome: .internalApp
+            )
+        }
+
+        return externalSelection()
+    }
+
+    static func captureExternalSelectedText(
+        hasAccessibilityPermission: Bool,
+        axSelection: () -> String?,
+        hintAccessibilityTree: () -> Void,
+        hintedAXSelection: () -> String?,
+        clipboardSelection: () -> String?
+    ) -> SelectionCaptureResult {
+        guard hasAccessibilityPermission else {
+            return SelectionCaptureResult(text: nil, outcome: .noPermission)
+        }
+
+        if let text = nonEmptyText(axSelection()) {
+            return SelectionCaptureResult(text: text, outcome: .ax)
+        }
+
+        hintAccessibilityTree()
+
+        if let text = nonEmptyText(hintedAXSelection()) {
+            return SelectionCaptureResult(text: text, outcome: .axHinted)
+        }
+
+        if let text = nonEmptyText(clipboardSelection()) {
+            return SelectionCaptureResult(text: text, outcome: .clipboard)
+        }
+
+        return SelectionCaptureResult(text: nil, outcome: .emptyExternal)
     }
 
     // MARK: - Selection Reading
@@ -57,6 +185,75 @@ final class SelectionReaderService {
             }
 
             Thread.sleep(forTimeInterval: selectionReadRetryDelay)
+        }
+
+        return nil
+    }
+
+    func captureSelectedText() -> SelectionCaptureResult {
+        let frontmostApp = NSWorkspace.shared.frontmostApplication
+        let frontmostBundleId = frontmostApp?.bundleIdentifier
+        var useHintSettleBudget = false
+
+        let result = Self.captureExternalSelectedText(
+            hasAccessibilityPermission: cursorService.hasAccessibilityPermission,
+            axSelection: { [self] in
+                getSelectedText()
+            },
+            hintAccessibilityTree: { [self] in
+                useHintSettleBudget = hintAccessibilityTree(for: frontmostApp)
+            },
+            hintedAXSelection: { [self] in
+                readSelectedTextFromFocusedElement(
+                    attempts: useHintSettleBudget ? hintedSelectionReadAttempts : 1,
+                    retryDelay: useHintSettleBudget ? hintedSelectionReadRetryDelay : 0,
+                    retryMissingFocusedElement: useHintSettleBudget,
+                    retryEmptySelection: useHintSettleBudget
+                )
+            },
+            clipboardSelection: { [self] in
+                copySelectedTextThroughClipboard(from: frontmostApp)
+            }
+        )
+
+        DebugLog.log(
+            "[SelectionReader] external capture " +
+            "rung=\(result.outcome.telemetryRung) " +
+            "selectedLength=\(result.text?.count ?? 0) " +
+            "activeBundleId=\(frontmostBundleId ?? "unknown")"
+        )
+
+        return result
+    }
+
+    private func readSelectedTextFromFocusedElement(
+        attempts: Int,
+        retryDelay: TimeInterval,
+        retryMissingFocusedElement: Bool,
+        retryEmptySelection: Bool
+    ) -> String? {
+        let cappedAttempts = max(1, attempts)
+
+        for attempt in 1...cappedAttempts {
+            guard let focusedElement = getFocusedElement() else {
+                if retryMissingFocusedElement && attempt < cappedAttempts {
+                    Thread.sleep(forTimeInterval: retryDelay)
+                    continue
+                }
+                return nil
+            }
+
+            let selectionResult = extractSelectedText(from: focusedElement)
+            if let text = selectionResult.text {
+                return text
+            }
+
+            let shouldRetry = retryEmptySelection || shouldRetrySelectionRead(for: selectionResult.error)
+            if attempt == cappedAttempts || !shouldRetry {
+                break
+            }
+
+            Thread.sleep(forTimeInterval: retryDelay)
         }
 
         return nil
@@ -194,6 +391,94 @@ final class SelectionReaderService {
         }
     }
 
+    private func hintAccessibilityTree(for app: NSRunningApplication?) -> Bool {
+        guard let app else {
+            return false
+        }
+
+        let pid = app.processIdentifier
+        let wasAlreadyHinted = hintedApplicationPIDs.contains(pid)
+        guard !wasAlreadyHinted else {
+            return false
+        }
+
+        let appElement = AXUIElementCreateApplication(pid)
+        AXUIElementSetAttributeValue(
+            appElement,
+            Self.axEnhancedUserInterfaceAttribute,
+            kCFBooleanTrue
+        )
+        AXUIElementSetAttributeValue(
+            appElement,
+            Self.axManualAccessibilityAttribute,
+            kCFBooleanTrue
+        )
+        hintedApplicationPIDs.insert(pid)
+
+        return true
+    }
+
+    private func copySelectedTextThroughClipboard(from app: NSRunningApplication?) -> String? {
+        guard let app else {
+            return nil
+        }
+
+        let pasteboard = NSPasteboard.general
+        let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+
+        postCopyShortcut(to: app.processIdentifier)
+
+        guard waitForPasteboardChange(pasteboard, after: snapshot.changeCount) else {
+            return nil
+        }
+
+        let copiedText = pasteboard.string(forType: .string)
+        snapshot.restore(to: pasteboard)
+
+        return copiedText
+    }
+
+    private func postCopyShortcut(to pid: pid_t) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+
+        let keyDown = CGEvent(
+            keyboardEventSource: source,
+            virtualKey: Self.copyKeyCode,
+            keyDown: true
+        )
+        keyDown?.flags = .maskCommand
+        keyDown?.postToPid(pid)
+
+        let keyUp = CGEvent(
+            keyboardEventSource: source,
+            virtualKey: Self.copyKeyCode,
+            keyDown: false
+        )
+        keyUp?.flags = .maskCommand
+        keyUp?.postToPid(pid)
+    }
+
+    private func waitForPasteboardChange(_ pasteboard: NSPasteboard, after changeCount: Int) -> Bool {
+        for attempt in 1...clipboardPollAttempts {
+            if pasteboard.changeCount != changeCount {
+                return true
+            }
+
+            if attempt < clipboardPollAttempts {
+                Thread.sleep(forTimeInterval: clipboardPollDelay)
+            }
+        }
+
+        return pasteboard.changeCount != changeCount
+    }
+
+    private static func nonEmptyText(_ text: String?) -> String? {
+        guard let text, !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
     // MARK: - Active App Information
 
     /// Get the name of the currently active/frontmost application
@@ -256,6 +541,7 @@ final class SelectionReaderService {
     /// Captures everything at once BEFORE focus changes
     func buildContext(
         selectedText providedSelectedText: String? = nil,
+        selectionCaptureOutcome: SelectionCaptureOutcome = .notAttempted,
         readSelectionFromAX: Bool = true,
         panelSize: CGSize = CGSize(width: QuickPanelWindow.defaultWidth, height: QuickPanelWindow.minHeight)
     ) -> QuickPanelContext {
@@ -279,7 +565,8 @@ final class SelectionReaderService {
             windowTitle: getActiveWindowTitle(),
             panelPosition: position,
             clipboardImage: clipboardImageData,
-            isScreenshot: false
+            isScreenshot: false,
+            selectionCaptureOutcome: selectionCaptureOutcome
         )
         DebugLog.log(
             "[SelectionReader] buildContext result " +
@@ -318,6 +605,26 @@ struct QuickPanelContext {
     /// True only for explicit app-initiated screenshot mode (currently deprecated).
     /// Clipboard-derived images should keep this false.
     let isScreenshot: Bool
+    /// Outcome of the external-app selection ladder when Quick Panel was invoked.
+    let selectionCaptureOutcome: SelectionCaptureOutcome
+
+    init(
+        selectedText: String?,
+        activeApp: String?,
+        windowTitle: String?,
+        panelPosition: CGPoint,
+        clipboardImage: Data?,
+        isScreenshot: Bool,
+        selectionCaptureOutcome: SelectionCaptureOutcome = .notAttempted
+    ) {
+        self.selectedText = selectedText
+        self.activeApp = activeApp
+        self.windowTitle = windowTitle
+        self.panelPosition = panelPosition
+        self.clipboardImage = clipboardImage
+        self.isScreenshot = isScreenshot
+        self.selectionCaptureOutcome = selectionCaptureOutcome
+    }
 
     var trimmedSelectedText: String? {
         guard let trimmed = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -5,6 +5,9 @@ enum SelectionCaptureOutcome: Equatable {
     case notAttempted
     case internalApp
     case noPermission
+    /// AXIsProcessTrusted() says yes but the AX API answers kAXErrorAPIDisabled —
+    /// TCC revoked the grant behind a stale in-process cache (OS update / re-sign).
+    case stalePermission
     case ax
     case axHinted
     case clipboard
@@ -18,6 +21,8 @@ enum SelectionCaptureOutcome: Equatable {
             return "ax-hinted"
         case .clipboard:
             return "clipboard"
+        case .stalePermission:
+            return "stale-permission"
         case .notAttempted, .internalApp, .noPermission, .emptyExternal:
             return "none"
         }
@@ -216,14 +221,34 @@ final class SelectionReaderService {
             }
         )
 
+        var finalResult = result
+        if result.outcome == .emptyExternal && axPermissionIsStale() {
+            finalResult = SelectionCaptureResult(text: nil, outcome: .stalePermission)
+        }
+
         DebugLog.log(
             "[SelectionReader] external capture " +
-            "rung=\(result.outcome.telemetryRung) " +
-            "selectedLength=\(result.text?.count ?? 0) " +
+            "rung=\(finalResult.outcome.telemetryRung) " +
+            "selectedLength=\(finalResult.text?.count ?? 0) " +
             "activeBundleId=\(frontmostBundleId ?? "unknown")"
         )
 
-        return result
+        return finalResult
+    }
+
+    /// Canary for the trusted-but-revoked TCC state: AXIsProcessTrusted() reads a
+    /// per-process cache and can keep returning true after the grant was invalidated
+    /// (OS update, binary re-sign). A live AX call answering kAXErrorAPIDisabled is
+    /// the reliable tell.
+    private func axPermissionIsStale() -> Bool {
+        guard cursorService.hasAccessibilityPermission else { return false }
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            AXUIElementCreateSystemWide(),
+            kAXFocusedUIElementAttribute as CFString,
+            &value
+        )
+        return result == .apiDisabled
     }
 
     private func readSelectedTextFromFocusedElement(

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -260,10 +260,23 @@ final class SelectionReaderService {
     }
 
     private func getFocusedElement() -> AXUIElement? {
-        let systemWide = AXUIElementCreateSystemWide()
+        if let element = focusedElement(of: AXUIElementCreateSystemWide()) {
+            return element
+        }
+
+        // Sequoia regression (old repo #121): the system-wide focus query fails
+        // outright for some apps (kitty: kAXErrorCannotComplete) while the app's
+        // own AX element still answers. Fall back to the frontmost app.
+        guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
+            return nil
+        }
+        return focusedElement(of: AXUIElementCreateApplication(pid))
+    }
+
+    private func focusedElement(of container: AXUIElement) -> AXUIElement? {
         var focusedElementValue: CFTypeRef?
         let focusedElementResult = AXUIElementCopyAttributeValue(
-            systemWide,
+            container,
             kAXFocusedUIElementAttribute as CFString,
             &focusedElementValue
         )
@@ -426,7 +439,10 @@ final class SelectionReaderService {
         let pasteboard = NSPasteboard.general
         let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
 
-        postCopyShortcut(to: app.processIdentifier)
+        // Post ⌘C to the system HID stream, not the app's pid: GLFW/game-loop apps
+        // (kitty, Alacritty) never see pid-targeted events. Capture runs before the
+        // panel shows, so the target app is still the focused one.
+        postCopyShortcut()
 
         guard waitForPasteboardChange(pasteboard, after: snapshot.changeCount) else {
             return nil
@@ -438,24 +454,25 @@ final class SelectionReaderService {
         return copiedText
     }
 
-    private func postCopyShortcut(to pid: pid_t) {
-        let source = CGEventSource(stateID: .combinedSessionState)
+    private func postCopyShortcut() {
+        // GLFW apps (kitty, Alacritty) track modifiers from the modifier key's own
+        // events, not from flags on the letter key — synthesize the full ⌘C sequence.
+        let source = CGEventSource(stateID: .hidSystemState)
+        let commandKeyCode = CGKeyCode(55)  // kVK_Command
 
-        let keyDown = CGEvent(
-            keyboardEventSource: source,
-            virtualKey: Self.copyKeyCode,
-            keyDown: true
-        )
+        let commandDown = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: true)
+        commandDown?.flags = .maskCommand
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: Self.copyKeyCode, keyDown: true)
         keyDown?.flags = .maskCommand
-        keyDown?.postToPid(pid)
-
-        let keyUp = CGEvent(
-            keyboardEventSource: source,
-            virtualKey: Self.copyKeyCode,
-            keyDown: false
-        )
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: Self.copyKeyCode, keyDown: false)
         keyUp?.flags = .maskCommand
-        keyUp?.postToPid(pid)
+        let commandUp = CGEvent(keyboardEventSource: source, virtualKey: commandKeyCode, keyDown: false)
+        commandUp?.flags = []
+
+        for event in [commandDown, keyDown, keyUp, commandUp] {
+            event?.post(tap: .cghidEventTap)
+            usleep(5_000)
+        }
     }
 
     private func waitForPasteboardChange(_ pasteboard: NSPasteboard, after changeCount: Int) -> Bool {

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -3,6 +3,42 @@ import XCTest
 @testable import Ticker
 
 final class DeviceKeyServiceTests: XCTestCase {
+    func test_logRingCapsAndPreservesOrder() {
+        let ring = LogRing(capacity: 3)
+
+        for i in 0..<5 {
+            ring.append("line-\(i)", date: Date(timeIntervalSince1970: TimeInterval(i)))
+        }
+
+        let snapshot = ring.snapshot()
+        XCTAssertEqual(snapshot.count, 3)
+        XCTAssertTrue(snapshot[0].contains("line-2"))
+        XCTAssertTrue(snapshot[1].contains("line-3"))
+        XCTAssertTrue(snapshot[2].contains("line-4"))
+        XCTAssertLessThanOrEqual(Data(ring.joined(maxBytes: 20).utf8).count, 20)
+    }
+
+    func test_logRingThreadSafetySmoke() {
+        let ring = LogRing(capacity: 1_000)
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { index in
+            ring.append("line-\(index)")
+        }
+
+        XCTAssertEqual(ring.snapshot().count, 1_000)
+    }
+
+    func test_crashSessionSentinelEvaluateLaunch() {
+        XCTAssertEqual(
+            CrashSessionSentinel.evaluateLaunch(markerExisted: true, markerWriteSucceeded: true),
+            CrashSessionSentinel.LaunchResult(lastSessionCrashed: true, markerWriteSucceeded: true)
+        )
+        XCTAssertEqual(
+            CrashSessionSentinel.evaluateLaunch(markerExisted: false, markerWriteSucceeded: false),
+            CrashSessionSentinel.LaunchResult(lastSessionCrashed: false, markerWriteSucceeded: false)
+        )
+    }
+
     func test_loadProxyAuth_createsDeviceJsonWithPrivatePermissions() async throws {
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -102,5 +138,57 @@ final class DeviceKeyServiceTests: XCTestCase {
         XCTAssertEqual(recent.count, 50)
         XCTAssertEqual(recent.first?["request_id"] as? String, "req-10")
         XCTAssertEqual(recent.last?["request_id"] as? String, "req-59")
+    }
+
+    func test_getSupportBundle_includesLogsCrashUptimeAndCrashSentinel() async throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let diagnosticReportsDir = tempDir.appendingPathComponent("DiagnosticReports", isDirectory: true)
+        try fileManager.createDirectory(at: diagnosticReportsDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let recentCrashURL = diagnosticReportsDir.appendingPathComponent("TickerNext-2026-07-05-133000.ips")
+        let staleCrashURL = diagnosticReportsDir.appendingPathComponent("TickerNext-2026-06-01-133000.ips")
+        let otherCrashURL = diagnosticReportsDir.appendingPathComponent("OtherApp-2026-07-05-133000.ips")
+        let recentCrashPayload = "newest crash header\n" + String(repeating: "x", count: 40 * 1024)
+
+        try recentCrashPayload.write(to: recentCrashURL, atomically: true, encoding: .utf8)
+        try "stale crash".write(to: staleCrashURL, atomically: true, encoding: .utf8)
+        try "other crash".write(to: otherCrashURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-60)],
+            ofItemAtPath: recentCrashURL.path
+        )
+        try fileManager.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-(8 * 24 * 60 * 60))],
+            ofItemAtPath: staleCrashURL.path
+        )
+        try fileManager.setAttributes(
+            [.modificationDate: now],
+            ofItemAtPath: otherCrashURL.path
+        )
+
+        let fileURL = tempDir.appendingPathComponent("device.json")
+        let service = DeviceKeyService(
+            fileURL: fileURL,
+            diagnosticReportsDirectoryURL: diagnosticReportsDir,
+            launchDate: now.addingTimeInterval(-65),
+            nowProvider: { now },
+            recentLogsProvider: { "log-a\nlog-b" },
+            lastSessionCrashedProvider: { true }
+        )
+
+        _ = await service.loadProxyAuth()
+        let bundle = await service.getSupportBundle()
+
+        XCTAssertEqual(bundle["recent_logs"] as? String, "log-a\nlog-b")
+        XCTAssertEqual(bundle["uptime_seconds"] as? Int, 65)
+        XCTAssertEqual(bundle["last_session_crashed"] as? Bool, true)
+
+        let recentCrash = try XCTUnwrap(bundle["recent_crash"] as? String)
+        XCTAssertTrue(recentCrash.contains("newest crash header"))
+        XCTAssertFalse(recentCrash.contains("stale crash"))
+        XCTAssertLessThanOrEqual(Data(recentCrash.utf8).count, SupportDiagnostics.recentCrashMaxBytes)
     }
 }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -95,6 +95,147 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertEqual(externalSelection, "AX selection")
         XCTAssertFalse(localSelectionWasRequested)
     }
+
+    func test_selectionCaptureLadderRunsRungsInOrder() {
+        var calls: [String] = []
+
+        let result = SelectionReaderService.captureExternalSelectedText(
+            hasAccessibilityPermission: true,
+            axSelection: {
+                calls.append("ax")
+                return nil
+            },
+            hintAccessibilityTree: {
+                calls.append("hint")
+            },
+            hintedAXSelection: {
+                calls.append("hinted")
+                return nil
+            },
+            clipboardSelection: {
+                calls.append("clipboard")
+                return "Clipboard selection"
+            }
+        )
+
+        XCTAssertEqual(result, SelectionCaptureResult(text: "Clipboard selection", outcome: .clipboard))
+        XCTAssertEqual(calls, ["ax", "hint", "hinted", "clipboard"])
+    }
+
+    func test_selectionCaptureLadderShortCircuitsOnFirstSuccess() {
+        var calls: [String] = []
+
+        let result = SelectionReaderService.captureExternalSelectedText(
+            hasAccessibilityPermission: true,
+            axSelection: {
+                calls.append("ax")
+                return "AX selection"
+            },
+            hintAccessibilityTree: {
+                calls.append("hint")
+            },
+            hintedAXSelection: {
+                calls.append("hinted")
+                return "Hinted selection"
+            },
+            clipboardSelection: {
+                calls.append("clipboard")
+                return "Clipboard selection"
+            }
+        )
+
+        XCTAssertEqual(result, SelectionCaptureResult(text: "AX selection", outcome: .ax))
+        XCTAssertEqual(calls, ["ax"])
+    }
+
+    func test_selectionCaptureLadderSkipsRungsWithoutPermission() {
+        var calls: [String] = []
+
+        let result = SelectionReaderService.captureExternalSelectedText(
+            hasAccessibilityPermission: false,
+            axSelection: {
+                calls.append("ax")
+                return "AX selection"
+            },
+            hintAccessibilityTree: {
+                calls.append("hint")
+            },
+            hintedAXSelection: {
+                calls.append("hinted")
+                return "Hinted selection"
+            },
+            clipboardSelection: {
+                calls.append("clipboard")
+                return "Clipboard selection"
+            }
+        )
+
+        XCTAssertEqual(result, SelectionCaptureResult(text: nil, outcome: .noPermission))
+        XCTAssertTrue(calls.isEmpty)
+    }
+
+    func test_selectionCaptureStatusMapping() {
+        XCTAssertEqual(
+            QuickPanelStatus.selectionCaptureStatus(for: .noPermission, activeApp: "Chrome"),
+            QuickPanelStatus(
+                message: "Grant Accessibility permission to capture text selections",
+                tone: .warning,
+                action: .openAccessibilitySettings
+            )
+        )
+        XCTAssertEqual(
+            QuickPanelStatus.selectionCaptureStatus(for: .emptyExternal, activeApp: "Chrome"),
+            QuickPanelStatus(
+                message: "No text selected in Chrome",
+                tone: .info,
+                action: nil
+            )
+        )
+        XCTAssertEqual(
+            QuickPanelStatus.selectionCaptureStatus(for: .emptyExternal, activeApp: " "),
+            QuickPanelStatus(
+                message: "No text selected",
+                tone: .info,
+                action: nil
+            )
+        )
+        XCTAssertNil(QuickPanelStatus.selectionCaptureStatus(for: .internalApp, activeApp: "Ticker"))
+        XCTAssertNil(QuickPanelStatus.selectionCaptureStatus(for: .axHinted, activeApp: "Chrome"))
+    }
+
+    func test_pasteboardSnapshotRestoresItemsAndTypes() throws {
+        let pasteboardName = NSPasteboard.Name("TickerPasteboardSnapshotTests.\(UUID().uuidString)")
+        let pasteboard = NSPasteboard(name: pasteboardName)
+        let binaryType = NSPasteboard.PasteboardType("com.ticker.test.binary")
+        let customTextType = NSPasteboard.PasteboardType("com.ticker.test.custom-text")
+        let binaryData = Data([0x01, 0x02, 0x03, 0xff])
+
+        pasteboard.clearContents()
+        defer {
+            pasteboard.clearContents()
+        }
+
+        let firstItem = NSPasteboardItem()
+        XCTAssertTrue(firstItem.setString("Original string", forType: .string))
+        XCTAssertTrue(firstItem.setData(binaryData, forType: binaryType))
+
+        let secondItem = NSPasteboardItem()
+        XCTAssertTrue(secondItem.setString("Custom payload", forType: customTextType))
+
+        XCTAssertTrue(pasteboard.writeObjects([firstItem, secondItem]))
+
+        let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.setString("Mutated", forType: .string))
+
+        snapshot.restore(to: pasteboard)
+
+        let restoredItems = try XCTUnwrap(pasteboard.pasteboardItems)
+        XCTAssertEqual(restoredItems.count, 2)
+        XCTAssertEqual(restoredItems[0].string(forType: .string), "Original string")
+        XCTAssertEqual(restoredItems[0].data(forType: binaryType), binaryData)
+        XCTAssertEqual(restoredItems[1].string(forType: customTextType), "Custom payload")
+    }
 }
 
 final class StreamDocumentTests: XCTestCase {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -184,6 +184,14 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
             )
         )
         XCTAssertEqual(
+            QuickPanelStatus.selectionCaptureStatus(for: .stalePermission, activeApp: "Chrome"),
+            QuickPanelStatus(
+                message: "Accessibility permission is stale — remove Ticker from the list and re-add it",
+                tone: .warning,
+                action: .openAccessibilitySettings
+            )
+        )
+        XCTAssertEqual(
             QuickPanelStatus.selectionCaptureStatus(for: .emptyExternal, activeApp: "Chrome"),
             QuickPanelStatus(
                 message: "No text selected in Chrome",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1267,6 +1267,41 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertFalse(fullscreenLayout.shouldResizeWindow)
     }
 
+    func test_pdfPaneOpeningWidthIsInteriorAfterHostBasedMax() throws {
+        let visibleFrame = CGRect(x: 0, y: 25, width: 1440, height: 875)
+        let layout = PDFPaneOpeningLayout.calculate(
+            currentFrame: CGRect(x: 220, y: 120, width: 900, height: 700),
+            visibleFrame: visibleFrame,
+            isNativeFullscreen: false
+        )
+        let maxWidth = PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: visibleFrame.width)
+
+        XCTAssertEqual(layout.paneWidth, 720)
+        XCTAssertGreaterThan(layout.paneWidth, PDFPaneWidthPolicy.minimumPDFPaneWidth)
+        XCTAssertLessThan(layout.paneWidth, maxWidth)
+    }
+
+    func test_pdfPaneClampAllowsBothDirectionsForStandardHost() throws {
+        let hostWidth: CGFloat = 1440
+        let openingWidth = floor(hostWidth * 0.5)
+
+        let smaller = PDFPaneWidthPolicy.clampPDFPaneWidth(openingWidth - 100, hostWidth: hostWidth)
+        let larger = PDFPaneWidthPolicy.clampPDFPaneWidth(openingWidth + 100, hostWidth: hostWidth)
+
+        XCTAssertLessThan(smaller, openingWidth)
+        XCTAssertGreaterThan(larger, openingWidth)
+        XCTAssertEqual(PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: hostWidth), 1040)
+    }
+
+    func test_pdfPaneClampHandlesDegenerateSmallHosts() throws {
+        XCTAssertEqual(PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: 500), 320)
+        XCTAssertEqual(PDFPaneWidthPolicy.clampPDFPaneWidth(900, hostWidth: 500), 320)
+
+        XCTAssertEqual(PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: 260), 260)
+        XCTAssertEqual(PDFPaneWidthPolicy.clampPDFPaneWidth(900, hostWidth: 260), 260)
+        XCTAssertEqual(PDFPaneWidthPolicy.clampPDFPaneWidth(20, hostWidth: 260), 260)
+    }
+
     func test_pdfPaneWindowRestoreUsesSavedFrameExceptInFullscreen() throws {
         let saved = CGRect(x: 120, y: 80, width: 900, height: 700)
 

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -660,6 +660,7 @@
 				isa = XCBuildConfiguration;
 				buildSettings = {
 					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					APP_DISPLAY_NAME = "Ticker Debug";
 					CODE_SIGN_ENTITLEMENTS = Sources/Ticker/Ticker.entitlements;
 					CODE_SIGN_STYLE = Automatic;
 					COMBINE_HIDPI_IMAGES = YES;
@@ -675,7 +676,7 @@
 				);
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				MARKETING_VERSION = 2025.12.1;
-					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.next;
+					PRODUCT_BUNDLE_IDENTIFIER = io.ticker.next.debug;
 					PRODUCT_MODULE_NAME = Ticker;
 					PRODUCT_NAME = TickerNext;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -687,6 +688,7 @@
 					isa = XCBuildConfiguration;
 					buildSettings = {
 					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+					APP_DISPLAY_NAME = "Ticker Next";
 					CODE_SIGN_ENTITLEMENTS = Sources/Ticker/Ticker.entitlements;
 					CODE_SIGN_STYLE = Automatic;
 					COMBINE_HIDPI_IMAGES = YES;

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
@@ -51,6 +51,11 @@ interface FloatingMenuState {
   visible: boolean;
   left: number;
   top: number;
+  selectionFrom: number;
+  selectionTo: number;
+  selectionHead: number;
+  menuWidth?: number;
+  menuHeight?: number;
 }
 
 interface AiFeedbackState {
@@ -245,6 +250,9 @@ export function StreamEditor({
     visible: false,
     left: 0,
     top: 0,
+    selectionFrom: 0,
+    selectionTo: 0,
+    selectionHead: 0,
   });
   const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
     visible: false,
@@ -465,7 +473,14 @@ export function StreamEditor({
     hideAiFeedback();
     clearSourceIndexNoticeTimer();
     setSourceIndexNotice(null);
-    setFloatingMenu({ visible: false, left: 0, top: 0 });
+    setFloatingMenu({
+      visible: false,
+      left: 0,
+      top: 0,
+      selectionFrom: 0,
+      selectionTo: 0,
+      selectionHead: 0,
+    });
     setShowPrompt(false);
     setPromptValue('');
     setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
@@ -1059,7 +1074,10 @@ export function StreamEditor({
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
-  const getSelectionMenuPlacement = useCallback((view: EditorView): { left: number; top: number } | null => {
+  const getSelectionMenuPlacement = useCallback((
+    view: EditorView,
+    measuredMenuSize?: { width: number; height: number }
+  ): { left: number; top: number } | null => {
     const shell = editorShellRef.current;
     if (!shell) return null;
 
@@ -1072,13 +1090,64 @@ export function StreamEditor({
     return computeSelectionMenuPlacement({
       coords,
       shellRect,
-      menuSize: {
+      menuSize: measuredMenuSize ?? {
         width: menu?.offsetWidth,
         height: menu?.offsetHeight,
       },
       viewportHeight: window.innerHeight,
     });
   }, []);
+
+  useLayoutEffect(() => {
+    if (!floatingMenu.visible) return;
+
+    const menu = selectionActionMenuRef.current;
+    const view = editorViewRef.current;
+    if (!menu || !view) return;
+
+    const measuredMenuSize = {
+      width: menu.offsetWidth,
+      height: menu.offsetHeight,
+    };
+    if (measuredMenuSize.width <= 0 || measuredMenuSize.height <= 0) return;
+
+    const placement = getSelectionMenuPlacement(view, measuredMenuSize);
+    if (!placement) return;
+
+    setFloatingMenu((previous) => {
+      if (!previous.visible) return previous;
+
+      const sameSize = previous.menuWidth === measuredMenuSize.width &&
+        previous.menuHeight === measuredMenuSize.height;
+      const samePlacement = Math.abs(previous.left - placement.left) < 0.5 &&
+        Math.abs(previous.top - placement.top) < 0.5;
+
+      if (sameSize && samePlacement) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        left: placement.left,
+        top: placement.top,
+        menuWidth: measuredMenuSize.width,
+        menuHeight: measuredMenuSize.height,
+      };
+    });
+  }, [
+    floatingMenu.left,
+    floatingMenu.menuHeight,
+    floatingMenu.menuWidth,
+    floatingMenu.selectionFrom,
+    floatingMenu.selectionHead,
+    floatingMenu.selectionTo,
+    floatingMenu.top,
+    floatingMenu.visible,
+    getSelectionMenuPlacement,
+    pdfPaneState.streamId,
+    pdfPaneState.visible,
+    stream.id,
+  ]);
 
   const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
@@ -1115,6 +1184,9 @@ export function StreamEditor({
         visible: true,
         left: placement.left,
         top: placement.top,
+        selectionFrom: currentSelection.from,
+        selectionTo: currentSelection.to,
+        selectionHead: currentSelection.head,
       });
     }, SELECTION_MENU_DELAY_MS);
   }, [clearSelectionMenuTimer, getSelectionMenuPlacement, hideSelectionMenu]);

--- a/Web/src/utils/selectionMenuPlacement.test.ts
+++ b/Web/src/utils/selectionMenuPlacement.test.ts
@@ -62,4 +62,39 @@ describe('computeSelectionMenuPlacement', () => {
       viewportHeight: 600,
     }).left).toBe(35);
   });
+
+  it('keeps a wide menu inside the left shell edge', () => {
+    const wideMenu = { width: 250, height: 44 };
+    const placement = computeSelectionMenuPlacement({
+      coords: { left: 0, right: 8, top: 100, bottom: 120 },
+      shellRect: { left: 0, right: 500, top: 0, bottom: 500 },
+      menuSize: wideMenu,
+      viewportHeight: 600,
+    });
+
+    expect(placement.left - wideMenu.width / 2).toBeGreaterThanOrEqual(8);
+    expect(placement.left + wideMenu.width / 2).toBeLessThanOrEqual(492);
+  });
+
+  it('keeps a wide menu inside the right shell edge', () => {
+    const wideMenu = { width: 250, height: 44 };
+    const placement = computeSelectionMenuPlacement({
+      coords: { left: 492, right: 500, top: 100, bottom: 120 },
+      shellRect: { left: 0, right: 500, top: 0, bottom: 500 },
+      menuSize: wideMenu,
+      viewportHeight: 600,
+    });
+
+    expect(placement.left - wideMenu.width / 2).toBeGreaterThanOrEqual(8);
+    expect(placement.left + wideMenu.width / 2).toBeLessThanOrEqual(492);
+  });
+
+  it('centers a wide menu when the shell is narrower than the menu', () => {
+    expect(computeSelectionMenuPlacement({
+      coords: { left: 0, right: 8, top: 100, bottom: 120 },
+      shellRect: { left: 0, right: 180, top: 0, bottom: 500 },
+      menuSize: { width: 250, height: 44 },
+      viewportHeight: 600,
+    }).left).toBe(90);
+  });
 });

--- a/Web/src/utils/selectionMenuPlacement.ts
+++ b/Web/src/utils/selectionMenuPlacement.ts
@@ -24,7 +24,7 @@ export interface SelectionMenuPlacement {
   top: number;
 }
 
-export const DEFAULT_SELECTION_MENU_WIDTH = 82;
+export const DEFAULT_SELECTION_MENU_WIDTH = 250;
 export const DEFAULT_SELECTION_MENU_HEIGHT = 44;
 export const DEFAULT_SELECTION_MENU_GAP = 10;
 export const DEFAULT_SELECTION_MENU_HORIZONTAL_INSET = 8;

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ Notes:
     codesign the installed lane app if `SIGN_IDENTITY` is set (recommended so macOS
     permissions like Accessibility/Screen Recording stick across rebuilds).
   - Stable lane installs to `~/Applications/Ticker Next.app` by default.
+  - Debug stable builds keep the Xcode project's Debug bundle id/display name.
   - QA lane installs to `~/Applications/Ticker Next QA.app` by default.
   - Distribution builds should follow the signing/notarization runbook.
   - Override build output location with DERIVED_DATA_PATH (or TICKER_NEXT_DERIVED_DATA_PATH), e.g.:
@@ -34,7 +35,9 @@ DERIVED_DATA_PATH_DEFAULT="$ROOT_DIR/.build/xcode"
 DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${TICKER_NEXT_DERIVED_DATA_PATH:-$DERIVED_DATA_PATH_DEFAULT}}"
 APP="$DERIVED_DATA_PATH/Build/Products"
 APP_BUNDLE_ID="${APP_BUNDLE_ID:-io.ticker.next}"
+DEBUG_APP_BUNDLE_ID="${DEBUG_APP_BUNDLE_ID:-io.ticker.next.debug}"
 QA_APP_BUNDLE_ID="${QA_APP_BUNDLE_ID:-io.ticker.next.qa}"
+DEBUG_APP_DISPLAY_NAME="${DEBUG_APP_DISPLAY_NAME:-Ticker Debug}"
 STABLE_APP_DISPLAY_NAME="${STABLE_APP_DISPLAY_NAME:-Ticker Next}"
 QA_APP_DISPLAY_NAME="${QA_APP_DISPLAY_NAME:-Ticker Next QA}"
 STABLE_APP_PRODUCT_NAME="${STABLE_APP_PRODUCT_NAME:-TickerNext}"
@@ -76,7 +79,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 lane_bundle_id() {
-  if [[ "$LANE" == "qa" ]]; then
+  if [[ "$MODE" == "dev" && "$LANE" == "stable" ]]; then
+    echo "$DEBUG_APP_BUNDLE_ID"
+  elif [[ "$LANE" == "qa" ]]; then
     echo "$QA_APP_BUNDLE_ID"
   else
     echo "$APP_BUNDLE_ID"
@@ -84,7 +89,9 @@ lane_bundle_id() {
 }
 
 lane_display_name() {
-  if [[ "$LANE" == "qa" ]]; then
+  if [[ "$MODE" == "dev" && "$LANE" == "stable" ]]; then
+    echo "$DEBUG_APP_DISPLAY_NAME"
+  elif [[ "$LANE" == "qa" ]]; then
     echo "$QA_APP_DISPLAY_NAME"
   else
     echo "$STABLE_APP_DISPLAY_NAME"
@@ -209,12 +216,14 @@ build_app() {
     build_number="$(git rev-list --count HEAD 2>/dev/null || echo 1)"
     extra_build_settings+=("CURRENT_PROJECT_VERSION=$build_number")
   fi
-  if [[ "$LANE" == "qa" ]]; then
+  if [[ "$configuration" == "Debug" && "$LANE" == "stable" ]]; then
+    :
+  elif [[ "$LANE" == "qa" ]]; then
     extra_build_settings+=("PRODUCT_BUNDLE_IDENTIFIER=$QA_APP_BUNDLE_ID")
-    extra_build_settings+=("INFOPLIST_KEY_CFBundleDisplayName=$QA_APP_DISPLAY_NAME")
+    extra_build_settings+=("APP_DISPLAY_NAME=$QA_APP_DISPLAY_NAME")
   else
     extra_build_settings+=("PRODUCT_BUNDLE_IDENTIFIER=$APP_BUNDLE_ID")
-    extra_build_settings+=("INFOPLIST_KEY_CFBundleDisplayName=$STABLE_APP_DISPLAY_NAME")
+    extra_build_settings+=("APP_DISPLAY_NAME=$STABLE_APP_DISPLAY_NAME")
   fi
 
   local log_path

--- a/tickerctl.sh
+++ b/tickerctl.sh
@@ -61,7 +61,8 @@ Config (optional):
 
 Notes:
   - Dev/prod commands build unsigned (CODE_SIGNING_ALLOWED=NO).
-  - `run-dev`/`run-prod` use stable lane (`io.ticker.next` by default).
+  - `build-dev`/`run-dev` use the Debug app identity from the Xcode project.
+  - `run-prod` uses stable lane (`io.ticker.next` by default).
   - `run-dev-qa`/`run-prod-qa` use QA lane (`io.ticker.next.qa` by default).
   - Sparkle update testing requires an older build installed in /Applications
     and a newer build published in the appcast.
@@ -350,9 +351,13 @@ build_app() {
   local -a extra=(
     "CODE_SIGNING_ALLOWED=NO"
     "CURRENT_PROJECT_VERSION=$build_num"
-    "PRODUCT_BUNDLE_IDENTIFIER=$APP_BUNDLE_ID"
-    "INFOPLIST_KEY_CFBundleDisplayName=$APP_NAME"
   )
+  if [[ "$configuration" == "Release" ]]; then
+    extra+=(
+      "PRODUCT_BUNDLE_IDENTIFIER=$APP_BUNDLE_ID"
+      "APP_DISPLAY_NAME=$APP_NAME"
+    )
+  fi
   if [[ -n "$marketing_version" ]]; then
     extra+=("MARKETING_VERSION=$marketing_version")
   fi


### PR DESCRIPTION
First-round user-testing fixes.

## Capture (the critical one)
- Three-rung external selection ladder: plain AX → Chromium/Electron AX-enable hint with retry budget → synthesized ⌘C with invisible clipboard snapshot/restore. Fixes browser/web-page capture (verified live in Arc via the hint rung).
- Sequoia regression fix (legacy repo #121): system-wide AX focus query fails for some apps (kitty: cannotComplete) — fall back to the frontmost app's own AX element.
- Clipboard rung posts the full ⌘-down/C/⌘-up sequence to the HID stream (GLFW apps ignore pid-targeted, flag-decorated events).
- Honest quick-panel status: permission warning is actionable (Open Settings), and 'No text selected in ⟨App⟩' when permission is fine but the app exposed nothing.
- Known limit: kitty ≤0.26.2 reports an empty AX selection while one exists (proven against a concurrent manual-⌘C clipboard bump) — needs a kitty upgrade, not app code.

## Rest
- PDF pane divider travels both directions (host-based width clamp; pane no longer opens pinned at its own max).
- Selection toolbar re-clamps with its measured width — no more off-screen crop at line starts.
- Field diagnostics: all-builds log ring buffer, newest crash report + uptime + last-session-crashed sentinel in feedback payloads.
- Debug builds get their own identity (io.ticker.next.debug, 'Ticker Debug') — ends TCC permission poisoning and stale-app confusion between dev and release copies.

Gates: swift build+test, 63 web tests, bundle, bridge contract — all green (run per-round and consolidated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)