### PR TITLE
H1.2: clipboard-rung wrong-capture guard (AX empty vs unavailable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Quick Panel now avoids copying an editor cursor line when Accessibility reports that no text is selected.
 - Debug builds now use a distinct bundle id and display name so they do not share the release app's macOS permission identity.
 - Bug report support bundles now include recent metadata logs, crash evidence, uptime, and prior-crash detection.
 - Selection action menus now re-clamp after measuring so they stay inside the editor shell.

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -260,17 +260,26 @@ struct QuickPanelView: View {
         let title = context.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
         let sourceApp = app?.isEmpty == false ? app : nil
         let sourceTitle = title?.isEmpty == false ? title : nil
+        let baseLabel: String?
 
         switch (sourceApp, sourceTitle) {
         case let (sourceApp?, sourceTitle?):
-            return "\(sourceApp) — \(truncate(sourceTitle, maxLength: 60))"
+            baseLabel = "\(sourceApp) — \(truncate(sourceTitle, maxLength: 60))"
         case let (sourceApp?, nil):
-            return sourceApp
+            baseLabel = sourceApp
         case let (nil, sourceTitle?):
-            return truncate(sourceTitle, maxLength: 60)
+            baseLabel = truncate(sourceTitle, maxLength: 60)
         case (nil, nil):
-            return nil
+            baseLabel = nil
         }
+
+        guard context.selectionCaptureOutcome == .clipboard else {
+            return baseLabel
+        }
+
+        return [baseLabel, "from clipboard"]
+            .compactMap { $0 }
+            .joined(separator: " · ")
     }
 
     private func truncate(_ text: String, maxLength: Int) -> String {

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -29,6 +29,12 @@ enum SelectionCaptureOutcome: Equatable {
     }
 }
 
+enum AXSelectionRead: Equatable {
+    case text(String)
+    case empty
+    case unavailable
+}
+
 struct SelectionCaptureResult: Equatable {
     let text: String?
     let outcome: SelectionCaptureOutcome
@@ -140,23 +146,29 @@ final class SelectionReaderService {
 
     static func captureExternalSelectedText(
         hasAccessibilityPermission: Bool,
-        axSelection: () -> String?,
+        axSelection: () -> AXSelectionRead,
         hintAccessibilityTree: () -> Void,
-        hintedAXSelection: () -> String?,
+        hintedAXSelection: () -> AXSelectionRead,
         clipboardSelection: () -> String?
     ) -> SelectionCaptureResult {
         guard hasAccessibilityPermission else {
             return SelectionCaptureResult(text: nil, outcome: .noPermission)
         }
 
-        if let text = nonEmptyText(axSelection()) {
+        let first = axSelection()
+        if case .text(let text) = first, let text = nonEmptyText(text) {
             return SelectionCaptureResult(text: text, outcome: .ax)
         }
 
         hintAccessibilityTree()
 
-        if let text = nonEmptyText(hintedAXSelection()) {
+        let second = hintedAXSelection()
+        if case .text(let text) = second, let text = nonEmptyText(text) {
             return SelectionCaptureResult(text: text, outcome: .axHinted)
+        }
+
+        guard second == .unavailable else {
+            return SelectionCaptureResult(text: nil, outcome: .emptyExternal)
         }
 
         if let text = nonEmptyText(clipboardSelection()) {
@@ -171,28 +183,24 @@ final class SelectionReaderService {
     /// Get currently selected text from the focused application
     /// Returns nil if no permission, no selection, or app doesn't support it
     func getSelectedText() -> String? {
-        guard cursorService.hasAccessibilityPermission else {
-            return nil
-        }
-
-        for attempt in 1...maxSelectionReadAttempts {
-            guard let focusedElement = getFocusedElement() else {
-                return nil
-            }
-
-            let selectionResult = extractSelectedText(from: focusedElement)
-            if let text = selectionResult.text {
-                return text
-            }
-
-            if attempt == maxSelectionReadAttempts || !shouldRetrySelectionRead(for: selectionResult.error) {
-                break
-            }
-
-            Thread.sleep(forTimeInterval: selectionReadRetryDelay)
+        if case .text(let text) = readSelection() {
+            return text
         }
 
         return nil
+    }
+
+    func readSelection() -> AXSelectionRead {
+        guard cursorService.hasAccessibilityPermission else {
+            return .unavailable
+        }
+
+        return readSelectionFromFocusedElement(
+            attempts: maxSelectionReadAttempts,
+            retryDelay: selectionReadRetryDelay,
+            retryMissingFocusedElement: false,
+            retryEmptySelection: false
+        )
     }
 
     func captureSelectedText() -> SelectionCaptureResult {
@@ -203,13 +211,13 @@ final class SelectionReaderService {
         let result = Self.captureExternalSelectedText(
             hasAccessibilityPermission: cursorService.hasAccessibilityPermission,
             axSelection: { [self] in
-                getSelectedText()
+                readSelection()
             },
             hintAccessibilityTree: { [self] in
                 useHintSettleBudget = hintAccessibilityTree(for: frontmostApp)
             },
             hintedAXSelection: { [self] in
-                readSelectedTextFromFocusedElement(
+                readSelectionFromFocusedElement(
                     attempts: useHintSettleBudget ? hintedSelectionReadAttempts : 1,
                     retryDelay: useHintSettleBudget ? hintedSelectionReadRetryDelay : 0,
                     retryMissingFocusedElement: useHintSettleBudget,
@@ -251,12 +259,12 @@ final class SelectionReaderService {
         return result == .apiDisabled
     }
 
-    private func readSelectedTextFromFocusedElement(
+    private func readSelectionFromFocusedElement(
         attempts: Int,
         retryDelay: TimeInterval,
         retryMissingFocusedElement: Bool,
         retryEmptySelection: Bool
-    ) -> String? {
+    ) -> AXSelectionRead {
         let cappedAttempts = max(1, attempts)
 
         for attempt in 1...cappedAttempts {
@@ -265,23 +273,26 @@ final class SelectionReaderService {
                     Thread.sleep(forTimeInterval: retryDelay)
                     continue
                 }
-                return nil
+                return .unavailable
             }
 
             let selectionResult = extractSelectedText(from: focusedElement)
             if let text = selectionResult.text {
-                return text
+                return .text(text)
             }
 
-            let shouldRetry = retryEmptySelection || shouldRetrySelectionRead(for: selectionResult.error)
+            let read: AXSelectionRead = selectionResult.error == nil ? .empty : .unavailable
+            let shouldRetry = read == .empty
+                ? retryEmptySelection
+                : shouldRetrySelectionRead(for: selectionResult.error)
             if attempt == cappedAttempts || !shouldRetry {
-                break
+                return read
             }
 
             Thread.sleep(forTimeInterval: retryDelay)
         }
 
-        return nil
+        return .unavailable
     }
 
     private func getFocusedElement() -> AXUIElement? {
@@ -457,7 +468,7 @@ final class SelectionReaderService {
     }
 
     private func copySelectedTextThroughClipboard(from app: NSRunningApplication?) -> String? {
-        guard let app else {
+        guard app != nil else {
             return nil
         }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -96,21 +96,21 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertFalse(localSelectionWasRequested)
     }
 
-    func test_selectionCaptureLadderRunsRungsInOrder() {
+    func test_selectionCaptureLadderUsesClipboardWhenAXUnavailable() {
         var calls: [String] = []
 
         let result = SelectionReaderService.captureExternalSelectedText(
             hasAccessibilityPermission: true,
             axSelection: {
                 calls.append("ax")
-                return nil
+                return .unavailable
             },
             hintAccessibilityTree: {
                 calls.append("hint")
             },
             hintedAXSelection: {
                 calls.append("hinted")
-                return nil
+                return .unavailable
             },
             clipboardSelection: {
                 calls.append("clipboard")
@@ -122,21 +122,47 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertEqual(calls, ["ax", "hint", "hinted", "clipboard"])
     }
 
-    func test_selectionCaptureLadderShortCircuitsOnFirstSuccess() {
+    func test_selectionCaptureLadderDoesNotClipboardWhenAXSaysEmpty() {
         var calls: [String] = []
 
         let result = SelectionReaderService.captureExternalSelectedText(
             hasAccessibilityPermission: true,
             axSelection: {
                 calls.append("ax")
-                return "AX selection"
+                return .empty
             },
             hintAccessibilityTree: {
                 calls.append("hint")
             },
             hintedAXSelection: {
                 calls.append("hinted")
-                return "Hinted selection"
+                return .empty
+            },
+            clipboardSelection: {
+                calls.append("clipboard")
+                return "Cursor line copied by editor"
+            }
+        )
+
+        XCTAssertEqual(result, SelectionCaptureResult(text: nil, outcome: .emptyExternal))
+        XCTAssertEqual(calls, ["ax", "hint", "hinted"])
+    }
+
+    func test_selectionCaptureLadderShortCircuitsOnAXText() {
+        var calls: [String] = []
+
+        let result = SelectionReaderService.captureExternalSelectedText(
+            hasAccessibilityPermission: true,
+            axSelection: {
+                calls.append("ax")
+                return .text("AX selection")
+            },
+            hintAccessibilityTree: {
+                calls.append("hint")
+            },
+            hintedAXSelection: {
+                calls.append("hinted")
+                return .text("Hinted selection")
             },
             clipboardSelection: {
                 calls.append("clipboard")
@@ -155,14 +181,14 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
             hasAccessibilityPermission: false,
             axSelection: {
                 calls.append("ax")
-                return "AX selection"
+                return .text("AX selection")
             },
             hintAccessibilityTree: {
                 calls.append("hint")
             },
             hintedAXSelection: {
                 calls.append("hinted")
-                return "Hinted selection"
+                return .text("Hinted selection")
             },
             clipboardSelection: {
                 calls.append("clipboard")


### PR DESCRIPTION
Roadmap 3 / Phase H1. Closes a latent bug shipped in 2026.7.2: the synthesized-⌘C capture rung could attach the *cursor line* in VS Code / Cursor / Zed (they copy the current line on ⌘C when nothing is selected).

## Fix — gate rung 3 on AX availability, not an app denylist
The capture ladder collapsed two different AX outcomes into nil. Now distinguished via `AXSelectionRead { text, empty, unavailable }`:
- **empty** = the app answered AXSelectedText successfully with no selection → there is genuinely nothing selected → do NOT synthesize a copy.
- **unavailable** = AX errored / app is AX-blind → we don't know → the clipboard rung may try.

So the synthetic ⌘C only fires when the app couldn't tell us about the selection (terminals like kitty), never when it told us the selection is empty (VS Code class). No hardcoded app list; generalizes to any copy-line editor. Attribution backstop: clipboard-derived context shows '· from clipboard' in the panel preview.

## Tests
Ladder tests extended: AX-empty → clipboard closure never called, outcome .emptyExternal (the guard); AX-unavailable → clipboard called, .clipboard; AX-text short-circuits; no-permission calls nothing. All Swift gates + contract green (re-run independently).

## One empirical note
Unit tests prove the gate; the assumption is that VS Code returns *success-empty* (not an error) when nothing is selected — could not probe live (no editor running). If a VS Code user still sees cursor-line capture, VS Code returns .unavailable on empty and the attribution marker is the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)