### PR TITLE
H3.1: recent-clipboard-text capture rung (terminal/AX-blind capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Quick Panel can now attach recently copied clipboard text as context when no live selection is available.
 - Quick panel now detects a stale Accessibility grant (permission shown as on but revoked by macOS) and says exactly how to fix it.
 - Sources can now be marked Private so their contents stay out of AI context while remaining locally searchable and readable.
 - Stream editor headers now keep long titles to one calm ellipsized line without crowding actions or document content.

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -90,9 +90,9 @@ struct QuickPanelStatus: Equatable {
             let appName = activeApp?.trimmingCharacters(in: .whitespacesAndNewlines)
             let message: String
             if let appName, !appName.isEmpty {
-                message = "No text selected in \(appName)"
+                message = "No text selected in \(appName) — copy it (⌘C) and press ⌘L to attach."
             } else {
-                message = "No text selected"
+                message = "No text selected — copy it (⌘C) and press ⌘L to attach."
             }
             return QuickPanelStatus(
                 message: message,
@@ -156,6 +156,7 @@ final class QuickPanelManager: ObservableObject {
     private var hostingView: NSHostingView<QuickPanelView>?
     private var currentAppearance: NSAppearance?  // Stored to apply when panel is created
     private var suppressedClipboardImageChangeCount: Int?
+    private var suppressedClipboardTextChangeCount: Int?
     private var presentationGeneration: Int = 0
 
     // MARK: - Initialization
@@ -216,13 +217,15 @@ final class QuickPanelManager: ObservableObject {
 
     private func toggleAfterCapturingContext() async {
         // Capture context BEFORE we steal focus
-        let capturedContext = contextRespectingDismissedClipboardImage(await buildContextForQuickPanelToggle())
+        let capturedContext = contextRespectingDismissedClipboardText(
+            contextRespectingDismissedClipboardImage(await buildContextForQuickPanelToggle())
+        )
         logCapturedContext(capturedContext)
 
         if isVisible {
             // Check if there's a new selection
-            let hasNewSelection = capturedContext.hasSelection &&
-                capturedContext.selectedText != context?.selectedText
+            let hasNewSelection = capturedContext.contextText != nil &&
+                capturedContext.contextText != context?.contextText
 
             if hasNewSelection {
                 // Update context in place, don't move the panel
@@ -242,6 +245,7 @@ final class QuickPanelManager: ObservableObject {
     private func buildContextForQuickPanelToggle() async -> QuickPanelContext {
         let activeBundleId = selectionService.getActiveAppBundleId()
         let appBundleId = Bundle.main.bundleIdentifier
+        let clipboardTextCandidate = SelectionReaderService.recentClipboardTextCandidate()
         let selectionResult = await SelectionReaderService.resolveSelectedTextWithOutcome(
             activeBundleId: activeBundleId,
             currentBundleId: appBundleId,
@@ -255,6 +259,7 @@ final class QuickPanelManager: ObservableObject {
 
         return selectionService.buildContext(
             selectedText: selectionResult.text,
+            clipboardTextCandidate: clipboardTextCandidate,
             selectionCaptureOutcome: selectionResult.outcome,
             readSelectionFromAX: false,
             panelSize: currentPanelSizeForPositioning()
@@ -276,6 +281,7 @@ final class QuickPanelManager: ObservableObject {
                 windowTitle: capturedContext.windowTitle,
                 panelPosition: capturedContext.panelPosition,
                 clipboardImage: imageData,
+                clipboardText: capturedContext.clipboardText,
                 isScreenshot: true,
                 selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
             )
@@ -302,6 +308,7 @@ final class QuickPanelManager: ObservableObject {
             windowTitle: capturedContext.windowTitle,
             panelPosition: capturedContext.panelPosition,
             clipboardImage: nil,
+            clipboardText: nil,
             isScreenshot: false,
             selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
         )
@@ -320,7 +327,7 @@ final class QuickPanelManager: ObservableObject {
         // Load available streams for picker
         loadAvailableStreams()
 
-        if showAccessibilityWarning && !capturedContext.hasSelection {
+        if showAccessibilityWarning && !capturedContext.hasSelection && !capturedContext.isClipboardTextContext {
             status = QuickPanelStatus.selectionCaptureStatus(
                 for: capturedContext.selectionCaptureOutcome,
                 activeApp: capturedContext.activeApp
@@ -463,14 +470,13 @@ final class QuickPanelManager: ObservableObject {
     }
 
     private func logCapturedContext(_ capturedContext: QuickPanelContext) {
-        let selectedLength = capturedContext.selectedText?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .count ?? 0
+        let contextTextLength = capturedContext.contextText?.count ?? 0
         DebugLog.log(
             "[QuickPanel] toggle captured context " +
             "axTrusted=\(cursorService.hasAccessibilityPermission) " +
             "hasSelection=\(capturedContext.hasSelection) " +
-            "selectedLength=\(selectedLength) " +
+            "isClipboardText=\(capturedContext.isClipboardTextContext) " +
+            "contextTextLength=\(contextTextLength) " +
             "hasImage=\(capturedContext.hasImage) " +
             "activeApp=\(capturedContext.activeApp ?? "unknown")"
         )
@@ -510,7 +516,7 @@ final class QuickPanelManager: ObservableObject {
 
         // Build context for first turn only
         let isFirstTurn = ephemeralConversation.turns.isEmpty
-        let contextForAI: String? = isFirstTurn ? context?.selectedText : nil
+        let contextForAI: String? = isFirstTurn ? context?.contextText : nil
 
         // Record user turn
         ephemeralConversation.turns.append(ConversationTurn(
@@ -588,7 +594,7 @@ final class QuickPanelManager: ObservableObject {
 
         // Second: clear input/context
         if !inputText.isEmpty || context?.hasContent == true {
-            suppressDismissedClipboardImageIfNeeded()
+            suppressDismissedClipboardContextIfNeeded()
             inputText = ""
             context = nil
             return
@@ -600,7 +606,7 @@ final class QuickPanelManager: ObservableObject {
 
     /// Clear attached context
     func clearContext() {
-        suppressDismissedClipboardImageIfNeeded()
+        suppressDismissedClipboardContextIfNeeded()
         context = nil
     }
 
@@ -618,10 +624,21 @@ final class QuickPanelManager: ObservableObject {
         ephemeralConversation.clear()
     }
 
+    private func suppressDismissedClipboardContextIfNeeded() {
+        suppressDismissedClipboardImageIfNeeded()
+        suppressDismissedClipboardTextIfNeeded()
+    }
+
     /// Suppress reattaching the current clipboard image on Cmd+L until clipboard changes.
     private func suppressDismissedClipboardImageIfNeeded() {
         guard context?.hasImage == true else { return }
         suppressedClipboardImageChangeCount = ClipboardService.changeCount()
+    }
+
+    /// Suppress reattaching the current clipboard text on Cmd+L until clipboard changes.
+    private func suppressDismissedClipboardTextIfNeeded() {
+        guard context?.isClipboardTextContext == true else { return }
+        suppressedClipboardTextChangeCount = ClipboardService.changeCount()
     }
 
     /// Applies explicit image-dismissal state to freshly captured context.
@@ -644,7 +661,45 @@ final class QuickPanelManager: ObservableObject {
             windowTitle: capturedContext.windowTitle,
             panelPosition: capturedContext.panelPosition,
             clipboardImage: nil,
+            clipboardText: capturedContext.clipboardText,
             isScreenshot: false,
+            selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
+        )
+    }
+
+    /// Applies explicit text-dismissal state to freshly captured context.
+    private func contextRespectingDismissedClipboardText(_ capturedContext: QuickPanelContext) -> QuickPanelContext {
+        let currentClipboardChangeCount = ClipboardService.changeCount()
+        return Self.contextRespectingDismissedClipboardText(
+            capturedContext,
+            suppressedChangeCount: &suppressedClipboardTextChangeCount,
+            currentClipboardChangeCount: currentClipboardChangeCount
+        )
+    }
+
+    static func contextRespectingDismissedClipboardText(
+        _ capturedContext: QuickPanelContext,
+        suppressedChangeCount: inout Int?,
+        currentClipboardChangeCount: Int
+    ) -> QuickPanelContext {
+        if let suppressedCount = suppressedChangeCount,
+           suppressedCount != currentClipboardChangeCount {
+            suppressedChangeCount = nil
+        }
+
+        guard capturedContext.isClipboardTextContext,
+              suppressedChangeCount == currentClipboardChangeCount else {
+            return capturedContext
+        }
+
+        return QuickPanelContext(
+            selectedText: capturedContext.selectedText,
+            activeApp: capturedContext.activeApp,
+            windowTitle: capturedContext.windowTitle,
+            panelPosition: capturedContext.panelPosition,
+            clipboardImage: capturedContext.clipboardImage,
+            clipboardText: nil,
+            isScreenshot: capturedContext.isScreenshot,
             selectionCaptureOutcome: capturedContext.selectionCaptureOutcome
         )
     }
@@ -658,7 +713,7 @@ final class QuickPanelManager: ObservableObject {
             return
         }
 
-        let hasContext = nonEmptyTrimmed(context?.selectedText) != nil || context?.clipboardImage != nil
+        let hasContext = context?.hasContext == true
         let prompt = nonEmptyTrimmed(inputText)
         let hasInput = prompt != nil
 
@@ -1048,8 +1103,8 @@ enum QuickPanelMarkdownFormatter {
         var blocks: [String] = []
 
         if let context {
-            if let selectedText = nonEmptyTrimmed(context.selectedText) {
-                blocks.append(markdownBlockquote(selectedText))
+            if let contextText = nonEmptyTrimmed(context.contextText) {
+                blocks.append(markdownBlockquote(contextText))
 
                 if let source = sourceAttribution(for: context) {
                     blocks.append("*— \(escapeMarkdownEmphasis(source))*")

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -146,8 +146,8 @@ struct QuickPanelView: View {
 
     @ViewBuilder
     private func contextBadge(context: QuickPanelContext) -> some View {
-        if let selectedText = context.trimmedSelectedText {
-            selectedTextContextPreview(context: context, selectedText: selectedText)
+        if let contextText = context.contextText {
+            selectedTextContextPreview(context: context, selectedText: contextText)
         } else {
             attachmentContextBadge(context: context)
         }
@@ -243,7 +243,7 @@ struct QuickPanelView: View {
         if context.isScreenshot {
             return "Screenshot attached"
         }
-        if let text = context.trimmedSelectedText {
+        if let text = context.contextText {
             if text.count > 40 {
                 return String(text.prefix(37)) + "..."
             }
@@ -273,13 +273,12 @@ struct QuickPanelView: View {
             baseLabel = nil
         }
 
-        guard context.selectionCaptureOutcome == .clipboard else {
+        let isClipboardText = context.selectionCaptureOutcome == .clipboard || context.isClipboardTextContext
+        guard isClipboardText else {
             return baseLabel
         }
 
-        return [baseLabel, "from clipboard"]
-            .compactMap { $0 }
-            .joined(separator: " · ")
+        return "\(baseLabel ?? "Copied text") · from clipboard"
     }
 
     private func truncate(_ text: String, maxLength: Int) -> String {

--- a/Sources/Ticker/Services/System/ClipboardService.swift
+++ b/Sources/Ticker/Services/System/ClipboardService.swift
@@ -4,12 +4,24 @@ import AppKit
 enum ClipboardService {
 
     /// Track last known change count and when it changed
-    private static var lastChangeCount: Int = NSPasteboard.general.changeCount
-    private static var lastChangeTime: Date = Date.distantPast
+    private struct ChangeTracker {
+        var lastChangeCount: Int
+        var lastChangeTime: Date
+    }
+
+    private static var changeTrackers: [NSPasteboard.Name: ChangeTracker] = [
+        .general: ChangeTracker(
+            lastChangeCount: NSPasteboard.general.changeCount,
+            lastChangeTime: .distantPast
+        )
+    ]
+
+    static let concealedType = NSPasteboard.PasteboardType("org.nspasteboard.ConcealedType")
+    static let transientType = NSPasteboard.PasteboardType("org.nspasteboard.TransientType")
 
     /// Get current clipboard text
-    static func getText() -> String? {
-        NSPasteboard.general.string(forType: .string)
+    static func getText(pasteboard: NSPasteboard = .general) -> String? {
+        pasteboard.string(forType: .string)
     }
 
     /// Check if clipboard contains an image
@@ -60,23 +72,55 @@ enum ClipboardService {
     }
 
     /// Get clipboard change count (to detect changes)
-    static func changeCount() -> Int {
-        NSPasteboard.general.changeCount
+    static func changeCount(pasteboard: NSPasteboard = .general) -> Int {
+        pasteboard.changeCount
     }
 
     /// Check if clipboard was recently modified (within threshold)
     /// Updates internal tracking on each call
-    static func wasRecentlyModified(threshold: TimeInterval = 60) -> Bool {
-        let currentCount = NSPasteboard.general.changeCount
+    static func wasRecentlyModified(
+        threshold: TimeInterval = 60,
+        pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        let currentCount = pasteboard.changeCount
+        var tracker = changeTracker(for: pasteboard)
 
         // If change count differs, clipboard was modified
-        if currentCount != lastChangeCount {
-            lastChangeCount = currentCount
-            lastChangeTime = Date()
+        if currentCount != tracker.lastChangeCount {
+            tracker.lastChangeCount = currentCount
+            tracker.lastChangeTime = Date()
+            changeTrackers[pasteboard.name] = tracker
             return true
         }
 
         // Check if last change was within threshold
-        return Date().timeIntervalSince(lastChangeTime) < threshold
+        changeTrackers[pasteboard.name] = tracker
+        return Date().timeIntervalSince(tracker.lastChangeTime) < threshold
+    }
+
+    /// A synthetic copy/restore cycle can bump changeCount without being user intent.
+    /// Sync the count while preserving lastChangeTime so only genuine copies remain recent.
+    static func syncChangeCount(pasteboard: NSPasteboard = .general) {
+        var tracker = changeTracker(for: pasteboard)
+        tracker.lastChangeCount = pasteboard.changeCount
+        changeTrackers[pasteboard.name] = tracker
+    }
+
+    static func hasConcealedOrTransientTypes(pasteboard: NSPasteboard = .general) -> Bool {
+        let types = pasteboard.types ?? []
+        return types.contains(concealedType) || types.contains(transientType)
+    }
+
+    private static func changeTracker(for pasteboard: NSPasteboard) -> ChangeTracker {
+        if let tracker = changeTrackers[pasteboard.name] {
+            return tracker
+        }
+
+        let tracker = ChangeTracker(
+            lastChangeCount: pasteboard.changeCount,
+            lastChangeTime: .distantPast
+        )
+        changeTrackers[pasteboard.name] = tracker
+        return tracker
     }
 }

--- a/Sources/Ticker/Services/System/SelectionReaderService.swift
+++ b/Sources/Ticker/Services/System/SelectionReaderService.swift
@@ -98,6 +98,8 @@ final class SelectionReaderService {
     private let hintedSelectionReadRetryDelay: TimeInterval = 0.05
     private let clipboardPollAttempts = 15
     private let clipboardPollDelay: TimeInterval = 0.02
+    private static let recentClipboardTextThreshold: TimeInterval = 15
+    private static let maxClipboardTextContextLength = 10_000
     private var hintedApplicationPIDs = Set<pid_t>()
 
     private static let axEnhancedUserInterfaceAttribute = "AXEnhancedUserInterface" as CFString
@@ -479,6 +481,9 @@ final class SelectionReaderService {
         // (kitty, Alacritty) never see pid-targeted events. Capture runs before the
         // panel shows, so the target app is still the focused one.
         postCopyShortcut()
+        defer {
+            ClipboardService.syncChangeCount(pasteboard: pasteboard)
+        }
 
         guard waitForPasteboardChange(pasteboard, after: snapshot.changeCount) else {
             return nil
@@ -594,6 +599,7 @@ final class SelectionReaderService {
     /// Captures everything at once BEFORE focus changes
     func buildContext(
         selectedText providedSelectedText: String? = nil,
+        clipboardTextCandidate: String? = nil,
         selectionCaptureOutcome: SelectionCaptureOutcome = .notAttempted,
         readSelectionFromAX: Bool = true,
         panelSize: CGSize = CGSize(width: QuickPanelWindow.defaultWidth, height: QuickPanelWindow.minHeight)
@@ -605,10 +611,12 @@ final class SelectionReaderService {
         let position = cursorService.calculatePanelPosition(panelSize: panelSize)
 
         let selectedText = providedSelectedText ?? (readSelectionFromAX ? getSelectedText() : nil)
+        let hasSelectedText = Self.nonEmptyText(selectedText) != nil
+        let clipboardText = hasSelectedText ? nil : Self.nonEmptyText(clipboardTextCandidate)
 
-        // Only grab clipboard image if no text selection
+        // Only grab clipboard image if no text context.
         var clipboardImageData: Data? = nil
-        if selectedText == nil || selectedText?.isEmpty == true {
+        if !hasSelectedText && clipboardText == nil {
             clipboardImageData = getRecentClipboardImage()
         }
 
@@ -618,13 +626,14 @@ final class SelectionReaderService {
             windowTitle: getActiveWindowTitle(),
             panelPosition: position,
             clipboardImage: clipboardImageData,
+            clipboardText: clipboardText,
             isScreenshot: false,
             selectionCaptureOutcome: selectionCaptureOutcome
         )
         DebugLog.log(
             "[SelectionReader] buildContext result " +
             "hasSelection=\(context.hasSelection) " +
-            "selectedLength=\(context.trimmedSelectedText?.count ?? 0) " +
+            "contextTextLength=\(context.contextText?.count ?? 0) " +
             "hasImage=\(context.hasImage) " +
             "activeApp=\(context.activeApp ?? "unknown")"
         )
@@ -644,6 +653,28 @@ final class SelectionReaderService {
 
         return ClipboardService.getImageData()
     }
+
+    static func recentClipboardTextCandidate(
+        pasteboard: NSPasteboard = .general,
+        threshold: TimeInterval = recentClipboardTextThreshold,
+        maxLength: Int = maxClipboardTextContextLength
+    ) -> String? {
+        guard ClipboardService.wasRecentlyModified(threshold: threshold, pasteboard: pasteboard),
+              !ClipboardService.hasConcealedOrTransientTypes(pasteboard: pasteboard),
+              let rawText = ClipboardService.getText(pasteboard: pasteboard) else {
+            return nil
+        }
+
+        guard let text = Self.nonEmptyText(rawText.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return nil
+        }
+
+        guard text.count > maxLength else {
+            return text
+        }
+
+        return String(text.prefix(maxLength)) + "…"
+    }
 }
 
 /// Context captured when Quick Panel is invoked
@@ -655,6 +686,8 @@ struct QuickPanelContext {
     let panelPosition: CGPoint
     /// Clipboard image data (if no text selection and clipboard has image)
     let clipboardImage: Data?
+    /// Recent user-copied clipboard text used as context when no real selection exists.
+    let clipboardText: String?
     /// True only for explicit app-initiated screenshot mode (currently deprecated).
     /// Clipboard-derived images should keep this false.
     let isScreenshot: Bool
@@ -667,6 +700,7 @@ struct QuickPanelContext {
         windowTitle: String?,
         panelPosition: CGPoint,
         clipboardImage: Data?,
+        clipboardText: String? = nil,
         isScreenshot: Bool,
         selectionCaptureOutcome: SelectionCaptureOutcome = .notAttempted
     ) {
@@ -675,6 +709,7 @@ struct QuickPanelContext {
         self.windowTitle = windowTitle
         self.panelPosition = panelPosition
         self.clipboardImage = clipboardImage
+        self.clipboardText = clipboardText
         self.isScreenshot = isScreenshot
         self.selectionCaptureOutcome = selectionCaptureOutcome
     }
@@ -687,6 +722,22 @@ struct QuickPanelContext {
         return trimmed
     }
 
+    var trimmedClipboardText: String? {
+        guard let trimmed = clipboardText?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    var contextText: String? {
+        trimmedSelectedText ?? trimmedClipboardText
+    }
+
+    var isClipboardTextContext: Bool {
+        trimmedSelectedText == nil && trimmedClipboardText != nil
+    }
+
     var hasSelection: Bool {
         trimmedSelectedText != nil
     }
@@ -695,8 +746,12 @@ struct QuickPanelContext {
         clipboardImage != nil
     }
 
+    var hasContext: Bool {
+        contextText != nil || hasImage
+    }
+
     var hasContent: Bool {
-        hasSelection || hasImage
+        hasContext
     }
 
     /// Truncated preview of selected text for display

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -36,6 +36,139 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         """)
     }
 
+    func test_buildFragment_usesClipboardTextAsBlockquoteContext() throws {
+        let context = QuickPanelContext(
+            selectedText: nil,
+            activeApp: "Terminal",
+            windowTitle: "Shell",
+            panelPosition: CGPoint(x: 0, y: 0),
+            clipboardImage: nil,
+            clipboardText: " Copied line ",
+            isScreenshot: false
+        )
+
+        let fragment = try QuickPanelMarkdownFormatter.buildFragment(
+            context: context,
+            inputText: ""
+        ) { _ in
+            XCTFail("Image formatter should not run for text-only context")
+            return ""
+        }
+
+        XCTAssertEqual(context.contextText, "Copied line")
+        XCTAssertTrue(context.isClipboardTextContext)
+        XCTAssertEqual(fragment, """
+        > Copied line
+
+        *— Terminal — Shell*
+        """)
+    }
+
+    func test_recentClipboardTextCandidateReturnsRecentPlainText() throws {
+        let pasteboard = makeTrackedPasteboard()
+        defer { pasteboard.clearContents() }
+
+        writeText(" Copied text ", to: pasteboard)
+
+        XCTAssertEqual(
+            SelectionReaderService.recentClipboardTextCandidate(pasteboard: pasteboard),
+            "Copied text"
+        )
+    }
+
+    func test_recentClipboardTextCandidateRejectsStaleEmptyAndPrivateText() throws {
+        let stalePasteboard = makeTrackedPasteboard()
+        defer { stalePasteboard.clearContents() }
+        writeText("Stale text", to: stalePasteboard)
+        ClipboardService.syncChangeCount(pasteboard: stalePasteboard)
+        XCTAssertNil(SelectionReaderService.recentClipboardTextCandidate(pasteboard: stalePasteboard))
+
+        let emptyPasteboard = makeTrackedPasteboard()
+        defer { emptyPasteboard.clearContents() }
+        writeText(" \n\t ", to: emptyPasteboard)
+        XCTAssertNil(SelectionReaderService.recentClipboardTextCandidate(pasteboard: emptyPasteboard))
+
+        let concealedPasteboard = makeTrackedPasteboard()
+        defer { concealedPasteboard.clearContents() }
+        writeText("Password", to: concealedPasteboard, extraTypes: [ClipboardService.concealedType])
+        XCTAssertNil(SelectionReaderService.recentClipboardTextCandidate(pasteboard: concealedPasteboard))
+
+        let transientPasteboard = makeTrackedPasteboard()
+        defer { transientPasteboard.clearContents() }
+        writeText("Transient", to: transientPasteboard, extraTypes: [ClipboardService.transientType])
+        XCTAssertNil(SelectionReaderService.recentClipboardTextCandidate(pasteboard: transientPasteboard))
+    }
+
+    func test_recentClipboardTextCandidateTruncatesLongText() throws {
+        let pasteboard = makeTrackedPasteboard()
+        defer { pasteboard.clearContents() }
+        writeText(String(repeating: "x", count: 10_005), to: pasteboard)
+
+        let result = try XCTUnwrap(SelectionReaderService.recentClipboardTextCandidate(pasteboard: pasteboard))
+
+        XCTAssertEqual(result.count, 10_001)
+        XCTAssertEqual(result.last, "…")
+        XCTAssertEqual(result.dropLast().count, 10_000)
+    }
+
+    func test_clipboardSyncChangeCountIgnoresSyntheticCopyRestoreBumps() throws {
+        let pasteboard = makeTrackedPasteboard()
+        defer { pasteboard.clearContents() }
+        let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+
+        writeText("Synthetic copy", to: pasteboard)
+        snapshot.restore(to: pasteboard)
+        ClipboardService.syncChangeCount(pasteboard: pasteboard)
+
+        XCTAssertFalse(ClipboardService.wasRecentlyModified(threshold: 15, pasteboard: pasteboard))
+
+        writeText("Genuine copy", to: pasteboard)
+        XCTAssertTrue(ClipboardService.wasRecentlyModified(threshold: 15, pasteboard: pasteboard))
+    }
+
+    func test_buildContextPrefersSelectionOverClipboardText() {
+        let context = SelectionReaderService().buildContext(
+            selectedText: " Selected text ",
+            clipboardTextCandidate: "Copied text",
+            readSelectionFromAX: false
+        )
+
+        XCTAssertEqual(context.contextText, "Selected text")
+        XCTAssertNil(context.clipboardText)
+        XCTAssertTrue(context.hasSelection)
+        XCTAssertFalse(context.isClipboardTextContext)
+    }
+
+    @MainActor
+    func test_clipboardTextDismissSuppressionSkipsSameChangeCountOnly() {
+        let context = QuickPanelContext(
+            selectedText: nil,
+            activeApp: "Terminal",
+            windowTitle: nil,
+            panelPosition: CGPoint(x: 0, y: 0),
+            clipboardImage: nil,
+            clipboardText: "Copied text",
+            isScreenshot: false
+        )
+        var suppressedChangeCount: Int? = 7
+
+        let sameCopy = QuickPanelManager.contextRespectingDismissedClipboardText(
+            context,
+            suppressedChangeCount: &suppressedChangeCount,
+            currentClipboardChangeCount: 7
+        )
+        XCTAssertNil(sameCopy.clipboardText)
+        XCTAssertEqual(suppressedChangeCount, 7)
+
+        let newCopy = QuickPanelManager.contextRespectingDismissedClipboardText(
+            context,
+            suppressedChangeCount: &suppressedChangeCount,
+            currentClipboardChangeCount: 8
+        )
+        XCTAssertEqual(newCopy.clipboardText, "Copied text")
+        XCTAssertNil(suppressedChangeCount)
+    }
+
     @MainActor
     func test_localSelectionProviderPrefersPDFSelectionOverEditorSelection() async {
         var editorSelectionWasRequested = false
@@ -220,7 +353,7 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertEqual(
             QuickPanelStatus.selectionCaptureStatus(for: .emptyExternal, activeApp: "Chrome"),
             QuickPanelStatus(
-                message: "No text selected in Chrome",
+                message: "No text selected in Chrome — copy it (⌘C) and press ⌘L to attach.",
                 tone: .info,
                 action: nil
             )
@@ -228,7 +361,7 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertEqual(
             QuickPanelStatus.selectionCaptureStatus(for: .emptyExternal, activeApp: " "),
             QuickPanelStatus(
-                message: "No text selected",
+                message: "No text selected — copy it (⌘C) and press ⌘L to attach.",
                 tone: .info,
                 action: nil
             )
@@ -269,6 +402,29 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         XCTAssertEqual(restoredItems[0].string(forType: .string), "Original string")
         XCTAssertEqual(restoredItems[0].data(forType: binaryType), binaryData)
         XCTAssertEqual(restoredItems[1].string(forType: customTextType), "Custom payload")
+    }
+
+    private func makeTrackedPasteboard() -> NSPasteboard {
+        let pasteboardName = NSPasteboard.Name("TickerClipboardTextTests.\(UUID().uuidString)")
+        let pasteboard = NSPasteboard(name: pasteboardName)
+        pasteboard.clearContents()
+        ClipboardService.syncChangeCount(pasteboard: pasteboard)
+        return pasteboard
+    }
+
+    private func writeText(
+        _ text: String,
+        to pasteboard: NSPasteboard,
+        extraTypes: [NSPasteboard.PasteboardType] = []
+    ) {
+        let item = NSPasteboardItem()
+        XCTAssertTrue(item.setString(text, forType: .string))
+        for type in extraTypes {
+            XCTAssertTrue(item.setString("", forType: type))
+        }
+
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([item]))
     }
 }
 


### PR DESCRIPTION
Roadmap 3 / Phase H3. Restores capture for terminals and any AX-blind app (kitty, Alacritty, remote desktops) via an accessibility-independent path: copy text (⌘C), press ⌘L within 15 seconds → the copied text attaches as quick-panel context, attributed and dismissible.

## Verified live
kitty: copy → ⌘L → 'isClipboardText=true, contextTextLength=31, activeApp=kitty' — captured with no AX involvement (kitty exposes no usable AXSelectedText on macOS 26). This is the durable answer to the whole kitty/terminal-capture problem.

## Design (mirrors the existing recent-clipboard-image affordance)
- `recentClipboardTextCandidate()` read BEFORE the selection ladder runs, so the synthetic-⌘C rung cannot manufacture a false 'you just copied this'.
- `ClipboardService.syncChangeCount()` after the synthetic rung's restore absorbs its own changeCount bumps → a stale copy isn't re-offered next ⌘L.
- Privacy: pasteboard items marked `org.nspasteboard.ConcealedType`/`TransientType` (password managers) are skipped; text capped at 10k chars.
- Selection always wins: clipboard text attaches only when the resolved selection is empty. `contextText = selection ?? clipboardText` routes save-as-quote / AI context / new-context detection.
- Dismissible via `suppressedClipboardTextChangeCount` (mirrors image dismissal). Attributed '· from clipboard' in the panel preview. Empty-capture status now teaches the gesture: 'No text selected in <App> — copy it (⌘C) and press ⌘L to attach.'

## Tests
Candidate logic (recent/stale/empty/concealed/transient/cap), selection precedence, no-self-pollution (syncChangeCount absorbs synthetic bumps via injectable pasteboard seam), dismiss round-trip, contextText routing. All Swift gates + contract green (re-run independently). No bridge/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)