### PR TITLE
H1.1: source-biased dispatch (single-source retrieval floor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- Document AI now biases toward the only attached large source when a question has weak but present lexical overlap.
 - Document AI now uses local source retrieval for large source sets instead of concatenating every source.
 - Main window chrome is now transparent, with content inset around the floating traffic-light controls.
 - Stream sources now open in a modal instead of a persistent sidebar, preserving editor width beside the PDF pane.

--- a/Sources/Ticker/Services/RetrievalService.swift
+++ b/Sources/Ticker/Services/RetrievalService.swift
@@ -67,8 +67,9 @@ final class RetrievalService {
             return nil
         }
 
-        let extractedTexts = stream.sources
+        let nonPrivateSources = stream.sources
             .filter { !$0.aiExcluded }
+        let extractedTexts = nonPrivateSources
             .compactMap(\.extractedText)
         let combinedText = extractedTexts.joined(separator: "\n\n---\n\n")
         let totalTokens = extractedTexts.reduce(0) { $0 + estimatedTokenCount($1) }
@@ -80,14 +81,52 @@ final class RetrievalService {
             return SourceContext(text: combinedText, chunks: [], mode: .passthrough)
         }
 
-        let chunks = try retrieve(query: query, streamId: streamId, applyThreshold: scope == .auto)
-        guard !chunks.isEmpty else {
+        if scope == .all {
+            let chunks = try retrieve(query: query, streamId: streamId, applyThreshold: false)
+            guard !chunks.isEmpty else {
+                return nil
+            }
+
+            return SourceContext(
+                text: Self.buildManifest(from: chunks),
+                chunks: chunks,
+                mode: .retrieved
+            )
+        }
+
+        let contentSourceCount = try nonPrivateSources.reduce(0) { count, source in
+            if source.extractedText?.isEmpty == false {
+                return count + 1
+            }
+
+            return try persistence.loadSourceChunks(sourceId: source.id).isEmpty ? count : count + 1
+        }
+
+        let candidates = try retrieve(query: query, streamId: streamId, applyThreshold: false)
+        guard !candidates.isEmpty,
+              let ftsQuery = Self.sanitizedFTSQuery(query) else {
             return nil
         }
 
+        let relevanceCutoff = Self.relevanceCutoff(tokenCount: ftsQuery.tokenCount)
+        let chunks = candidates.filter { $0.score <= relevanceCutoff }
+        if !chunks.isEmpty {
+            return SourceContext(
+                text: Self.buildManifest(from: chunks),
+                chunks: chunks,
+                mode: .retrieved
+            )
+        }
+
+        guard contentSourceCount == 1 else {
+            return nil
+        }
+
+        // ponytail: Single-source weak lexical matches are an intent floor; upgrade with
+        // R3 golden-set embeddings before loosening the shared BM25 cutoff.
         return SourceContext(
-            text: Self.buildManifest(from: chunks),
-            chunks: chunks,
+            text: Self.buildManifest(from: candidates),
+            chunks: candidates,
             mode: .retrieved
         )
     }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -524,7 +524,7 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
-    func test_retrievalReturnsNoContextForIrrelevantQuery() throws {
+    func test_retrievalSingleSourceFloorReturnsBestChunkForWeakQuery() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "Large Source")
             try service.saveStream(stream)
@@ -534,19 +534,29 @@ final class StreamDocumentTests: XCTestCase {
                 displayName: "Manual.pdf",
                 extractedText: largeExtractedText(),
                 chunks: [
-                    (0, "Storage manifolds and caliper fixtures are indexed here.", 4, 4, "Storage")
+                    (0, "Storage manifolds and caliper fixtures are indexed as the best fallback.", 4, 4, "Storage")
                 ]
             )
 
             let retrieval = RetrievalService(persistence: service)
 
-            let unrelatedQuery = "what is the best way to do this"
-            XCTAssertTrue(try retrieval.retrieve(query: unrelatedQuery, streamId: stream.id).isEmpty)
-            XCTAssertNil(try retrieval.assembleSourceContext(query: unrelatedQuery, streamId: stream.id))
+            let weakQuery = "what is the best way to do this"
+            let rawResults = try retrieval.retrieve(query: weakQuery, streamId: stream.id, applyThreshold: false)
+
+            XCTAssertFalse(rawResults.isEmpty)
+            XCTAssertTrue(try retrieval.retrieve(query: weakQuery, streamId: stream.id).isEmpty)
+
+            // H1.1: one content source plus a weak lexical candidate is user intent, not no-context.
+            let context = try XCTUnwrap(
+                retrieval.assembleSourceContext(query: weakQuery, streamId: stream.id)
+            )
+            XCTAssertEqual(context.mode, .retrieved)
+            XCTAssertEqual(context.chunks.map(\.sourceName), ["Manual.pdf"])
+            XCTAssertTrue(context.text.contains("Storage manifolds and caliper fixtures"))
         }
     }
 
-    func test_retrievalReturnsNoContextWhenAllQueryTokensMatchOnlyWeakly() throws {
+    func test_retrievalSingleSourceFloorReturnsBestChunkWhenAllQueryTokensMatchOnlyWeakly() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "Weak Matches")
             try service.saveStream(stream)
@@ -572,7 +582,106 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertLessThan(bestScore, 0)
             XCTAssertGreaterThan(bestScore, cutoff)
             XCTAssertTrue(try retrieval.retrieve(query: query, streamId: stream.id).isEmpty)
+
+            // H1.1: the single-source floor deliberately abandoned the old nil here.
+            let context = try XCTUnwrap(
+                retrieval.assembleSourceContext(query: query, streamId: stream.id)
+            )
+            XCTAssertEqual(context.mode, .retrieved)
+            XCTAssertFalse(context.chunks.isEmpty)
+            XCTAssertTrue(context.chunks.allSatisfy { $0.sourceName == "Technical.pdf" })
+        }
+    }
+
+    func test_retrievalSingleSourceFloorStillGatesZeroVocabularyQuery() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Zero Vocabulary")
+            try service.saveStream(stream)
+            _ = try saveRetrievalSource(
+                in: service,
+                streamId: stream.id,
+                displayName: "Manual.pdf",
+                extractedText: largeExtractedText(),
+                chunks: [
+                    (0, "Storage manifolds and caliper fixtures are indexed here.", 4, 4, "Storage")
+                ]
+            )
+
+            let retrieval = RetrievalService(persistence: service)
+            let query = "orchid saxophone nebula"
+            let rawResults = try retrieval.retrieve(query: query, streamId: stream.id, applyThreshold: false)
+
+            XCTAssertTrue(rawResults.isEmpty)
             XCTAssertNil(try retrieval.assembleSourceContext(query: query, streamId: stream.id))
+        }
+    }
+
+    func test_retrievalMultiSourceWeakMatchesStillGateAutoContext() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Weak Multi Source")
+            try service.saveStream(stream)
+            _ = try saveRetrievalSource(
+                in: service,
+                streamId: stream.id,
+                displayName: "Alpha.pdf",
+                extractedText: largeExtractedText("alpha"),
+                chunks: weakUnrelatedChunks()
+            )
+            _ = try saveRetrievalSource(
+                in: service,
+                streamId: stream.id,
+                displayName: "Beta.pdf",
+                extractedText: largeExtractedText("beta"),
+                chunks: weakUnrelatedChunks()
+            )
+
+            let retrieval = RetrievalService(persistence: service)
+            let query = "good dish party friends"
+            let sanitized = try XCTUnwrap(RetrievalService.sanitizedFTSQuery(query))
+            let cutoff = -1.0 * Double(sanitized.tokenCount)
+            let rawResults = try retrieval.retrieve(query: query, streamId: stream.id, applyThreshold: false)
+            let bestScore = try XCTUnwrap(rawResults.first?.score)
+
+            XCTAssertFalse(rawResults.isEmpty)
+            XCTAssertGreaterThan(bestScore, cutoff)
+            XCTAssertTrue(try retrieval.retrieve(query: query, streamId: stream.id).isEmpty)
+            XCTAssertNil(try retrieval.assembleSourceContext(query: query, streamId: stream.id))
+        }
+    }
+
+    func test_retrievalMultiSourceStrongMatchRetrievesConfidentChunk() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Strong Multi Source")
+            try service.saveStream(stream)
+            _ = try saveRetrievalSource(
+                in: service,
+                streamId: stream.id,
+                displayName: "Lease.pdf",
+                extractedText: largeExtractedText("lease"),
+                chunks: stronglyRelevantChunks(
+                    strongText: "termination termination termination lease lease lease option option option",
+                    pageStart: 7,
+                    pageEnd: 7
+                )
+            )
+            _ = try saveRetrievalSource(
+                in: service,
+                streamId: stream.id,
+                displayName: "Appendix.pdf",
+                extractedText: largeExtractedText("appendix"),
+                chunks: [
+                    (0, "Storage manifolds and caliper fixtures are indexed here.", 4, 4, "Storage")
+                ]
+            )
+
+            let retrieval = RetrievalService(persistence: service)
+            let context = try XCTUnwrap(
+                retrieval.assembleSourceContext(query: "termination lease option", streamId: stream.id)
+            )
+
+            XCTAssertEqual(context.mode, .retrieved)
+            XCTAssertEqual(context.chunks.map(\.sourceName), ["Lease.pdf"])
+            XCTAssertTrue(context.text.contains("termination termination termination"))
         }
     }
 


### PR DESCRIPTION
Roadmap 3 / Phase H1. Fixes a field-reported bug: a user attached a commercial lease and asked plain-English questions; the lease's legalese didn't lexically clear the BM25 cutoff, so retrieval returned nil and answers came from model knowledge instead of her document.

## Change
One decision point (`RetrievalService.assembleSourceContext`, auto scope, non-passthrough): retrieve raw top-k candidates; if any clear the existing cutoff, use them (unchanged confident path); if none clear it but there's exactly **one** content source, return the best candidates anyway — a single attached document is unambiguous intent. Zero FTS candidates (no shared vocabulary) still returns nil; multi-source weak matches still gate (discrimination preserved until R3 embeddings). No relaxed magic-number cutoff — the floor sidesteps threshold fragility so it can't un-gate the deliberately-gated unrelated case.

## Verified live (real Forth Programmer's Handbook stream, single source, 274pp)
- Paraphrased question dodging the book's vocabulary → 'Using retrieved source context (2 chunks)', answer cited the book with page links. Previously gated.
- Off-topic (pasta) control → floor retrieved 8 chunks, model ignored them and answered from general knowledge, no false provenance line. Discrimination intact.

## Tests
Two old-behavior tests deliberately flipped (with intent comments): single-source weak query now retrieves the floor chunk. Three added: zero-vocabulary still gates, multi-source weak still gates, multi-source strong still retrieves. All Swift gates + contract green (re-run independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)