### PR TITLE
H1.3 (partial): clear crash sentinel on Sparkle relaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Bug reports no longer falsely claim the previous session crashed after an app auto-update.
 - Quick Panel now avoids copying an editor cursor line when Accessibility reports that no text is selected.
 - Debug builds now use a distinct bundle id and display name so they do not share the release app's macOS permission identity.
 - Bug report support bundles now include recent metadata logs, crash evidence, uptime, and prior-crash detection.

--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -36,10 +36,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var quickPanelManager: QuickPanelManager?
     private var pdfFindKeyMonitor: Any?
 
-    // Sparkle updater (lives for app lifetime)
-    private let updaterController = SPUStandardUpdaterController(
+    // Sparkle updater (lives for app lifetime). Delegate is self so we can clear the
+    // crash sentinel before Sparkle relaunches — an update relaunch does not reliably
+    // fire applicationWillTerminate, which would otherwise report a false crash.
+    private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
-        updaterDelegate: nil,
+        updaterDelegate: self,
         userDriverDelegate: nil
     )
 
@@ -426,5 +428,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         quickPanelManager?.showWithStatusMessage(
             "Screenshot mode is deprecated. Use macOS screenshot shortcuts, then press Cmd+L."
         )
+    }
+}
+
+extension AppDelegate: SPUUpdaterDelegate {
+    /// Sparkle relaunches the app to finish an update; that path does not reliably fire
+    /// applicationWillTerminate, so clear the crash sentinel here to avoid a false
+    /// "last session crashed" in the first feedback after an update.
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        CrashSessionSentinel.markCleanTermination()
     }
 }


### PR DESCRIPTION
Roadmap 3 / Phase H1. Fixes a false-positive in the crash diagnostics shipped in 2026.7.2.

## Bug
The FF4 crash sentinel writes `session.lock` on launch and clears it in `applicationWillTerminate`. Sparkle's update relaunch does not reliably fire `applicationWillTerminate`, so the marker survives the update and the **first feedback after every auto-update falsely reports `last_session_crashed=true`** — quietly poisoning the diagnostics.

## Fix
The Sparkle updater now uses AppDelegate as its `SPUUpdaterDelegate` and clears the sentinel in `updaterWillRelaunchApplication(_:)`, the reliable pre-relaunch hook. The normal-quit path (`applicationWillTerminate`) is unchanged, so both the relaunch-now and install-on-quit update flows clear the marker.

Genuine crashes (no clean terminate, no Sparkle relaunch) still leave the marker → still reported. Scope note: this is the unblocked half of H1.3; the tester's actual crash stays blocked on their .ips.

Swift build + tests + contract green (independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)