### PR TITLE
Roadmap 4 P2: document dignity (open moment, links, PDF resume/outline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- PDF sources now reopen to the last-read page, expose document outlines when available, and describe pane failures in text.
 - Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.
 - Quick Panel can now attach recently copied clipboard text as context when no live selection is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -30,6 +30,7 @@ enum StreamCodec {
                 "streamId": document.streamId.uuidString,
                 "markdown": document.markdown,
                 "revision": document.revision,
+                "scrollOffset": document.scrollOffset,
                 "createdAt": formatter.string(from: document.createdAt),
                 "updatedAt": formatter.string(from: document.updatedAt)
             ]

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -49,6 +49,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "updateStreamTitle",
         "deleteStream",
         "saveStreamDocument",
+        "saveScrollPosition",
         "exportStream"
     ]
 
@@ -97,7 +98,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     let document = try persistence.loadOrCreateStreamDocument(streamId: id)
 
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                    let payload: [String: AnyCodable] = [
+                        "stream": AnyCodable(streamPayload),
+                        "scrollOffset": AnyCodable(document.scrollOffset)
+                    ]
+                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
                     ingestService?.enqueuePendingSources(for: id)
                 }
             } catch {
@@ -111,7 +116,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 delegate?.setCurrentStreamIdForFileDrops(stream.id)
                 let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
                 let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                let payload: [String: AnyCodable] = [
+                    "stream": AnyCodable(streamPayload),
+                    "scrollOffset": AnyCodable(document.scrollOffset)
+                ]
+                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
             }
@@ -192,6 +201,21 @@ final class StreamMessageHandler: BridgeMessageHandler {
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
                 await bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+            }
+
+        case "saveScrollPosition":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let offset = payload["offset"]?.doubleValue else {
+                DebugLog.log("[WebViewManager] Invalid saveScrollPosition payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveScrollPosition payload")
+                return
+            }
+            do {
+                try persistence.saveScrollOffset(streamId: streamId, offset: offset)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -50,6 +50,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "deleteStream",
         "saveStreamDocument",
         "saveScrollPosition",
+        "openExternalURL",
         "exportStream"
     ]
 
@@ -216,6 +217,23 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 try persistence.saveScrollOffset(streamId: streamId, offset: offset)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "openExternalURL":
+            guard let payload = message.payload,
+                  let rawURL = payload["url"]?.value as? String,
+                  rawURL.range(of: #"^https?://"#, options: [.regularExpression, .caseInsensitive]) != nil,
+                  let components = URLComponents(string: rawURL),
+                  let scheme = components.scheme?.lowercased(),
+                  (scheme == "http" || scheme == "https"),
+                  components.host != nil,
+                  let url = components.url else {
+                DebugLog.log("[StreamMessageHandler] Rejected external URL")
+                return
+            }
+
+            await MainActor.run {
+                _ = NSWorkspace.shared.open(url)
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -381,10 +381,17 @@ private final class PDFPaneFindSearchField: NSSearchField {
     }
 }
 
+private struct PDFOutlineSidebarEntry {
+    let title: String
+    let destination: PDFDestination?
+    let depth: Int
+}
+
 final class PDFReaderPaneController: NSViewController {
     var onLinkSelection: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPlaced: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPickCancelled: ((UUID) -> Void)?
+    var onPageChanged: ((UUID, Int) -> Void)?
     var highlightsProvider: ((UUID) -> [PDFHighlightRecord])?
     var onClose: (() -> Void)?
 
@@ -394,6 +401,7 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfPaneTitleField = NSTextField(labelWithString: "")
     private let pdfPaneStatusField = NSTextField(labelWithString: "")
     private let pdfPaneHintIconView = NSImageView(frame: .zero)
+    private let pdfPaneOutlineButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneLinkButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneCloseButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindBarView = NSView(frame: .zero)
@@ -401,9 +409,13 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfFindCounterField = NSTextField(labelWithString: "")
     private let pdfFindPreviousButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindNextButton = NSButton(title: "", target: nil, action: nil)
+    private let pdfOutlineScrollView = NSScrollView(frame: .zero)
+    private let pdfOutlineStackView = NSStackView(frame: .zero)
     private let pdfPanePDFView = PDFView(frame: .zero)
     private var pdfPaneWidthConstraint: NSLayoutConstraint?
     private var pdfFindBarHeightConstraint: NSLayoutConstraint?
+    private var pdfOutlineWidthConstraint: NSLayoutConstraint?
+    private var pdfPaneOutlineButtonWidthConstraint: NSLayoutConstraint?
     private var pdfPaneStatusLeadingConstraint: NSLayoutConstraint?
     private var pdfPaneStatusHintLeadingConstraint: NSLayoutConstraint?
     private var isPDFPaneVisible = false
@@ -423,9 +435,16 @@ final class PDFReaderPaneController: NSViewController {
     private var pdfFindMatches: [PDFSelection] = []
     private var pdfFindCurrentIndex: Int?
     private var pdfFindIsCapped = false
+    private var pdfPageSaveWorkItem: DispatchWorkItem?
+    private var pdfPaneMessageWorkItem: DispatchWorkItem?
+    private var pdfPaneTransientMessage: String?
+    private var pdfOutlineEntries: [PDFOutlineSidebarEntry] = []
+    private var isPDFOutlineVisible = false
 
     deinit {
         pdfFindDebounceWorkItem?.cancel()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self)
         exitAnchorPickMode(notifyCancelled: false)
         releaseActivePDFContext()
@@ -436,7 +455,7 @@ final class PDFReaderPaneController: NSViewController {
         configurePDFPane()
     }
 
-    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String) throws {
+    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String, lastPageIndex: Int? = nil) throws {
         if let existing = activePDFContext, existing.sourceId != sourceId {
             exitAnchorPickMode(notifyCancelled: true)
             releaseActivePDFContext()
@@ -460,6 +479,7 @@ final class PDFReaderPaneController: NSViewController {
         }
 
         pdfPanePDFView.document = document
+        configurePDFOutline(document: document)
         setPDFPaneHeader(displayName: displayName)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -470,6 +490,9 @@ final class PDFReaderPaneController: NSViewController {
             fileURL: url
         )
         applySavedHighlights(sourceId: sourceId)
+        if let lastPageIndex {
+            navigate(toPageIndex: lastPageIndex)
+        }
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -691,6 +714,7 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneTitleField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneStatusField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneHintIconView.translatesAutoresizingMaskIntoConstraints = false
+        pdfPaneOutlineButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneLinkButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneCloseButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindBarView.translatesAutoresizingMaskIntoConstraints = false
@@ -698,6 +722,8 @@ final class PDFReaderPaneController: NSViewController {
         pdfFindCounterField.translatesAutoresizingMaskIntoConstraints = false
         pdfFindPreviousButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindNextButton.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineScrollView.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineStackView.translatesAutoresizingMaskIntoConstraints = false
         pdfPanePDFView.translatesAutoresizingMaskIntoConstraints = false
 
         pdfPaneResizeHandle.wantsLayer = true
@@ -729,6 +755,23 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneHintIconView.imageScaling = .scaleProportionallyDown
         pdfPaneHintIconView.contentTintColor = PDFPaneStyle.accent
         pdfPaneHintIconView.isHidden = true
+
+        pdfPaneOutlineButton.target = self
+        pdfPaneOutlineButton.action = #selector(handlePDFOutlineToggle)
+        pdfPaneOutlineButton.bezelStyle = .texturedRounded
+        pdfPaneOutlineButton.controlSize = .small
+        pdfPaneOutlineButton.image = NSImage(systemSymbolName: "list.bullet", accessibilityDescription: nil)
+        pdfPaneOutlineButton.imagePosition = .imageOnly
+        pdfPaneOutlineButton.imageScaling = .scaleProportionallyDown
+        pdfPaneOutlineButton.isBordered = true
+        pdfPaneOutlineButton.showsBorderOnlyWhileMouseInside = true
+        pdfPaneOutlineButton.contentTintColor = PDFPaneStyle.textMuted
+        pdfPaneOutlineButton.toolTip = "Show outline"
+        pdfPaneOutlineButton.setAccessibilityLabel("Toggle PDF outline")
+        pdfPaneOutlineButton.setButtonType(.toggle)
+        pdfPaneOutlineButton.isHidden = true
+        pdfPaneOutlineButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        pdfPaneOutlineButton.setContentHuggingPriority(.required, for: .horizontal)
 
         pdfPaneLinkButton.target = self
         pdfPaneLinkButton.action = #selector(handlePDFPaneLinkSelection)
@@ -799,6 +842,19 @@ final class PDFReaderPaneController: NSViewController {
             action: #selector(handlePDFFindNext)
         )
 
+        pdfOutlineScrollView.drawsBackground = true
+        pdfOutlineScrollView.backgroundColor = PDFPaneStyle.surface
+        pdfOutlineScrollView.hasVerticalScroller = true
+        pdfOutlineScrollView.hasHorizontalScroller = false
+        pdfOutlineScrollView.borderType = .noBorder
+        pdfOutlineScrollView.isHidden = true
+        pdfOutlineScrollView.documentView = pdfOutlineStackView
+
+        pdfOutlineStackView.orientation = .vertical
+        pdfOutlineStackView.alignment = .leading
+        pdfOutlineStackView.distribution = .gravityAreas
+        pdfOutlineStackView.spacing = 0
+
         pdfPanePDFView.autoScales = true
         pdfPanePDFView.displayMode = .singlePageContinuous
         pdfPanePDFView.displayDirection = .vertical
@@ -823,10 +879,12 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneView.addSubview(pdfPaneResizeHandle)
         pdfPaneView.addSubview(pdfPaneHeaderView)
         pdfPaneView.addSubview(pdfFindBarView)
+        pdfPaneView.addSubview(pdfOutlineScrollView)
         pdfPaneView.addSubview(pdfPanePDFView)
         pdfPaneHeaderView.addSubview(pdfPaneTitleField)
         pdfPaneHeaderView.addSubview(pdfPaneHintIconView)
         pdfPaneHeaderView.addSubview(pdfPaneStatusField)
+        pdfPaneHeaderView.addSubview(pdfPaneOutlineButton)
         pdfPaneHeaderView.addSubview(pdfPaneLinkButton)
         pdfPaneHeaderView.addSubview(pdfPaneCloseButton)
         pdfPaneHeaderView.addSubview(headerSeparator)
@@ -866,7 +924,7 @@ final class PDFReaderPaneController: NSViewController {
                 constant: PDFPaneStyle.trafficLightSafeLeading
             ),
             pdfPaneTitleField.topAnchor.constraint(equalTo: pdfPaneHeaderView.topAnchor, constant: 6),
-            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
 
             pdfPaneHintIconView.leadingAnchor.constraint(equalTo: pdfPaneTitleField.leadingAnchor),
             pdfPaneHintIconView.centerYAnchor.constraint(equalTo: pdfPaneStatusField.centerYAnchor),
@@ -874,7 +932,7 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneHintIconView.heightAnchor.constraint(equalToConstant: 12),
 
             pdfPaneStatusField.topAnchor.constraint(equalTo: pdfPaneTitleField.bottomAnchor, constant: 1),
-            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
             pdfPaneStatusField.bottomAnchor.constraint(lessThanOrEqualTo: pdfPaneHeaderView.bottomAnchor, constant: -5),
 
             pdfPaneCloseButton.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor, constant: -10),
@@ -886,6 +944,10 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneLinkButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
             pdfPaneLinkButton.widthAnchor.constraint(equalToConstant: 28),
             pdfPaneLinkButton.heightAnchor.constraint(equalToConstant: 28),
+
+            pdfPaneOutlineButton.trailingAnchor.constraint(equalTo: pdfPaneLinkButton.leadingAnchor, constant: -8),
+            pdfPaneOutlineButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
+            pdfPaneOutlineButton.heightAnchor.constraint(equalToConstant: 28),
 
             headerSeparator.leadingAnchor.constraint(equalTo: pdfPaneHeaderView.leadingAnchor),
             headerSeparator.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor),
@@ -920,7 +982,16 @@ final class PDFReaderPaneController: NSViewController {
             findSeparator.bottomAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             findSeparator.heightAnchor.constraint(equalToConstant: 1),
 
-            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
+            pdfOutlineScrollView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
+
+            pdfOutlineStackView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.leadingAnchor),
+            pdfOutlineStackView.trailingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.trailingAnchor),
+            pdfOutlineStackView.topAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.topAnchor),
+            pdfOutlineStackView.widthAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.widthAnchor),
+
+            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.trailingAnchor),
             pdfPanePDFView.trailingAnchor.constraint(equalTo: pdfPaneView.trailingAnchor, constant: -8),
             pdfPanePDFView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             pdfPanePDFView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
@@ -928,6 +999,10 @@ final class PDFReaderPaneController: NSViewController {
 
         pdfFindBarHeightConstraint = pdfFindBarView.heightAnchor.constraint(equalToConstant: 0)
         pdfFindBarHeightConstraint?.isActive = true
+        pdfOutlineWidthConstraint = pdfOutlineScrollView.widthAnchor.constraint(equalToConstant: 0)
+        pdfOutlineWidthConstraint?.isActive = true
+        pdfPaneOutlineButtonWidthConstraint = pdfPaneOutlineButton.widthAnchor.constraint(equalToConstant: 0)
+        pdfPaneOutlineButtonWidthConstraint?.isActive = true
         pdfFindSearchField.trailingAnchor.constraint(
             lessThanOrEqualTo: pdfFindCounterField.leadingAnchor,
             constant: -8
@@ -959,6 +1034,130 @@ final class PDFReaderPaneController: NSViewController {
         button.contentTintColor = PDFPaneStyle.textMuted
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    private func configurePDFOutline(document: PDFDocument?) {
+        pdfOutlineEntries = document?.outlineRoot.flatMap { flattenPDFOutline($0) } ?? []
+        rebuildPDFOutlineSidebar()
+        pdfPaneOutlineButton.isHidden = pdfOutlineEntries.isEmpty
+        pdfPaneOutlineButtonWidthConstraint?.constant = pdfOutlineEntries.isEmpty ? 0 : 28
+        if pdfOutlineEntries.isEmpty {
+            setPDFOutlineVisible(false)
+        }
+    }
+
+    private func flattenPDFOutline(_ root: PDFOutline, depth: Int = 0) -> [PDFOutlineSidebarEntry] {
+        guard depth < 3 else { return [] }
+
+        var entries: [PDFOutlineSidebarEntry] = []
+        for index in 0..<root.numberOfChildren {
+            guard let child = root.child(at: index) else { continue }
+            let title = child.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayTitle = title.flatMap { $0.isEmpty ? nil : $0 } ?? "Untitled"
+            entries.append(PDFOutlineSidebarEntry(
+                title: displayTitle,
+                destination: child.destination,
+                depth: depth
+            ))
+            entries.append(contentsOf: flattenPDFOutline(child, depth: depth + 1))
+        }
+        return entries
+    }
+
+    private func rebuildPDFOutlineSidebar() {
+        pdfOutlineStackView.arrangedSubviews.forEach { view in
+            pdfOutlineStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
+        for (index, entry) in pdfOutlineEntries.enumerated() {
+            let row = NSView(frame: .zero)
+            row.translatesAutoresizingMaskIntoConstraints = false
+            let button = NSButton(title: entry.title, target: self, action: #selector(handlePDFOutlineEntryClick(_:)))
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.tag = index
+            button.isBordered = false
+            button.alignment = .left
+            button.font = NSFont.systemFont(ofSize: 12)
+            button.contentTintColor = entry.destination == nil ? PDFPaneStyle.textMuted : PDFPaneStyle.text
+            button.isEnabled = entry.destination != nil
+            button.lineBreakMode = .byTruncatingTail
+            button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            row.addSubview(button)
+            pdfOutlineStackView.addArrangedSubview(row)
+
+            NSLayoutConstraint.activate([
+                row.widthAnchor.constraint(equalTo: pdfOutlineStackView.widthAnchor),
+                row.heightAnchor.constraint(greaterThanOrEqualToConstant: 26),
+                button.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 10 + CGFloat(entry.depth * 14)),
+                button.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -8),
+                button.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            ])
+        }
+    }
+
+    @objc private func handlePDFOutlineToggle() {
+        setPDFOutlineVisible(!isPDFOutlineVisible)
+    }
+
+    @objc private func handlePDFOutlineEntryClick(_ sender: NSButton) {
+        guard sender.tag >= 0,
+              sender.tag < pdfOutlineEntries.count,
+              let destination = pdfOutlineEntries[sender.tag].destination else {
+            return
+        }
+
+        pdfPanePDFView.go(to: destination)
+    }
+
+    private func setPDFOutlineVisible(_ visible: Bool) {
+        let shouldShow = visible && !pdfOutlineEntries.isEmpty
+        isPDFOutlineVisible = shouldShow
+        pdfOutlineScrollView.isHidden = !shouldShow
+        pdfOutlineWidthConstraint?.constant = shouldShow ? 220 : 0
+        pdfPaneOutlineButton.state = shouldShow ? .on : .off
+        pdfPaneOutlineButton.toolTip = shouldShow ? "Hide outline" : "Show outline"
+        view.layoutSubtreeIfNeeded()
+    }
+
+    private func schedulePDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.saveCurrentPDFPageIndex()
+        }
+        pdfPageSaveWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: workItem)
+    }
+
+    private func flushPDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        pdfPageSaveWorkItem = nil
+        saveCurrentPDFPageIndex()
+    }
+
+    private func saveCurrentPDFPageIndex() {
+        guard let context = activePDFContext,
+              let document = pdfPanePDFView.document,
+              let page = pdfPanePDFView.currentPage else {
+            return
+        }
+
+        let pageIndex = document.index(for: page)
+        guard pageIndex >= 0, pageIndex < document.pageCount else { return }
+        onPageChanged?(context.sourceId, pageIndex)
+    }
+
+    private func showPDFPaneMessage(_ message: String) {
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = message
+        updatePDFPaneStatus()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pdfPaneTransientMessage = nil
+            self?.updatePDFPaneStatus()
+        }
+        pdfPaneMessageWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: workItem)
     }
 
     private func handlePDFFindKeyDown(_ event: NSEvent) -> Bool {
@@ -1220,12 +1419,17 @@ final class PDFReaderPaneController: NSViewController {
 
     private func releaseActivePDFContext() {
         exitAnchorPickMode(notifyCancelled: false)
+        flushPDFPageSave()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = nil
         resetPDFFindState()
         if let current = activePDFContext {
             current.fileURL.stopAccessingSecurityScopedResource()
         }
         activePDFContext = nil
         pdfPanePDFView.document = nil
+        configurePDFOutline(document: nil)
         setPDFPaneHeader(displayName: nil)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -1247,6 +1451,7 @@ final class PDFReaderPaneController: NSViewController {
 
     @objc private func handlePDFPanePageChanged() {
         updatePDFPaneStatus()
+        schedulePDFPageSave()
     }
 
     @objc private func handlePDFPaneResizePan(_ recognizer: NSPanGestureRecognizer) {
@@ -1272,23 +1477,23 @@ final class PDFReaderPaneController: NSViewController {
         exitAnchorPickMode(notifyCancelled: true)
 
         guard let context = activePDFContext else {
-            NSSound.beep()
+            showPDFPaneMessage("Open a PDF before linking.")
             return
         }
         guard let selection = pdfPanePDFView.currentSelection else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !quote.isEmpty else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let rects = highlightRects(for: selection)
         guard let firstRect = rects.first else {
-            NSSound.beep()
+            showPDFPaneMessage("That selection cannot be linked.")
             return
         }
 
@@ -1455,6 +1660,21 @@ final class PDFReaderPaneController: NSViewController {
         return page
     }
 
+    @discardableResult
+    private func navigate(toPageIndex pageIndex: Int) -> PDFPage? {
+        guard let document = pdfPanePDFView.document,
+              document.pageCount > 0 else {
+            return nil
+        }
+
+        let clampedPageIndex = max(0, min(pageIndex, document.pageCount - 1))
+        guard let page = document.page(at: clampedPageIndex) else { return nil }
+        let bounds = page.bounds(for: .mediaBox)
+        let destination = PDFDestination(page: page, at: CGPoint(x: bounds.minX, y: bounds.maxY))
+        pdfPanePDFView.go(to: destination)
+        return page
+    }
+
     private func showCitationPageFallbackAffordance(on page: PDFPage) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             guard let self else { return }
@@ -1568,7 +1788,7 @@ final class PDFReaderPaneController: NSViewController {
         guard let context = activePDFContext,
               let document = pdfPanePDFView.document,
               let page = pdfPanePDFView.page(for: pointInPDFView, nearest: true) else {
-            NSSound.beep()
+            showPDFPaneMessage("Pick a spot inside the PDF.")
             cancelAnchorPickMode()
             return
         }
@@ -1669,6 +1889,14 @@ final class PDFReaderPaneController: NSViewController {
 
     private func updatePDFPaneStatus() {
         let pageText = pdfPanePageText()
+        if let message = pdfPaneTransientMessage {
+            pdfPaneHintIconView.isHidden = true
+            pdfPaneStatusLeadingConstraint?.isActive = true
+            pdfPaneStatusHintLeadingConstraint?.isActive = false
+            pdfPaneStatusField.stringValue = [pageText, message].filter { !$0.isEmpty }.joined(separator: " · ")
+            return
+        }
+
         let showHint = isAnchorPickMode
         let hintText = "Click a spot to link · Esc to cancel"
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -151,6 +151,14 @@ final class WebViewManager: NSObject {
         pdfPaneController.onAnchorPickCancelled = { [weak self] streamId in
             self?.sendPDFAnchorPickCancelled(streamId: streamId)
         }
+        pdfPaneController.onPageChanged = { [weak self] sourceId, pageIndex in
+            guard let self, let persistence = self.persistence else { return }
+            do {
+                try persistence.saveSourceLastPageIndex(sourceId: sourceId, pageIndex: pageIndex)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save PDF page position (\(DebugLog.errorSummary(error)))")
+            }
+        }
         pdfPaneController.onClose = { [weak self] in
             self?.activePDFPaneStreamId = nil
             self?.sendPDFPaneStateChanged(visible: false)
@@ -372,7 +380,8 @@ final class WebViewManager: NSObject {
                         url: url,
                         streamId: source.streamId,
                         sourceId: source.id,
-                        displayName: source.displayName
+                        displayName: source.displayName,
+                        lastPageIndex: afterPresent == nil ? source.lastPageIndex : nil
                     )
                     self.activePDFPaneStreamId = source.streamId
                     self.sendPDFPaneStateChanged(

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -211,9 +211,11 @@ final class WebViewManager: NSObject {
 
             let document = try persistence.loadOrCreateStreamDocument(streamId: createdStream.id)
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
-            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: [
-                "stream": AnyCodable(streamPayload)
-            ]))
+            let streamLoadedPayload: [String: AnyCodable] = [
+                "stream": AnyCodable(streamPayload),
+                "scrollOffset": AnyCodable(document.scrollOffset)
+            ]
+            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))
 
             let summaries = try persistence.loadStreamSummaries()
             let payload = StreamCodec.encodeSummaries(summaries)

--- a/Sources/Ticker/Models/SourceReference.swift
+++ b/Sources/Ticker/Models/SourceReference.swift
@@ -14,6 +14,7 @@ struct SourceReference: Identifiable, Codable {
     var embeddingStatus: SourceEmbeddingStatus
     var indexStatus: SourceIndexStatus
     var aiExcluded: Bool
+    var lastPageIndex: Int?
     let addedAt: Date
 
     var shortTitle: String {
@@ -33,6 +34,7 @@ struct SourceReference: Identifiable, Codable {
         embeddingStatus: SourceEmbeddingStatus = .none,
         indexStatus: SourceIndexStatus = .pending,
         aiExcluded: Bool = false,
+        lastPageIndex: Int? = nil,
         addedAt: Date = Date()
     ) {
         self.id = id
@@ -47,6 +49,7 @@ struct SourceReference: Identifiable, Codable {
         self.embeddingStatus = embeddingStatus
         self.indexStatus = indexStatus
         self.aiExcluded = aiExcluded
+        self.lastPageIndex = lastPageIndex
         self.addedAt = addedAt
     }
 }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -41,6 +41,7 @@ struct StreamDocument: Codable {
     let streamId: UUID
     var markdown: String
     var revision: Int
+    var scrollOffset: Double
     let createdAt: Date
     var updatedAt: Date
 
@@ -48,12 +49,14 @@ struct StreamDocument: Codable {
         streamId: UUID,
         markdown: String = "",
         revision: Int = 0,
+        scrollOffset: Double = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.streamId = streamId
         self.markdown = markdown
         self.revision = revision
+        self.scrollOffset = scrollOffset
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -592,6 +592,7 @@ final class PersistenceService {
                     embeddingStatus: embeddingStatus,
                     indexStatus: indexStatus,
                     aiExcluded: aiExcluded != 0,
+                    lastPageIndex: row["last_page_index"],
                     addedAt: Date(timeIntervalSince1970: row["added_at"])
                 )
             }
@@ -964,6 +965,7 @@ final class PersistenceService {
                 embeddingStatus: embeddingStatus,
                 indexStatus: indexStatus,
                 aiExcluded: aiExcluded != 0,
+                lastPageIndex: row["last_page_index"],
                 addedAt: Date(timeIntervalSince1970: row["added_at"])
             )
         }
@@ -1014,6 +1016,15 @@ final class PersistenceService {
             try db.execute(
                 sql: "UPDATE sources SET ai_excluded = ? WHERE id = ?",
                 arguments: [excluded ? 1 : 0, sourceId.uuidString]
+            )
+        }
+    }
+
+    func saveSourceLastPageIndex(sourceId: UUID, pageIndex: Int) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sources SET last_page_index = ? WHERE id = ?",
+                arguments: [max(0, pageIndex), sourceId.uuidString]
             )
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -438,6 +438,11 @@ final class PersistenceService {
             """)
         }
 
+        migrator.registerMigration("v19_scroll_restore") { db in
+            try db.execute(sql: "ALTER TABLE stream_documents ADD COLUMN scroll_offset REAL NOT NULL DEFAULT 0")
+            try db.execute(sql: "ALTER TABLE sources ADD COLUMN last_page_index INTEGER")
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -737,7 +742,7 @@ final class PersistenceService {
         try dbQueue.read { db in
             guard let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) else {
                 return nil
@@ -747,6 +752,7 @@ final class PersistenceService {
                 streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                 markdown: row["markdown"],
                 revision: row["revision"],
+                scrollOffset: row["scroll_offset"],
                 createdAt: Date(timeIntervalSince1970: row["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: row["updated_at"])
             )
@@ -758,13 +764,14 @@ final class PersistenceService {
         try dbQueue.write { db in
             if let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) {
                 return StreamDocument(
                     streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                     markdown: row["markdown"],
                     revision: row["revision"],
+                    scrollOffset: row["scroll_offset"],
                     createdAt: Date(timeIntervalSince1970: row["created_at"]),
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"])
                 )
@@ -788,8 +795,27 @@ final class PersistenceService {
                 streamId: streamId,
                 markdown: markdown,
                 revision: 0,
+                scrollOffset: 0,
                 createdAt: now,
                 updatedAt: now
+            )
+        }
+    }
+
+    func saveScrollOffset(streamId: UUID, offset: Double) throws {
+        let clampedOffset = max(0, offset)
+        try dbQueue.write { db in
+            guard try Row.fetchOne(
+                db,
+                sql: "SELECT 1 FROM stream_documents WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            ) != nil else {
+                return
+            }
+
+            try db.execute(
+                sql: "UPDATE stream_documents SET scroll_offset = ? WHERE stream_id = ?",
+                arguments: [clampedOffset, streamId.uuidString]
             )
         }
     }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -906,6 +906,30 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_saveSourceLastPageIndexRoundTripsThroughPersistence() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "PDF Resume")
+            try service.saveStream(stream)
+            let source = SourceReference(
+                streamId: stream.id,
+                displayName: "Manual.pdf",
+                fileType: .pdf,
+                bookmarkData: Data(),
+                status: .ready
+            )
+            try service.saveSource(source)
+
+            XCTAssertNil(try service.loadSource(id: source.id)?.lastPageIndex)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: 117)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 117)
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sources.first?.lastPageIndex, 117)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: -4)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 0)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -865,6 +865,47 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
+        try withTempPersistenceServiceAndURL { _, dbURL, _ in
+            let dbQueue = try DatabaseQueue(path: dbURL.path)
+            let documentColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(stream_documents)").map { row -> String in
+                    row["name"]
+                }
+            }
+            let sourceColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(sources)").map { row -> String in
+                    row["name"]
+                }
+            }
+
+            XCTAssertTrue(documentColumns.contains("scroll_offset"))
+            XCTAssertTrue(sourceColumns.contains("last_page_index"))
+        }
+    }
+
+    func test_saveScrollOffsetRoundTripsWithoutBumpingRevision() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scroll Restore")
+            try service.saveStream(stream)
+            let revision = try service.saveStreamDocument(streamId: stream.id, markdown: "Line one\n\nLine two")
+            let before = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+
+            try service.saveScrollOffset(streamId: stream.id, offset: 512.5)
+
+            let after = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(revision, 1)
+            XCTAssertEqual(after.markdown, before.markdown)
+            XCTAssertEqual(after.revision, before.revision)
+            XCTAssertEqual(after.updatedAt, before.updatedAt)
+            XCTAssertEqual(after.scrollOffset, 512.5)
+
+            let payload = StreamCodec.encodeStream(stream, document: after)
+            let documentPayload = try XCTUnwrap(payload["document"] as? [String: Any])
+            XCTAssertEqual(documentPayload["scrollOffset"] as? Double, 512.5)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -164,7 +164,16 @@ export function App() {
           setIsLoading(false);
           break;
         case 'streamLoaded': {
-          const loadedStream = message.payload?.stream as Stream;
+          const payloadStream = message.payload?.stream as Stream | undefined;
+          if (!payloadStream) break;
+          const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
+          const loadedStream = {
+            ...payloadStream,
+            document: {
+              ...payloadStream.document,
+              scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,
+            },
+          };
           currentStreamIdRef.current = loadedStream?.id ?? null;
           viewRef.current = 'stream';
           setCurrentStream(loadedStream);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -5,7 +5,7 @@ import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { bridge, type Stream, type SourceReference, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
 import { SourcesModal } from './SourcesModal';
@@ -138,6 +138,19 @@ function focusEditorAtDocumentEnd(view: EditorView) {
   view.focus();
 }
 
+function restoreViewportEnd(view: EditorView, scrollOffset: number): number {
+  const docLength = view.state.doc.length;
+  if (docLength === 0 || scrollOffset <= 0) return view.viewport.to;
+
+  const scrollHeight = view.scrollDOM.scrollHeight;
+  const clientHeight = view.scrollDOM.clientHeight;
+  if (scrollHeight <= clientHeight) return view.viewport.to;
+
+  // ponytail: pixel-to-doc estimate; upgrade to measured CodeMirror mapping if deep restores ever flash.
+  const ratio = Math.min(1, (scrollOffset + clientHeight) / scrollHeight);
+  return Math.max(view.viewport.to, Math.min(docLength, Math.ceil(docLength * ratio)));
+}
+
 const clickToDocumentEndExtension: Extension = EditorView.domEventHandlers({
   mousedown: (event, view) => {
     if (event.button !== 0 || event.defaultPrevented) return false;
@@ -233,6 +246,7 @@ export function StreamEditor({
   const [title, setTitle] = useState(stream.title);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isPrepaintHidden, setIsPrepaintHidden] = useState(true);
   const [showSourcesModal, setShowSourcesModal] = useState(false);
   const [highlightedSourceId, setHighlightedSourceId] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<'saved' | 'saving'>('saved');
@@ -270,6 +284,9 @@ export function StreamEditor({
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
   const sourceIndexNoticeTimerRef = useRef<number | null>(null);
+  const scrollSaveTimerRef = useRef<number | null>(null);
+  const scrollCleanupRef = useRef<(() => void) | null>(null);
+  const revealFrameRef = useRef<number | null>(null);
   const pendingPDFAnchorSelectionRef = useRef<PendingPDFAnchorSelection | null>(null);
   const sourcesRef = useRef<SourceReference[]>(stream.sources);
   const sourceIndexStatusesRef = useRef<Map<string, SourceReference['indexStatus']>>(new Map());
@@ -447,6 +464,46 @@ export function StreamEditor({
     }, AI_INDEXING_NOTICE_MS);
   }, [clearSourceIndexNoticeTimer]);
 
+  const clearScrollSaveTimer = useCallback(() => {
+    if (scrollSaveTimerRef.current !== null) {
+      window.clearTimeout(scrollSaveTimerRef.current);
+      scrollSaveTimerRef.current = null;
+    }
+  }, []);
+
+  const sendScrollPosition = useCallback((offset: number) => {
+    bridge.send({
+      type: 'saveScrollPosition',
+      payload: { streamId: stream.id, offset: Math.max(0, offset) },
+    });
+  }, [stream.id]);
+
+  const scheduleScrollPositionSave = useCallback(() => {
+    clearScrollSaveTimer();
+    scrollSaveTimerRef.current = window.setTimeout(() => {
+      scrollSaveTimerRef.current = null;
+      const view = editorViewRef.current;
+      if (view) {
+        sendScrollPosition(view.scrollDOM.scrollTop);
+      }
+    }, 1000);
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const flushScrollPosition = useCallback(() => {
+    clearScrollSaveTimer();
+    const view = editorViewRef.current;
+    if (view) {
+      sendScrollPosition(view.scrollDOM.scrollTop);
+    }
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const clearRevealFrame = useCallback(() => {
+    if (revealFrameRef.current !== null) {
+      window.cancelAnimationFrame(revealFrameRef.current);
+      revealFrameRef.current = null;
+    }
+  }, []);
+
   const cycleSourceScope = useCallback(() => {
     setSourceScope((previous) => {
       const next = nextSourceScope(previous);
@@ -488,17 +545,6 @@ export function StreamEditor({
       dispatchAiRangeClear(view);
     }
   }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const view = editorViewRef.current;
-      if (view) {
-        focusEditorAtDocumentEnd(view);
-      }
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [stream.id]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -1486,6 +1532,15 @@ export function StreamEditor({
   }, [clearSourceIndexNoticeTimer]);
 
   useEffect(() => {
+    return () => {
+      flushScrollPosition();
+      scrollCleanupRef.current?.();
+      scrollCleanupRef.current = null;
+      clearRevealFrame();
+    };
+  }, [clearRevealFrame, flushScrollPosition]);
+
+  useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       if (!isEditorActive()) return;
       if (!event.clipboardData?.items?.length) return;
@@ -1745,7 +1800,7 @@ export function StreamEditor({
         <div className="stream-content">
           <div
             ref={editorShellRef}
-            className="document-editor-shell"
+            className={`document-editor-shell ${isPrepaintHidden ? 'cm-prepaint' : ''}`}
             onDrop={handleDrop}
             onDragOver={handleDragOver}
           >
@@ -1777,11 +1832,25 @@ export function StreamEditor({
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
-                window.setTimeout(() => {
-                  if (editorViewRef.current === view) {
-                    focusEditorAtDocumentEnd(view);
-                  }
-                }, 0);
+
+                scrollCleanupRef.current?.();
+                const handleScroll = () => scheduleScrollPositionSave();
+                view.scrollDOM.addEventListener('scroll', handleScroll, { passive: true });
+                scrollCleanupRef.current = () => view.scrollDOM.removeEventListener('scroll', handleScroll);
+
+                clearRevealFrame();
+                const scrollOffset = Math.max(0, Number(stream.document?.scrollOffset ?? 0));
+                ensureSyntaxTree(view.state, restoreViewportEnd(view, scrollOffset), 50);
+                view.scrollDOM.scrollTop = scrollOffset;
+                revealFrameRef.current = window.requestAnimationFrame(() => {
+                  revealFrameRef.current = window.requestAnimationFrame(() => {
+                    revealFrameRef.current = null;
+                    if (editorViewRef.current === view) {
+                      setIsPrepaintHidden(false);
+                    }
+                  });
+                });
+
               }}
               onChange={(value) => {
                 setMarkdownContent(value);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type FocusEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
@@ -15,6 +15,7 @@ import { AI_HISTORY_USER_EVENT, aiWritingExtension, getAiWritingRange, setAiWrit
 import { editorFindExtension } from '../extensions/EditorFindPanel';
 import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
+import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
@@ -52,6 +53,19 @@ interface FloatingMenuState {
   selectionFrom: number;
   selectionTo: number;
   selectionHead: number;
+  menuWidth?: number;
+  menuHeight?: number;
+}
+
+interface LinkPopoverState {
+  visible: boolean;
+  left: number;
+  top: number;
+  from: number;
+  to: number;
+  labelFrom: number;
+  label: string;
+  url: string;
   menuWidth?: number;
   menuHeight?: number;
 }
@@ -265,6 +279,16 @@ export function StreamEditor({
     selectionTo: 0,
     selectionHead: 0,
   });
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    from: 0,
+    to: 0,
+    labelFrom: 0,
+    label: '',
+    url: '',
+  });
   const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
     visible: false,
     kind: 'writing',
@@ -277,6 +301,7 @@ export function StreamEditor({
   const editorShellRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
   const selectionActionMenuRef = useRef<HTMLDivElement>(null);
+  const linkPopoverRef = useRef<HTMLDivElement>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
@@ -535,6 +560,7 @@ export function StreamEditor({
       selectionTo: 0,
       selectionHead: 0,
     });
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
     setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
@@ -1122,6 +1148,10 @@ export function StreamEditor({
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
+  const hideLinkPopover = useCallback(() => {
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+  }, []);
+
   const getSelectionMenuPlacement = useCallback((
     view: EditorView,
     measuredMenuSize?: { width: number; height: number }
@@ -1135,6 +1165,31 @@ export function StreamEditor({
 
     const shellRect = shell.getBoundingClientRect();
     const menu = selectionActionMenuRef.current;
+    return computeSelectionMenuPlacement({
+      coords,
+      shellRect,
+      menuSize: measuredMenuSize ?? {
+        width: menu?.offsetWidth,
+        height: menu?.offsetHeight,
+      },
+      viewportHeight: window.innerHeight,
+    });
+  }, []);
+
+  const getLinkPopoverPlacement = useCallback((
+    view: EditorView,
+    link: Pick<LinkPopoverState, 'from' | 'labelFrom'>,
+    measuredMenuSize?: { width: number; height: number }
+  ): { left: number; top: number } | null => {
+    const shell = editorShellRef.current;
+    if (!shell) return null;
+
+    const anchor = Math.min(Math.max(link.labelFrom, link.from), view.state.doc.length);
+    const coords = view.coordsAtPos(anchor) ?? view.coordsAtPos(link.from);
+    if (!coords) return null;
+
+    const shellRect = shell.getBoundingClientRect();
+    const menu = linkPopoverRef.current;
     return computeSelectionMenuPlacement({
       coords,
       shellRect,
@@ -1197,6 +1252,50 @@ export function StreamEditor({
     stream.id,
   ]);
 
+  useLayoutEffect(() => {
+    if (!linkPopover.visible) return;
+
+    const menu = linkPopoverRef.current;
+    const view = editorViewRef.current;
+    if (!menu || !view) return;
+
+    const measuredMenuSize = {
+      width: menu.offsetWidth,
+      height: menu.offsetHeight,
+    };
+    if (measuredMenuSize.width <= 0 || measuredMenuSize.height <= 0) return;
+
+    const placement = getLinkPopoverPlacement(view, linkPopover, measuredMenuSize);
+    if (!placement) return;
+
+    setLinkPopover((previous) => {
+      if (!previous.visible) return previous;
+
+      const sameSize = previous.menuWidth === measuredMenuSize.width &&
+        previous.menuHeight === measuredMenuSize.height;
+      const samePlacement = Math.abs(previous.left - placement.left) < 0.5 &&
+        Math.abs(previous.top - placement.top) < 0.5;
+
+      if (sameSize && samePlacement) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        left: placement.left,
+        top: placement.top,
+        menuWidth: measuredMenuSize.width,
+        menuHeight: measuredMenuSize.height,
+      };
+    });
+  }, [
+    getLinkPopoverPlacement,
+    linkPopover,
+    pdfPaneState.streamId,
+    pdfPaneState.visible,
+    stream.id,
+  ]);
+
   const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
 
@@ -1239,14 +1338,116 @@ export function StreamEditor({
     }, SELECTION_MENU_DELAY_MS);
   }, [clearSelectionMenuTimer, getSelectionMenuPlacement, hideSelectionMenu]);
 
+  const openLinkPopover = useCallback((view: EditorView, link: MarkdownLinkInfo | null) => {
+    if (!link) {
+      hideLinkPopover();
+      return;
+    }
+
+    const placement = getLinkPopoverPlacement(view, link);
+    if (!placement) {
+      hideLinkPopover();
+      return;
+    }
+
+    hideSelectionMenu();
+    setLinkPopover({
+      visible: true,
+      left: placement.left,
+      top: placement.top,
+      from: link.from,
+      to: link.to,
+      labelFrom: link.labelFrom,
+      label: link.label,
+      url: link.url,
+    });
+  }, [getLinkPopoverPlacement, hideLinkPopover, hideSelectionMenu]);
+
+  const linkInteraction = useMemo<Extension>(
+    () => linkInteractionExtension(openLinkPopover),
+    [openLinkPopover]
+  );
+
+  const commitLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    const change = buildLinkEditChange(linkPopover, linkPopover.label, linkPopover.url);
+    if (view && change) {
+      view.dispatch({
+        changes: change,
+        selection: { anchor: change.from + change.insert.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const unlinkLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: linkPopover.label },
+        selection: { anchor: linkPopover.from + linkPopover.label.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const removeLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: '' },
+        selection: { anchor: linkPopover.from },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const handleLinkPopoverBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+
+    window.setTimeout(() => {
+      const menu = linkPopoverRef.current;
+      if (menu && document.activeElement instanceof Node && menu.contains(document.activeElement)) return;
+      commitLinkPopover();
+    }, 0);
+  }, [commitLinkPopover]);
+
+  const handleLinkPopoverKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitLinkPopover();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      hideLinkPopover();
+      editorViewRef.current?.focus();
+    }
+  }, [commitLinkPopover, hideLinkPopover]);
+
   useEffect(() => {
     showPromptRef.current = showPrompt;
     isAiThinkingRef.current = isAiThinking;
 
     if (showPrompt || isAiThinking) {
       hideSelectionMenu();
+      hideLinkPopover();
     }
-  }, [hideSelectionMenu, isAiThinking, showPrompt]);
+  }, [hideLinkPopover, hideSelectionMenu, isAiThinking, showPrompt]);
 
   const selectionMenuExtension = useMemo<Extension>(() => [
     EditorView.updateListener.of((update) => {
@@ -1796,6 +1997,46 @@ export function StreamEditor({
         </div>
       )}
 
+      {linkPopover.visible && (
+        <div
+          ref={linkPopoverRef}
+          className="link-edit-popover"
+          style={{ left: `${linkPopover.left}px`, top: `${linkPopover.top}px` }}
+          onBlur={handleLinkPopoverBlur}
+        >
+          <input
+            className="link-edit-input link-edit-input--label"
+            value={linkPopover.label}
+            aria-label="Link label"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, label: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <input
+            className="link-edit-input link-edit-input--url"
+            value={linkPopover.url}
+            aria-label="Link URL"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, url: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <button
+            type="button"
+            className="link-edit-button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={unlinkLinkPopover}
+          >
+            Unlink
+          </button>
+          <button
+            type="button"
+            className="link-edit-button link-edit-button--remove"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={removeLinkPopover}
+          >
+            Remove
+          </button>
+        </div>
+      )}
+
       <div className="stream-body">
         <div className="stream-content">
           <div
@@ -1829,6 +2070,7 @@ export function StreamEditor({
                 markdownConcealExtension,
                 markdownImageWidgetExtension,
                 tickerPDFLinkExtension(stream.id),
+                linkInteraction,
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;

--- a/Web/src/extensions/LinkInteraction.test.ts
+++ b/Web/src/extensions/LinkInteraction.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildLinkEditChange, isAllowedExternalURL } from './LinkInteraction';
+
+describe('link interaction helpers', () => {
+  it('builds a markdown link replacement change', () => {
+    expect(buildLinkEditChange({ from: 4, to: 28 }, 'Example', 'https://example.com')).toEqual({
+      from: 4,
+      to: 28,
+      insert: '[Example](https://example.com)',
+    });
+  });
+
+  it('escapes edited link labels and trims URL fields', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'A ] B', ' https://example.com/path ')).toEqual({
+      from: 0,
+      to: 10,
+      insert: '[A \\] B](https://example.com/path)',
+    });
+  });
+
+  it('rejects empty edited links', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, '', 'https://example.com')).toBeNull();
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'Example', '')).toBeNull();
+  });
+
+  it('allows only http and https external URLs', () => {
+    expect(isAllowedExternalURL('https://example.com/path')).toBe(true);
+    expect(isAllowedExternalURL('http://example.com')).toBe(true);
+    expect(isAllowedExternalURL('ticker-pdf://source?page=1')).toBe(false);
+    expect(isAllowedExternalURL('file:///etc/passwd')).toBe(false);
+    expect(isAllowedExternalURL('javascript:alert(1)')).toBe(false);
+    expect(isAllowedExternalURL('https:example.com')).toBe(false);
+  });
+});

--- a/Web/src/extensions/LinkInteraction.ts
+++ b/Web/src/extensions/LinkInteraction.ts
@@ -1,0 +1,184 @@
+import { syntaxTree } from '@codemirror/language';
+import { type Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type { SyntaxNode } from '@lezer/common';
+import { bridge } from '../types';
+import { rawLinksAreRevealedOnLine, revealRawLinksEffect } from './MarkdownConceal';
+
+export interface MarkdownLinkInfo {
+  from: number;
+  to: number;
+  labelFrom: number;
+  labelTo: number;
+  label: string;
+  url: string;
+  lineFrom: number;
+}
+
+export interface LinkEditRange {
+  from: number;
+  to: number;
+}
+
+export interface LinkEditChange extends LinkEditRange {
+  insert: string;
+}
+
+export function isAllowedExternalURL(rawURL: string): boolean {
+  if (!/^https?:\/\//i.test(rawURL)) return false;
+
+  try {
+    const url = new URL(rawURL);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function buildLinkEditChange(oldRange: LinkEditRange, label: string, url: string): LinkEditChange | null {
+  const nextLabel = label.trim().replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
+  const nextURL = url.trim();
+  if (!nextLabel || !nextURL) return null;
+  return {
+    from: oldRange.from,
+    to: oldRange.to,
+    insert: `[${nextLabel}](${nextURL})`,
+  };
+}
+
+function linkInfoFromNode(view: EditorView, linkNode: SyntaxNode): MarkdownLinkInfo | null {
+  const marks: Array<{ from: number; to: number }> = [];
+  let urlFrom = -1;
+  let urlTo = -1;
+  const cursor = linkNode.cursor();
+  if (!cursor.firstChild()) return null;
+
+  do {
+    if (cursor.name === 'LinkMark') {
+      marks.push({ from: cursor.from, to: cursor.to });
+    } else if (cursor.name === 'URL') {
+      urlFrom = cursor.from;
+      urlTo = cursor.to;
+    }
+  } while (cursor.nextSibling());
+
+  if (marks.length < 2 || urlFrom < 0 || urlTo <= urlFrom) return null;
+
+  const labelFrom = marks[0].to;
+  const labelTo = marks[1].from;
+  const line = view.state.doc.lineAt(linkNode.from);
+  return {
+    from: linkNode.from,
+    to: linkNode.to,
+    labelFrom,
+    labelTo,
+    label: view.state.doc.sliceString(labelFrom, labelTo),
+    url: view.state.doc.sliceString(urlFrom, urlTo),
+    lineFrom: line.from,
+  };
+}
+
+function linkInfoAt(view: EditorView, pos: number): MarkdownLinkInfo | null {
+  for (let node: SyntaxNode | null = syntaxTree(view.state).resolveInner(pos, -1); node; node = node.parent) {
+    if (node.name === 'Link') return linkInfoFromNode(view, node);
+  }
+  return null;
+}
+
+function sameLink(left: MarkdownLinkInfo | null, right: MarkdownLinkInfo | null): boolean {
+  return Boolean(left && right && left.from === right.from && left.to === right.to);
+}
+
+export function linkInteractionExtension(
+  onEditLink: (view: EditorView, link: MarkdownLinkInfo | null) => void
+): Extension {
+  let clickStartedInsideLink: MarkdownLinkInfo | null = null;
+  let suppressSelectionPopover = false;
+
+  return [
+    EditorView.updateListener.of((update) => {
+      if (!update.selectionSet && !update.docChanged) return;
+
+      const selection = update.state.selection.main;
+      if (!selection.empty) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      const link = linkInfoAt(update.view, selection.head);
+      if (!link || rawLinksAreRevealedOnLine(update.state, link.lineFrom) || suppressSelectionPopover) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      onEditLink(update.view, link);
+    }),
+    EditorView.domEventHandlers({
+      mousedown: (event, view) => {
+        clickStartedInsideLink = null;
+        suppressSelectionPopover = false;
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        if (pos == null) return false;
+
+        const clickedLink = linkInfoAt(view, pos);
+        const selection = view.state.selection.main;
+        const currentLink = selection.empty ? linkInfoAt(view, selection.head) : null;
+        clickStartedInsideLink = sameLink(clickedLink, currentLink) ? clickedLink : null;
+        suppressSelectionPopover = Boolean(clickedLink && !clickStartedInsideLink);
+        return false;
+      },
+      click: (event, view) => {
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        const link = pos == null ? null : linkInfoAt(view, pos);
+        if (!link) {
+          suppressSelectionPopover = false;
+          onEditLink(view, null);
+          return false;
+        }
+
+        if (event.altKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = true;
+          onEditLink(view, null);
+          view.dispatch({
+            selection: { anchor: Math.min(pos ?? link.from, view.state.doc.length) },
+            effects: revealRawLinksEffect.of(link.lineFrom),
+          });
+          window.setTimeout(() => {
+            suppressSelectionPopover = false;
+          }, 0);
+          return true;
+        }
+
+        if (link.url.startsWith('ticker-pdf://')) {
+          suppressSelectionPopover = false;
+          return false;
+        }
+
+        if (sameLink(clickStartedInsideLink, link)) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = false;
+          onEditLink(view, link);
+          return true;
+        }
+
+        suppressSelectionPopover = false;
+        if (!isAllowedExternalURL(link.url)) return false;
+
+        event.preventDefault();
+        event.stopPropagation();
+        bridge.send({
+          type: 'openExternalURL',
+          payload: { url: link.url },
+        });
+        return true;
+      },
+    }),
+  ];
+}

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -1,10 +1,12 @@
-import { type Extension, type Range } from '@codemirror/state';
+import { EditorState, StateEffect, StateField, type Extension, type Range } from '@codemirror/state';
 import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
 const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark', 'CodeInfo']);
 const LINK_CONCEAL_NODE_NAMES = new Set(['LinkMark', 'URL', 'LinkTitle']);
 const INITIAL_MARKDOWN_PARSE_TIMEOUT_MS = 20;
+
+export const revealRawLinksEffect = StateEffect.define<number | null>();
 
 function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boolean {
   const doc = view.state.doc;
@@ -21,6 +23,52 @@ function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boo
 
     return lineFrom < to && lineEnd > from;
   });
+}
+
+function selectionIntersectsLine(state: EditorState, lineFrom: number, lineTo: number): boolean {
+  const lineEnd = lineTo < state.doc.length ? lineTo + 1 : lineTo;
+
+  return state.selection.ranges.some((range) => {
+    const from = Math.min(range.from, range.to);
+    const to = Math.max(range.from, range.to);
+
+    if (from === to) {
+      return state.doc.lineAt(from).from === lineFrom;
+    }
+
+    return lineFrom < to && lineEnd > from;
+  });
+}
+
+const revealRawLinksField = StateField.define<number | null>({
+  create: () => null,
+  update(value, transaction) {
+    let next = value;
+    if (next !== null && transaction.docChanged) {
+      next = transaction.changes.mapPos(next);
+    }
+
+    for (const effect of transaction.effects) {
+      if (effect.is(revealRawLinksEffect)) {
+        next = effect.value;
+      }
+    }
+
+    if (next !== null && (transaction.selection || transaction.docChanged)) {
+      const line = transaction.state.doc.lineAt(Math.min(next, transaction.state.doc.length));
+      if (!selectionIntersectsLine(transaction.state, line.from, line.to)) {
+        next = null;
+      } else {
+        next = line.from;
+      }
+    }
+
+    return next;
+  },
+});
+
+export function rawLinksAreRevealedOnLine(state: EditorState, lineFrom: number): boolean {
+  return state.field(revealRawLinksField, false) === lineFrom;
 }
 
 function rangeWithFollowingSpace(view: EditorView, from: number, to: number): { from: number; to: number } {
@@ -56,6 +104,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
   const decorations: Array<Range<Decoration>> = [];
   const blockquoteLineStarts = new Set<number>();
   const tree = markdownTreeForDecorations(view, ensureInitialParse);
+  const rawLinksLineFrom = view.state.field(revealRawLinksField, false);
 
   for (const visibleRange of view.visibleRanges) {
     tree.iterate({
@@ -63,7 +112,10 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
       to: visibleRange.to,
       enter: (node) => {
         const line = view.state.doc.lineAt(node.from);
-        if (isLineSelected(view, line.from, line.to)) return;
+        const isLinkConcealNode = LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link']);
+        if (isLineSelected(view, line.from, line.to) && (!isLinkConcealNode || rawLinksLineFrom === line.from)) {
+          return;
+        }
 
         if (node.name === 'HeaderMark') {
           const range = rangeWithFollowingSpace(view, node.from, node.to);
@@ -90,7 +142,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
           return;
         }
 
-        if (LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link'])) {
+        if (isLinkConcealNode) {
           const range = node.name === 'URL' ? rangeWithFollowingSpaces(view, node.from, node.to) : { from: node.from, to: node.to };
           const decoration = concealRange(range.from, range.to);
           if (decoration) decorations.push(decoration);
@@ -110,7 +162,9 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   }
 
   update(update: ViewUpdate): void {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    const rawLinksChanged = update.startState.field(revealRawLinksField, false) !==
+      update.state.field(revealRawLinksField, false);
+    if (update.docChanged || update.viewportChanged || update.selectionSet || rawLinksChanged) {
       this.decorations = buildMarkdownConcealDecorations(update.view);
     }
   }
@@ -118,4 +172,4 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   decorations: (value) => value.decorations,
 });
 
-export const markdownConcealExtension: Extension = markdownConcealPlugin;
+export const markdownConcealExtension: Extension = [revealRawLinksField, markdownConcealPlugin];

--- a/Web/src/extensions/PDFHighlightLink.ts
+++ b/Web/src/extensions/PDFHighlightLink.ts
@@ -129,6 +129,7 @@ export function tickerPDFLinkExtension(streamId: string): Extension {
     EditorView.domEventHandlers({
       click: (event, view) => {
         if (event.button !== 0 || event.defaultPrevented) return false;
+        if (event.altKey) return false;
         const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
         if (pos == null) return false;
 

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -855,6 +855,69 @@ body {
   opacity: 0.5;
 }
 
+.link-edit-popover {
+  position: fixed;
+  z-index: 930;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
+}
+
+.link-edit-input {
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  outline: none;
+}
+
+.link-edit-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.link-edit-input--label {
+  width: 150px;
+}
+
+.link-edit-input--url {
+  width: 260px;
+}
+
+.link-edit-button {
+  height: 30px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  transition: color 0.12s ease, background 0.12s ease;
+}
+
+.link-edit-button:hover {
+  color: var(--color-accent);
+  background: var(--accent-soft);
+}
+
+.link-edit-button--remove:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
 .document-editor-shell {
   position: relative;
   width: 100%;

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -868,6 +868,10 @@ body {
   overflow: visible;
 }
 
+.document-editor-shell.cm-prepaint {
+  visibility: hidden;
+}
+
 .document-editor-codemirror {
   min-height: inherit;
 }

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -51,6 +51,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadSettings',
   'loadStream',
   'loadStreams',
+  'openExternalURL',
   'openPdfDestination',
   'openSource',
   'refreshProxyAuth',

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -58,6 +58,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'retrySourceIndexing',
   'saveImage',
   'saveSettings',
+  'saveScrollPosition',
   'saveStreamDocument',
   'setFileDropContext',
   'setSourceAIExclusion',

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -13,6 +13,7 @@ export interface StreamDocument {
   streamId: string;
   markdown: string;
   revision: number;
+  scrollOffset: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -101,7 +101,8 @@
         "requiredPayloadKeys": ["streamId", "markdown", "revision"]
       },
       "streamLoaded": {
-        "requiredPayloadKeys": ["stream"]
+        "requiredPayloadKeys": ["stream"],
+        "optionalPayloadKeys": ["scrollOffset"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -197,6 +198,9 @@
       "saveStreamDocument": {
         "requiredPayloadKeys": ["streamId", "markdown", "baseRevision"],
         "requiredCallbackId": true
+      },
+      "saveScrollPosition": {
+        "requiredPayloadKeys": ["streamId", "offset"]
       },
       "setFileDropContext": {
         "requiredPayloadKeys": ["mode"],

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -157,6 +157,9 @@
       "loadStreams": {
         "requiredPayloadKeys": []
       },
+      "openExternalURL": {
+        "requiredPayloadKeys": ["url"]
+      },
       "openSource": {
         "requiredPayloadKeys": ["sourceId"]
       },


### PR DESCRIPTION
Phase P2 of docs/IA_CORE_PLAN.md, stacked on #41. Three tasks, one commit each:

- **2.1 The open moment (v19)** — `scroll_offset` on stream_documents (+ `sources.last_page_index`); `saveScrollPosition` bridge message (1s debounce, flush on unmount, never bumps revision — tested); editor mounts hidden under `cm-prepaint`, runs `ensureSyntaxTree` over the restore viewport, sets scrollTop, reveals on a double-rAF after the first decoration pass. Raw `##`/`**` is never the first frame. Opens at top on first open, last position after.
- **2.2 Link interaction** — clicking a rendered http(s) link opens the browser via `openExternalURL` (Swift-side strict http/https allow-list + host check; web-side guard too, both unit-tested against `javascript:`/`file:`/`ticker-pdf:`). Cursor-inside-a-link opens a label/URL popover (selection-menu surface) instead of exploding into raw markdown — link stays concealed on the active line. ⌥-click reveals raw markdown for that line (clears when selection leaves). ticker-pdf links keep their existing navigation (explicit ⌥ deference added).
- **2.3 Reading dignity** — PDFs reopen at the last-read page (2s-debounced persist; explicit citation destinations still win); outline sidebar (~220pt, max depth 3, `list.bullet` toolbar button only when the PDF has an outline); every `NSSound.beep()` replaced with a short human message in the pane's status affordance.

Gates green after each task (build-dev, swift-test, web typecheck/test/build, contract checker).

**Live verification pending** (needs the physical screen; queued): first-frame conceal screenshot, scroll-restore round trip, link click/popover/⌥-click, PDF resume + outline + spoken failure.

**Accepted edges:** scroll restore maps pixel offset → doc position by ratio estimate (ponytail comment documents the upgrade path); `)` in URLs isn't escaped when the popover rebuilds `[label](url)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)