### PR TITLE
Roadmap 4 P3: thought-verbs, document prose, stop control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- PDF sources now reopen to the last-read page, expose document outlines when available, and describe pane failures in text.
 - Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.
 - Quick Panel can now attach recently copied clipboard text as context when no live selection is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -42,23 +42,103 @@ enum DocumentAICitationManifest {
     }
 }
 
+private enum DocumentAIVerb: String {
+    case develop
+    case ask
+    case challenge
+    case define
+
+    var systemPrompt: String {
+        switch self {
+        case .develop:
+            return Prompts.verbDevelop
+        case .ask:
+            return Prompts.verbAsk
+        case .challenge:
+            return Prompts.verbChallenge
+        case .define:
+            return Prompts.verbDefine
+        }
+    }
+}
+
 final class AIMessageHandler: BridgeMessageHandler {
     let handledTypes: Set<String> = [
-        "thinkDocument"
+        "thinkDocument",
+        "cancelDocumentAI"
     ]
 
-    private let bridgeService: BridgeService
     private let assetService: AssetService
-    private let orchestrator: AIOrchestrator
-    private let deviceKeyService: DeviceKeyService
     private let persistence: PersistenceService?
+    private let sendToWeb: (BridgeMessage) -> Void
+    private let sendBridgeErrorMessage: (String, String) async -> Void
+    private let isProxyUsable: () async -> Bool
+    private let routeDocumentAI: (
+        _ query: String,
+        _ queryImages: [String],
+        _ streamId: UUID?,
+        _ sourceScope: SourceScope,
+        _ systemPromptOverride: String,
+        _ onChunk: @escaping (String) -> Void,
+        _ onComplete: @escaping (SourceContext?) -> Void,
+        _ onError: @escaping (Error) -> Void,
+        _ onModelSelected: ((String) -> Void)?
+    ) async -> Void
+    private var inFlightRequests: [String: Task<Void, Never>] = [:]
 
     init?(container: ServiceContainer) {
-        self.bridgeService = container.bridgeService
         self.assetService = container.assetService
-        self.orchestrator = container.orchestrator
-        self.deviceKeyService = container.deviceKeyService
         self.persistence = container.persistence
+        self.sendToWeb = { [bridgeService = container.bridgeService] message in
+            bridgeService.send(message)
+        }
+        self.sendBridgeErrorMessage = { [bridgeService = container.bridgeService] type, reason in
+            await bridgeService.sendBridgeError(type: type, reason: reason)
+        }
+        self.isProxyUsable = { [deviceKeyService = container.deviceKeyService] in
+            await deviceKeyService.currentState.isUsable
+        }
+        self.routeDocumentAI = { [orchestrator = container.orchestrator] query, queryImages, streamId, sourceScope, systemPromptOverride, onChunk, onComplete, onError, onModelSelected in
+            await orchestrator.route(
+                query: query,
+                queryImages: queryImages,
+                streamId: streamId,
+                sourceScope: sourceScope,
+                priorCells: [],
+                systemPromptOverride: systemPromptOverride,
+                includeHeading: false,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onModelSelected: onModelSelected
+            )
+        }
+    }
+
+    init(
+        assetService: AssetService = AssetService(),
+        persistence: PersistenceService? = nil,
+        sendToWeb: @escaping (BridgeMessage) -> Void,
+        sendBridgeErrorMessage: @escaping (String, String) async -> Void = { _, _ in },
+        isProxyUsable: @escaping () async -> Bool = { true },
+        routeDocumentAI: @escaping (
+            _ query: String,
+            _ queryImages: [String],
+            _ streamId: UUID?,
+            _ sourceScope: SourceScope,
+            _ systemPromptOverride: String,
+            _ onChunk: @escaping (String) -> Void,
+            _ onComplete: @escaping (SourceContext?) -> Void,
+            _ onError: @escaping (Error) -> Void,
+            _ onModelSelected: ((String) -> Void)?
+        ) async -> Void
+    ) {
+        self.assetService = assetService
+        self.persistence = persistence
+        self.sendToWeb = sendToWeb
+        self.sendBridgeErrorMessage = sendBridgeErrorMessage
+        self.isProxyUsable = isProxyUsable
+        self.routeDocumentAI = routeDocumentAI
     }
 
     func handle(_ message: BridgeMessage) async {
@@ -68,7 +148,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                   let requestId = payload["requestId"]?.value as? String,
                   let query = payload["query"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid thinkDocument payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid thinkDocument payload")
+                await sendBridgeErrorMessage(message.type, "Invalid thinkDocument payload")
                 return
             }
 
@@ -79,6 +159,8 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
             let sourceScopeRaw = payload["sourceScope"]?.value as? String
             let sourceScope = SourceScope(rawValue: sourceScopeRaw ?? "") ?? .auto
+            let verbRaw = payload["verb"]?.value as? String
+            let verb = DocumentAIVerb(rawValue: verbRaw ?? "") ?? .develop
 
             var streamIdForRAG: UUID? = nil
 
@@ -105,12 +187,14 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
 
             let onChunk: (String) -> Void = { [weak self] chunk in
-                self?.bridgeService.send(BridgeMessage(
+                guard !Task.isCancelled else { return }
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIChunk",
                     payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
                 ))
             }
             let onComplete: (SourceContext?) -> Void = { [weak self] sourceContext in
+                guard !Task.isCancelled else { return }
                 var payload: [String: AnyCodable] = ["requestId": AnyCodable(requestId)]
                 if let citations = DocumentAICitationManifest.bridgePayload(from: sourceContext) {
                     payload["citations"] = AnyCodable(citations)
@@ -120,12 +204,13 @@ final class AIMessageHandler: BridgeMessageHandler {
                 } else if sourceContext == nil, hasStreamSources {
                     payload["sourceContextMode"] = AnyCodable("none")
                 }
-                self?.bridgeService.send(BridgeMessage(
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIComplete",
                     payload: payload
                 ))
             }
             let onError: (Error) -> Void = { [weak self] error in
+                guard !Task.isCancelled else { return }
                 var payload: [String: AnyCodable] = [
                     "requestId": AnyCodable(requestId),
                     "error": AnyCodable(error.localizedDescription)
@@ -151,16 +236,19 @@ final class AIMessageHandler: BridgeMessageHandler {
                     }
                 }
 
-                self?.bridgeService.send(BridgeMessage(
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIError",
                     payload: payload
                 ))
             }
 
-            Task { [weak self] in
+            let task = Task { [weak self] in
                 guard let self else { return }
+                defer {
+                    self.inFlightRequests[requestId] = nil
+                }
 
-                let proxyUsable = await self.deviceKeyService.currentState.isUsable
+                let proxyUsable = await self.isProxyUsable()
 
                 guard proxyUsable else {
                     await MainActor.run {
@@ -169,24 +257,46 @@ final class AIMessageHandler: BridgeMessageHandler {
                     return
                 }
 
-                await self.orchestrator.route(
-                    query: resolvedQuery,
-                    queryImages: imageDataURLs,
-                    streamId: streamIdForRAG,
-                    sourceScope: sourceScope,
-                    priorCells: [],
-                    includeHeading: false,
-                    onChunk: onChunk,
-                    onComplete: onComplete,
-                    onError: onError,
-                    onModelSelected: { [weak self] modelId in
-                        self?.bridgeService.send(BridgeMessage(
+                if Task.isCancelled {
+                    return
+                }
+
+                await self.routeDocumentAI(
+                    resolvedQuery,
+                    imageDataURLs,
+                    streamIdForRAG,
+                    sourceScope,
+                    verb.systemPrompt,
+                    onChunk,
+                    onComplete,
+                    onError,
+                    { [weak self] modelId in
+                        guard !Task.isCancelled else { return }
+                        self?.sendToWeb(BridgeMessage(
                             type: "documentModelSelected",
                             payload: ["requestId": AnyCodable(requestId), "modelId": AnyCodable(modelId)]
                         ))
                     }
                 )
             }
+            inFlightRequests[requestId] = task
+
+        case "cancelDocumentAI":
+            guard let payload = message.payload,
+                  let requestId = payload["requestId"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid cancelDocumentAI payload")
+                await sendBridgeErrorMessage(message.type, "Invalid cancelDocumentAI payload")
+                return
+            }
+            inFlightRequests.removeValue(forKey: requestId)?.cancel()
+            sendToWeb(BridgeMessage(
+                type: "documentAIError",
+                payload: [
+                    "requestId": AnyCodable(requestId),
+                    "error": AnyCodable("Cancelled"),
+                    "errorCode": AnyCodable("cancelled")
+                ]
+            ))
 
         default:
             DebugLog.log("[AIMessageHandler] Unknown message type: \(message.type)")

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -30,6 +30,7 @@ enum StreamCodec {
                 "streamId": document.streamId.uuidString,
                 "markdown": document.markdown,
                 "revision": document.revision,
+                "scrollOffset": document.scrollOffset,
                 "createdAt": formatter.string(from: document.createdAt),
                 "updatedAt": formatter.string(from: document.updatedAt)
             ]

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -6,6 +6,7 @@ enum StreamCodec {
         return [
             "id": stream.id.uuidString,
             "title": stream.title,
+            "sourceScope": stream.sourceScope.rawValue,
             "sources": stream.sources.map { source -> [String: Any] in
                 var dict: [String: Any] = [
                     "id": source.id.uuidString,

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -49,6 +49,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "updateStreamTitle",
         "deleteStream",
         "saveStreamDocument",
+        "saveScrollPosition",
         "exportStream"
     ]
 
@@ -97,7 +98,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     let document = try persistence.loadOrCreateStreamDocument(streamId: id)
 
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                    let payload: [String: AnyCodable] = [
+                        "stream": AnyCodable(streamPayload),
+                        "scrollOffset": AnyCodable(document.scrollOffset)
+                    ]
+                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
                     ingestService?.enqueuePendingSources(for: id)
                 }
             } catch {
@@ -111,7 +116,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 delegate?.setCurrentStreamIdForFileDrops(stream.id)
                 let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
                 let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                let payload: [String: AnyCodable] = [
+                    "stream": AnyCodable(streamPayload),
+                    "scrollOffset": AnyCodable(document.scrollOffset)
+                ]
+                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
             }
@@ -192,6 +201,21 @@ final class StreamMessageHandler: BridgeMessageHandler {
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
                 await bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+            }
+
+        case "saveScrollPosition":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let offset = payload["offset"]?.doubleValue else {
+                DebugLog.log("[WebViewManager] Invalid saveScrollPosition payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveScrollPosition payload")
+                return
+            }
+            do {
+                try persistence.saveScrollOffset(streamId: streamId, offset: offset)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -50,6 +50,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "deleteStream",
         "saveStreamDocument",
         "saveScrollPosition",
+        "openExternalURL",
         "exportStream"
     ]
 
@@ -216,6 +217,23 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 try persistence.saveScrollOffset(streamId: streamId, offset: offset)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "openExternalURL":
+            guard let payload = message.payload,
+                  let rawURL = payload["url"]?.value as? String,
+                  rawURL.range(of: #"^https?://"#, options: [.regularExpression, .caseInsensitive]) != nil,
+                  let components = URLComponents(string: rawURL),
+                  let scheme = components.scheme?.lowercased(),
+                  (scheme == "http" || scheme == "https"),
+                  components.host != nil,
+                  let url = components.url else {
+                DebugLog.log("[StreamMessageHandler] Rejected external URL")
+                return
+            }
+
+            await MainActor.run {
+                _ = NSWorkspace.shared.open(url)
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -50,6 +50,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "deleteStream",
         "saveStreamDocument",
         "saveScrollPosition",
+        "setSourceScope",
         "openExternalURL",
         "exportStream"
     ]
@@ -101,6 +102,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
                     let payload: [String: AnyCodable] = [
                         "stream": AnyCodable(streamPayload),
+                        "sourceScope": AnyCodable(stream.sourceScope.rawValue),
                         "scrollOffset": AnyCodable(document.scrollOffset)
                     ]
                     bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
@@ -119,6 +121,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 let streamPayload = StreamCodec.encodeStream(stream, document: document)
                 let payload: [String: AnyCodable] = [
                     "stream": AnyCodable(streamPayload),
+                    "sourceScope": AnyCodable(stream.sourceScope.rawValue),
                     "scrollOffset": AnyCodable(document.scrollOffset)
                 ]
                 bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
@@ -217,6 +220,22 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 try persistence.saveScrollOffset(streamId: streamId, offset: offset)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "setSourceScope":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let scopeValue = payload["scope"]?.value as? String,
+                  let scope = SourceScope(rawValue: scopeValue) else {
+                DebugLog.log("[WebViewManager] Invalid setSourceScope payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid setSourceScope payload")
+                return
+            }
+            do {
+                _ = try persistence.setSourceScope(streamId: streamId, scope: scope)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to set source scope (\(DebugLog.errorSummary(error)))")
             }
 
         case "openExternalURL":

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -381,10 +381,17 @@ private final class PDFPaneFindSearchField: NSSearchField {
     }
 }
 
+private struct PDFOutlineSidebarEntry {
+    let title: String
+    let destination: PDFDestination?
+    let depth: Int
+}
+
 final class PDFReaderPaneController: NSViewController {
     var onLinkSelection: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPlaced: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPickCancelled: ((UUID) -> Void)?
+    var onPageChanged: ((UUID, Int) -> Void)?
     var highlightsProvider: ((UUID) -> [PDFHighlightRecord])?
     var onClose: (() -> Void)?
 
@@ -394,6 +401,7 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfPaneTitleField = NSTextField(labelWithString: "")
     private let pdfPaneStatusField = NSTextField(labelWithString: "")
     private let pdfPaneHintIconView = NSImageView(frame: .zero)
+    private let pdfPaneOutlineButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneLinkButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneCloseButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindBarView = NSView(frame: .zero)
@@ -401,9 +409,13 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfFindCounterField = NSTextField(labelWithString: "")
     private let pdfFindPreviousButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindNextButton = NSButton(title: "", target: nil, action: nil)
+    private let pdfOutlineScrollView = NSScrollView(frame: .zero)
+    private let pdfOutlineStackView = NSStackView(frame: .zero)
     private let pdfPanePDFView = PDFView(frame: .zero)
     private var pdfPaneWidthConstraint: NSLayoutConstraint?
     private var pdfFindBarHeightConstraint: NSLayoutConstraint?
+    private var pdfOutlineWidthConstraint: NSLayoutConstraint?
+    private var pdfPaneOutlineButtonWidthConstraint: NSLayoutConstraint?
     private var pdfPaneStatusLeadingConstraint: NSLayoutConstraint?
     private var pdfPaneStatusHintLeadingConstraint: NSLayoutConstraint?
     private var isPDFPaneVisible = false
@@ -423,9 +435,16 @@ final class PDFReaderPaneController: NSViewController {
     private var pdfFindMatches: [PDFSelection] = []
     private var pdfFindCurrentIndex: Int?
     private var pdfFindIsCapped = false
+    private var pdfPageSaveWorkItem: DispatchWorkItem?
+    private var pdfPaneMessageWorkItem: DispatchWorkItem?
+    private var pdfPaneTransientMessage: String?
+    private var pdfOutlineEntries: [PDFOutlineSidebarEntry] = []
+    private var isPDFOutlineVisible = false
 
     deinit {
         pdfFindDebounceWorkItem?.cancel()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self)
         exitAnchorPickMode(notifyCancelled: false)
         releaseActivePDFContext()
@@ -436,7 +455,7 @@ final class PDFReaderPaneController: NSViewController {
         configurePDFPane()
     }
 
-    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String) throws {
+    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String, lastPageIndex: Int? = nil) throws {
         if let existing = activePDFContext, existing.sourceId != sourceId {
             exitAnchorPickMode(notifyCancelled: true)
             releaseActivePDFContext()
@@ -460,6 +479,7 @@ final class PDFReaderPaneController: NSViewController {
         }
 
         pdfPanePDFView.document = document
+        configurePDFOutline(document: document)
         setPDFPaneHeader(displayName: displayName)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -470,6 +490,9 @@ final class PDFReaderPaneController: NSViewController {
             fileURL: url
         )
         applySavedHighlights(sourceId: sourceId)
+        if let lastPageIndex {
+            navigate(toPageIndex: lastPageIndex)
+        }
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -691,6 +714,7 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneTitleField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneStatusField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneHintIconView.translatesAutoresizingMaskIntoConstraints = false
+        pdfPaneOutlineButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneLinkButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneCloseButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindBarView.translatesAutoresizingMaskIntoConstraints = false
@@ -698,6 +722,8 @@ final class PDFReaderPaneController: NSViewController {
         pdfFindCounterField.translatesAutoresizingMaskIntoConstraints = false
         pdfFindPreviousButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindNextButton.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineScrollView.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineStackView.translatesAutoresizingMaskIntoConstraints = false
         pdfPanePDFView.translatesAutoresizingMaskIntoConstraints = false
 
         pdfPaneResizeHandle.wantsLayer = true
@@ -729,6 +755,23 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneHintIconView.imageScaling = .scaleProportionallyDown
         pdfPaneHintIconView.contentTintColor = PDFPaneStyle.accent
         pdfPaneHintIconView.isHidden = true
+
+        pdfPaneOutlineButton.target = self
+        pdfPaneOutlineButton.action = #selector(handlePDFOutlineToggle)
+        pdfPaneOutlineButton.bezelStyle = .texturedRounded
+        pdfPaneOutlineButton.controlSize = .small
+        pdfPaneOutlineButton.image = NSImage(systemSymbolName: "list.bullet", accessibilityDescription: nil)
+        pdfPaneOutlineButton.imagePosition = .imageOnly
+        pdfPaneOutlineButton.imageScaling = .scaleProportionallyDown
+        pdfPaneOutlineButton.isBordered = true
+        pdfPaneOutlineButton.showsBorderOnlyWhileMouseInside = true
+        pdfPaneOutlineButton.contentTintColor = PDFPaneStyle.textMuted
+        pdfPaneOutlineButton.toolTip = "Show outline"
+        pdfPaneOutlineButton.setAccessibilityLabel("Toggle PDF outline")
+        pdfPaneOutlineButton.setButtonType(.toggle)
+        pdfPaneOutlineButton.isHidden = true
+        pdfPaneOutlineButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        pdfPaneOutlineButton.setContentHuggingPriority(.required, for: .horizontal)
 
         pdfPaneLinkButton.target = self
         pdfPaneLinkButton.action = #selector(handlePDFPaneLinkSelection)
@@ -799,6 +842,19 @@ final class PDFReaderPaneController: NSViewController {
             action: #selector(handlePDFFindNext)
         )
 
+        pdfOutlineScrollView.drawsBackground = true
+        pdfOutlineScrollView.backgroundColor = PDFPaneStyle.surface
+        pdfOutlineScrollView.hasVerticalScroller = true
+        pdfOutlineScrollView.hasHorizontalScroller = false
+        pdfOutlineScrollView.borderType = .noBorder
+        pdfOutlineScrollView.isHidden = true
+        pdfOutlineScrollView.documentView = pdfOutlineStackView
+
+        pdfOutlineStackView.orientation = .vertical
+        pdfOutlineStackView.alignment = .leading
+        pdfOutlineStackView.distribution = .gravityAreas
+        pdfOutlineStackView.spacing = 0
+
         pdfPanePDFView.autoScales = true
         pdfPanePDFView.displayMode = .singlePageContinuous
         pdfPanePDFView.displayDirection = .vertical
@@ -823,10 +879,12 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneView.addSubview(pdfPaneResizeHandle)
         pdfPaneView.addSubview(pdfPaneHeaderView)
         pdfPaneView.addSubview(pdfFindBarView)
+        pdfPaneView.addSubview(pdfOutlineScrollView)
         pdfPaneView.addSubview(pdfPanePDFView)
         pdfPaneHeaderView.addSubview(pdfPaneTitleField)
         pdfPaneHeaderView.addSubview(pdfPaneHintIconView)
         pdfPaneHeaderView.addSubview(pdfPaneStatusField)
+        pdfPaneHeaderView.addSubview(pdfPaneOutlineButton)
         pdfPaneHeaderView.addSubview(pdfPaneLinkButton)
         pdfPaneHeaderView.addSubview(pdfPaneCloseButton)
         pdfPaneHeaderView.addSubview(headerSeparator)
@@ -866,7 +924,7 @@ final class PDFReaderPaneController: NSViewController {
                 constant: PDFPaneStyle.trafficLightSafeLeading
             ),
             pdfPaneTitleField.topAnchor.constraint(equalTo: pdfPaneHeaderView.topAnchor, constant: 6),
-            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
 
             pdfPaneHintIconView.leadingAnchor.constraint(equalTo: pdfPaneTitleField.leadingAnchor),
             pdfPaneHintIconView.centerYAnchor.constraint(equalTo: pdfPaneStatusField.centerYAnchor),
@@ -874,7 +932,7 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneHintIconView.heightAnchor.constraint(equalToConstant: 12),
 
             pdfPaneStatusField.topAnchor.constraint(equalTo: pdfPaneTitleField.bottomAnchor, constant: 1),
-            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
             pdfPaneStatusField.bottomAnchor.constraint(lessThanOrEqualTo: pdfPaneHeaderView.bottomAnchor, constant: -5),
 
             pdfPaneCloseButton.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor, constant: -10),
@@ -886,6 +944,10 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneLinkButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
             pdfPaneLinkButton.widthAnchor.constraint(equalToConstant: 28),
             pdfPaneLinkButton.heightAnchor.constraint(equalToConstant: 28),
+
+            pdfPaneOutlineButton.trailingAnchor.constraint(equalTo: pdfPaneLinkButton.leadingAnchor, constant: -8),
+            pdfPaneOutlineButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
+            pdfPaneOutlineButton.heightAnchor.constraint(equalToConstant: 28),
 
             headerSeparator.leadingAnchor.constraint(equalTo: pdfPaneHeaderView.leadingAnchor),
             headerSeparator.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor),
@@ -920,7 +982,16 @@ final class PDFReaderPaneController: NSViewController {
             findSeparator.bottomAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             findSeparator.heightAnchor.constraint(equalToConstant: 1),
 
-            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
+            pdfOutlineScrollView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
+
+            pdfOutlineStackView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.leadingAnchor),
+            pdfOutlineStackView.trailingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.trailingAnchor),
+            pdfOutlineStackView.topAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.topAnchor),
+            pdfOutlineStackView.widthAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.widthAnchor),
+
+            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.trailingAnchor),
             pdfPanePDFView.trailingAnchor.constraint(equalTo: pdfPaneView.trailingAnchor, constant: -8),
             pdfPanePDFView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             pdfPanePDFView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
@@ -928,6 +999,10 @@ final class PDFReaderPaneController: NSViewController {
 
         pdfFindBarHeightConstraint = pdfFindBarView.heightAnchor.constraint(equalToConstant: 0)
         pdfFindBarHeightConstraint?.isActive = true
+        pdfOutlineWidthConstraint = pdfOutlineScrollView.widthAnchor.constraint(equalToConstant: 0)
+        pdfOutlineWidthConstraint?.isActive = true
+        pdfPaneOutlineButtonWidthConstraint = pdfPaneOutlineButton.widthAnchor.constraint(equalToConstant: 0)
+        pdfPaneOutlineButtonWidthConstraint?.isActive = true
         pdfFindSearchField.trailingAnchor.constraint(
             lessThanOrEqualTo: pdfFindCounterField.leadingAnchor,
             constant: -8
@@ -959,6 +1034,130 @@ final class PDFReaderPaneController: NSViewController {
         button.contentTintColor = PDFPaneStyle.textMuted
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    private func configurePDFOutline(document: PDFDocument?) {
+        pdfOutlineEntries = document?.outlineRoot.flatMap { flattenPDFOutline($0) } ?? []
+        rebuildPDFOutlineSidebar()
+        pdfPaneOutlineButton.isHidden = pdfOutlineEntries.isEmpty
+        pdfPaneOutlineButtonWidthConstraint?.constant = pdfOutlineEntries.isEmpty ? 0 : 28
+        if pdfOutlineEntries.isEmpty {
+            setPDFOutlineVisible(false)
+        }
+    }
+
+    private func flattenPDFOutline(_ root: PDFOutline, depth: Int = 0) -> [PDFOutlineSidebarEntry] {
+        guard depth < 3 else { return [] }
+
+        var entries: [PDFOutlineSidebarEntry] = []
+        for index in 0..<root.numberOfChildren {
+            guard let child = root.child(at: index) else { continue }
+            let title = child.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayTitle = title.flatMap { $0.isEmpty ? nil : $0 } ?? "Untitled"
+            entries.append(PDFOutlineSidebarEntry(
+                title: displayTitle,
+                destination: child.destination,
+                depth: depth
+            ))
+            entries.append(contentsOf: flattenPDFOutline(child, depth: depth + 1))
+        }
+        return entries
+    }
+
+    private func rebuildPDFOutlineSidebar() {
+        pdfOutlineStackView.arrangedSubviews.forEach { view in
+            pdfOutlineStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
+        for (index, entry) in pdfOutlineEntries.enumerated() {
+            let row = NSView(frame: .zero)
+            row.translatesAutoresizingMaskIntoConstraints = false
+            let button = NSButton(title: entry.title, target: self, action: #selector(handlePDFOutlineEntryClick(_:)))
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.tag = index
+            button.isBordered = false
+            button.alignment = .left
+            button.font = NSFont.systemFont(ofSize: 12)
+            button.contentTintColor = entry.destination == nil ? PDFPaneStyle.textMuted : PDFPaneStyle.text
+            button.isEnabled = entry.destination != nil
+            button.lineBreakMode = .byTruncatingTail
+            button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            row.addSubview(button)
+            pdfOutlineStackView.addArrangedSubview(row)
+
+            NSLayoutConstraint.activate([
+                row.widthAnchor.constraint(equalTo: pdfOutlineStackView.widthAnchor),
+                row.heightAnchor.constraint(greaterThanOrEqualToConstant: 26),
+                button.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 10 + CGFloat(entry.depth * 14)),
+                button.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -8),
+                button.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            ])
+        }
+    }
+
+    @objc private func handlePDFOutlineToggle() {
+        setPDFOutlineVisible(!isPDFOutlineVisible)
+    }
+
+    @objc private func handlePDFOutlineEntryClick(_ sender: NSButton) {
+        guard sender.tag >= 0,
+              sender.tag < pdfOutlineEntries.count,
+              let destination = pdfOutlineEntries[sender.tag].destination else {
+            return
+        }
+
+        pdfPanePDFView.go(to: destination)
+    }
+
+    private func setPDFOutlineVisible(_ visible: Bool) {
+        let shouldShow = visible && !pdfOutlineEntries.isEmpty
+        isPDFOutlineVisible = shouldShow
+        pdfOutlineScrollView.isHidden = !shouldShow
+        pdfOutlineWidthConstraint?.constant = shouldShow ? 220 : 0
+        pdfPaneOutlineButton.state = shouldShow ? .on : .off
+        pdfPaneOutlineButton.toolTip = shouldShow ? "Hide outline" : "Show outline"
+        view.layoutSubtreeIfNeeded()
+    }
+
+    private func schedulePDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.saveCurrentPDFPageIndex()
+        }
+        pdfPageSaveWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: workItem)
+    }
+
+    private func flushPDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        pdfPageSaveWorkItem = nil
+        saveCurrentPDFPageIndex()
+    }
+
+    private func saveCurrentPDFPageIndex() {
+        guard let context = activePDFContext,
+              let document = pdfPanePDFView.document,
+              let page = pdfPanePDFView.currentPage else {
+            return
+        }
+
+        let pageIndex = document.index(for: page)
+        guard pageIndex >= 0, pageIndex < document.pageCount else { return }
+        onPageChanged?(context.sourceId, pageIndex)
+    }
+
+    private func showPDFPaneMessage(_ message: String) {
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = message
+        updatePDFPaneStatus()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pdfPaneTransientMessage = nil
+            self?.updatePDFPaneStatus()
+        }
+        pdfPaneMessageWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: workItem)
     }
 
     private func handlePDFFindKeyDown(_ event: NSEvent) -> Bool {
@@ -1220,12 +1419,17 @@ final class PDFReaderPaneController: NSViewController {
 
     private func releaseActivePDFContext() {
         exitAnchorPickMode(notifyCancelled: false)
+        flushPDFPageSave()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = nil
         resetPDFFindState()
         if let current = activePDFContext {
             current.fileURL.stopAccessingSecurityScopedResource()
         }
         activePDFContext = nil
         pdfPanePDFView.document = nil
+        configurePDFOutline(document: nil)
         setPDFPaneHeader(displayName: nil)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -1247,6 +1451,7 @@ final class PDFReaderPaneController: NSViewController {
 
     @objc private func handlePDFPanePageChanged() {
         updatePDFPaneStatus()
+        schedulePDFPageSave()
     }
 
     @objc private func handlePDFPaneResizePan(_ recognizer: NSPanGestureRecognizer) {
@@ -1272,23 +1477,23 @@ final class PDFReaderPaneController: NSViewController {
         exitAnchorPickMode(notifyCancelled: true)
 
         guard let context = activePDFContext else {
-            NSSound.beep()
+            showPDFPaneMessage("Open a PDF before linking.")
             return
         }
         guard let selection = pdfPanePDFView.currentSelection else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !quote.isEmpty else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let rects = highlightRects(for: selection)
         guard let firstRect = rects.first else {
-            NSSound.beep()
+            showPDFPaneMessage("That selection cannot be linked.")
             return
         }
 
@@ -1455,6 +1660,21 @@ final class PDFReaderPaneController: NSViewController {
         return page
     }
 
+    @discardableResult
+    private func navigate(toPageIndex pageIndex: Int) -> PDFPage? {
+        guard let document = pdfPanePDFView.document,
+              document.pageCount > 0 else {
+            return nil
+        }
+
+        let clampedPageIndex = max(0, min(pageIndex, document.pageCount - 1))
+        guard let page = document.page(at: clampedPageIndex) else { return nil }
+        let bounds = page.bounds(for: .mediaBox)
+        let destination = PDFDestination(page: page, at: CGPoint(x: bounds.minX, y: bounds.maxY))
+        pdfPanePDFView.go(to: destination)
+        return page
+    }
+
     private func showCitationPageFallbackAffordance(on page: PDFPage) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             guard let self else { return }
@@ -1568,7 +1788,7 @@ final class PDFReaderPaneController: NSViewController {
         guard let context = activePDFContext,
               let document = pdfPanePDFView.document,
               let page = pdfPanePDFView.page(for: pointInPDFView, nearest: true) else {
-            NSSound.beep()
+            showPDFPaneMessage("Pick a spot inside the PDF.")
             cancelAnchorPickMode()
             return
         }
@@ -1669,6 +1889,14 @@ final class PDFReaderPaneController: NSViewController {
 
     private func updatePDFPaneStatus() {
         let pageText = pdfPanePageText()
+        if let message = pdfPaneTransientMessage {
+            pdfPaneHintIconView.isHidden = true
+            pdfPaneStatusLeadingConstraint?.isActive = true
+            pdfPaneStatusHintLeadingConstraint?.isActive = false
+            pdfPaneStatusField.stringValue = [pageText, message].filter { !$0.isEmpty }.joined(separator: " · ")
+            return
+        }
+
         let showHint = isAnchorPickMode
         let hintText = "Click a spot to link · Esc to cancel"
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -151,6 +151,14 @@ final class WebViewManager: NSObject {
         pdfPaneController.onAnchorPickCancelled = { [weak self] streamId in
             self?.sendPDFAnchorPickCancelled(streamId: streamId)
         }
+        pdfPaneController.onPageChanged = { [weak self] sourceId, pageIndex in
+            guard let self, let persistence = self.persistence else { return }
+            do {
+                try persistence.saveSourceLastPageIndex(sourceId: sourceId, pageIndex: pageIndex)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save PDF page position (\(DebugLog.errorSummary(error)))")
+            }
+        }
         pdfPaneController.onClose = { [weak self] in
             self?.activePDFPaneStreamId = nil
             self?.sendPDFPaneStateChanged(visible: false)
@@ -372,7 +380,8 @@ final class WebViewManager: NSObject {
                         url: url,
                         streamId: source.streamId,
                         sourceId: source.id,
-                        displayName: source.displayName
+                        displayName: source.displayName,
+                        lastPageIndex: afterPresent == nil ? source.lastPageIndex : nil
                     )
                     self.activePDFPaneStreamId = source.streamId
                     self.sendPDFPaneStateChanged(

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -221,6 +221,7 @@ final class WebViewManager: NSObject {
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
             let streamLoadedPayload: [String: AnyCodable] = [
                 "stream": AnyCodable(streamPayload),
+                "sourceScope": AnyCodable(reloadedStream.sourceScope.rawValue),
                 "scrollOffset": AnyCodable(document.scrollOffset)
             ]
             bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -211,9 +211,11 @@ final class WebViewManager: NSObject {
 
             let document = try persistence.loadOrCreateStreamDocument(streamId: createdStream.id)
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
-            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: [
-                "stream": AnyCodable(streamPayload)
-            ]))
+            let streamLoadedPayload: [String: AnyCodable] = [
+                "stream": AnyCodable(streamPayload),
+                "scrollOffset": AnyCodable(document.scrollOffset)
+            ]
+            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))
 
             let summaries = try persistence.loadStreamSummaries()
             let payload = StreamCodec.encodeSummaries(summaries)

--- a/Sources/Ticker/Models/SourceReference.swift
+++ b/Sources/Ticker/Models/SourceReference.swift
@@ -14,6 +14,7 @@ struct SourceReference: Identifiable, Codable {
     var embeddingStatus: SourceEmbeddingStatus
     var indexStatus: SourceIndexStatus
     var aiExcluded: Bool
+    var lastPageIndex: Int?
     let addedAt: Date
 
     var shortTitle: String {
@@ -33,6 +34,7 @@ struct SourceReference: Identifiable, Codable {
         embeddingStatus: SourceEmbeddingStatus = .none,
         indexStatus: SourceIndexStatus = .pending,
         aiExcluded: Bool = false,
+        lastPageIndex: Int? = nil,
         addedAt: Date = Date()
     ) {
         self.id = id
@@ -47,6 +49,7 @@ struct SourceReference: Identifiable, Codable {
         self.embeddingStatus = embeddingStatus
         self.indexStatus = indexStatus
         self.aiExcluded = aiExcluded
+        self.lastPageIndex = lastPageIndex
         self.addedAt = addedAt
     }
 }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -41,6 +41,7 @@ struct StreamDocument: Codable {
     let streamId: UUID
     var markdown: String
     var revision: Int
+    var scrollOffset: Double
     let createdAt: Date
     var updatedAt: Date
 
@@ -48,12 +49,14 @@ struct StreamDocument: Codable {
         streamId: UUID,
         markdown: String = "",
         revision: Int = 0,
+        scrollOffset: Double = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.streamId = streamId
         self.markdown = markdown
         self.revision = revision
+        self.scrollOffset = scrollOffset
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -5,6 +5,7 @@ struct Stream: Identifiable, Codable {
     let id: UUID
     var title: String
     var sources: [SourceReference]
+    var sourceScope: SourceScope
     let createdAt: Date
     var updatedAt: Date
 
@@ -12,12 +13,14 @@ struct Stream: Identifiable, Codable {
         id: UUID = UUID(),
         title: String = "Untitled",
         sources: [SourceReference] = [],
+        sourceScope: SourceScope = .auto,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.id = id
         self.title = title
         self.sources = sources
+        self.sourceScope = sourceScope
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -592,6 +592,7 @@ final class PersistenceService {
                     embeddingStatus: embeddingStatus,
                     indexStatus: indexStatus,
                     aiExcluded: aiExcluded != 0,
+                    lastPageIndex: row["last_page_index"],
                     addedAt: Date(timeIntervalSince1970: row["added_at"])
                 )
             }
@@ -964,6 +965,7 @@ final class PersistenceService {
                 embeddingStatus: embeddingStatus,
                 indexStatus: indexStatus,
                 aiExcluded: aiExcluded != 0,
+                lastPageIndex: row["last_page_index"],
                 addedAt: Date(timeIntervalSince1970: row["added_at"])
             )
         }
@@ -1014,6 +1016,15 @@ final class PersistenceService {
             try db.execute(
                 sql: "UPDATE sources SET ai_excluded = ? WHERE id = ?",
                 arguments: [excluded ? 1 : 0, sourceId.uuidString]
+            )
+        }
+    }
+
+    func saveSourceLastPageIndex(sourceId: UUID, pageIndex: Int) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sources SET last_page_index = ? WHERE id = ?",
+                arguments: [max(0, pageIndex), sourceId.uuidString]
             )
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -438,6 +438,11 @@ final class PersistenceService {
             """)
         }
 
+        migrator.registerMigration("v19_scroll_restore") { db in
+            try db.execute(sql: "ALTER TABLE stream_documents ADD COLUMN scroll_offset REAL NOT NULL DEFAULT 0")
+            try db.execute(sql: "ALTER TABLE sources ADD COLUMN last_page_index INTEGER")
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -737,7 +742,7 @@ final class PersistenceService {
         try dbQueue.read { db in
             guard let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) else {
                 return nil
@@ -747,6 +752,7 @@ final class PersistenceService {
                 streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                 markdown: row["markdown"],
                 revision: row["revision"],
+                scrollOffset: row["scroll_offset"],
                 createdAt: Date(timeIntervalSince1970: row["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: row["updated_at"])
             )
@@ -758,13 +764,14 @@ final class PersistenceService {
         try dbQueue.write { db in
             if let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) {
                 return StreamDocument(
                     streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                     markdown: row["markdown"],
                     revision: row["revision"],
+                    scrollOffset: row["scroll_offset"],
                     createdAt: Date(timeIntervalSince1970: row["created_at"]),
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"])
                 )
@@ -788,8 +795,27 @@ final class PersistenceService {
                 streamId: streamId,
                 markdown: markdown,
                 revision: 0,
+                scrollOffset: 0,
                 createdAt: now,
                 updatedAt: now
+            )
+        }
+    }
+
+    func saveScrollOffset(streamId: UUID, offset: Double) throws {
+        let clampedOffset = max(0, offset)
+        try dbQueue.write { db in
+            guard try Row.fetchOne(
+                db,
+                sql: "SELECT 1 FROM stream_documents WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            ) != nil else {
+                return
+            }
+
+            try db.execute(
+                sql: "UPDATE stream_documents SET scroll_offset = ? WHERE stream_id = ?",
+                arguments: [clampedOffset, streamId.uuidString]
             )
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -601,6 +601,7 @@ final class PersistenceService {
                 id: UUID(uuidString: streamRow["id"])!,
                 title: streamRow["title"],
                 sources: sources,
+                sourceScope: SourceScope(rawValue: streamRow["source_scope"]) ?? .auto,
                 createdAt: Date(timeIntervalSince1970: streamRow["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: streamRow["updated_at"])
             )
@@ -611,8 +612,14 @@ final class PersistenceService {
         let stream = Stream(title: title)
         try dbQueue.write { db in
             try db.execute(
-                sql: "INSERT INTO streams (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)",
-                arguments: [stream.id.uuidString, stream.title, stream.createdAt.timeIntervalSince1970, stream.updatedAt.timeIntervalSince1970]
+                sql: "INSERT INTO streams (id, title, source_scope, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                arguments: [
+                    stream.id.uuidString,
+                    stream.title,
+                    stream.sourceScope.rawValue,
+                    stream.createdAt.timeIntervalSince1970,
+                    stream.updatedAt.timeIntervalSince1970
+                ]
             )
         }
         return stream
@@ -621,9 +628,23 @@ final class PersistenceService {
     func updateStream(_ stream: Stream) throws {
         try dbQueue.write { db in
             try db.execute(
-                sql: "UPDATE streams SET title = ?, updated_at = ? WHERE id = ?",
-                arguments: [stream.title, Date().timeIntervalSince1970, stream.id.uuidString]
+                sql: "UPDATE streams SET title = ?, source_scope = ?, updated_at = ? WHERE id = ?",
+                arguments: [stream.title, stream.sourceScope.rawValue, Date().timeIntervalSince1970, stream.id.uuidString]
             )
+        }
+    }
+
+    @discardableResult
+    func setSourceScope(streamId: UUID, scope: SourceScope) throws -> Bool {
+        try dbQueue.write { db in
+            guard try Row.fetchOne(db, sql: "SELECT id FROM streams WHERE id = ?", arguments: [streamId.uuidString]) != nil else {
+                return false
+            }
+            try db.execute(
+                sql: "UPDATE streams SET source_scope = ? WHERE id = ?",
+                arguments: [scope.rawValue, streamId.uuidString]
+            )
+            return true
         }
     }
 
@@ -714,11 +735,12 @@ final class PersistenceService {
     func saveStream(_ stream: Stream) throws {
         try dbQueue.write { db in
             try db.execute(sql: """
-                INSERT INTO streams (id, title, created_at, updated_at)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO streams (id, title, source_scope, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
             """, arguments: [
                 stream.id.uuidString,
                 stream.title,
+                stream.sourceScope.rawValue,
                 stream.createdAt.timeIntervalSince1970,
                 stream.updatedAt.timeIntervalSince1970
             ])

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -7,46 +7,34 @@ enum Prompts {
     // MARK: - OpenAI (Knowledge/Thinking Partner)
 
     static let thinkingPartner = """
-    You provide content for a research document. Responses become reference notes.
+    You are contributing text to the user's research document. Your output is inserted directly
+    into their notes and must read as part of the document — never as a chat reply.
 
-    Style:
-    - Terse. No filler, no hedging, no "I think" or "It's worth noting"
-    - Use markdown: bullets, bold for emphasis, code blocks
-    - Start with a short Markdown H2 title as the first line: "## <title>"
-      - Keep under 8 words
-      - No quotes, no commentary
-      - Follow with a blank line, then the content
-    - Use additional ##/### headers only for subsections within longer responses
-    - Lead with substance—facts, data, specifics
-    - If uncertain, state it briefly and move on
-
-    Example:
-    ## Topic
-    - **Key point**: ...
+    Rules:
+    - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
+      closing summary, no offers of further help.
+    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
+      API fields). Never use lists as the default shape. Never produce lists of bolded
+      term-colon-definition pairs.
+    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - Match the surrounding document's tone and terminology when context is provided.
     """
 
     /// Thinking partner prompt WITH heading requirement (for stream cell "think" flow)
     static let thinkingPartnerWithHeading = """
-    You provide content for a research document. Responses become reference notes.
+    First line: A Markdown H2 heading (`## Heading`) in ≤8 words summarizing the response.
 
-    Format (REQUIRED):
-    - First line: A Markdown H2 heading (## Topic) in ≤8 words summarizing the response
-    - Second line: Blank
-    - Remaining: Body content
+    You are contributing text to the user's research document. Your output is inserted directly
+    into their notes and must read as part of the document — never as a chat reply.
 
-    Example structure:
-    ## Photosynthesis in Plants
-
-    **Core process**: Plants convert sunlight...
-    - Step 1: Light absorption
-    - Step 2: ...
-
-    Style:
-    - Terse. No filler, no hedging, no "I think" or "It's worth noting"
-    - Use markdown: bullets, bold for emphasis, code blocks
-    - Use ### for subsections within the body (avoid additional ## headings)
-    - Lead with substance—facts, data, specifics
-    - If uncertain, state it briefly and move on
+    Rules:
+    - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
+      closing summary, no offers of further help.
+    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
+      API fields). Never use lists as the default shape. Never produce lists of bolded
+      term-colon-definition pairs.
+    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - Match the surrounding document's tone and terminology when context is provided.
     """
 
     static let restatement = """

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -37,6 +37,22 @@ enum Prompts {
     - Match the surrounding document's tone and terminology when context is provided.
     """
 
+    static let verbDevelop = """
+    Develop the following passage into a fuller, clearer version of the same idea. Preserve the author's voice and intent; deepen, do not pad. Output only the developed passage.
+    """
+
+    static let verbAsk = """
+    Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose.
+    """
+
+    static let verbChallenge = """
+    Identify the single weakest point in this passage — a hidden assumption, an internal contradiction, or an unsupported leap. State it plainly in two to four sentences, then end with one pointed question back to the author. Do not rewrite the passage. Do not answer your own question.
+    """
+
+    static let verbDefine = """
+    Define or explain the selected term or phrase concisely, in the context of the surrounding document. Two to four sentences. Output only the explanation.
+    """
+
     static let restatement = """
     Convert input to a brief heading. Return ONLY the heading, no quotes or explanation.
 

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -227,6 +227,10 @@ final class ProxyLLMService {
             }
 
             for try await rawLine in bytes.lines {
+                if Task.isCancelled {
+                    debugLog("Proxy stream cancelled")
+                    return
+                }
                 let line = rawLine.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
                 if !didReceiveAnyEvent && !line.isEmpty {
                     // Lightweight signal that the stream is alive.
@@ -282,6 +286,10 @@ final class ProxyLLMService {
 
         } catch let urlError as URLError {
             headerWatchdog.cancel()
+            if Task.isCancelled {
+                debugLog("Proxy stream cancelled")
+                return
+            }
             if urlError.code == .timedOut {
                 let timeoutSeconds = Int(urlRequest.timeoutInterval)
                 if didReceiveHeaders {
@@ -296,6 +304,10 @@ final class ProxyLLMService {
             }
         } catch {
             headerWatchdog.cancel()
+            if Task.isCancelled {
+                debugLog("Proxy stream cancelled")
+                return
+            }
             debugLog("Proxy stream failed (\(DebugLog.errorSummary(error)))")
             await MainActor.run {
                 onError(ProxyLLMError.unreachable)

--- a/Sources/Ticker/Services/RetrievalService.swift
+++ b/Sources/Ticker/Services/RetrievalService.swift
@@ -193,7 +193,7 @@ enum SourceContextMode: Equatable {
     case retrieved
 }
 
-enum SourceScope: String {
+enum SourceScope: String, Codable {
     case auto
     case all
     case none

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -479,6 +479,51 @@ private actor AutoTitleNotificationCounter {
     }
 }
 
+private final class BridgeMessageRecorder {
+    private let lock = NSLock()
+    private var storedMessages: [BridgeMessage] = []
+
+    func send(_ message: BridgeMessage) {
+        lock.lock()
+        storedMessages.append(message)
+        lock.unlock()
+    }
+
+    func messages(ofType type: String) -> [BridgeMessage] {
+        lock.lock()
+        let messages = storedMessages.filter { $0.type == type }
+        lock.unlock()
+        return messages
+    }
+}
+
+private actor SlowDocumentAIProvider {
+    private var lastSystemPrompt: String?
+    private var didCancel = false
+
+    func stream(
+        systemPrompt: String,
+        onChunk: @escaping (String) -> Void,
+        onComplete: @escaping (SourceContext?) -> Void
+    ) async {
+        lastSystemPrompt = systemPrompt
+        onChunk("first")
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        didCancel = true
+        onComplete(nil)
+    }
+
+    func prompt() -> String? {
+        lastSystemPrompt
+    }
+
+    func cancelled() -> Bool {
+        didCancel
+    }
+}
+
 final class StreamDocumentTests: XCTestCase {
     private enum TestPDFError: Error {
         case creationFailed
@@ -863,6 +908,67 @@ final class StreamDocumentTests: XCTestCase {
 
             XCTAssertEqual(try service.loadStream(id: stream.id)?.title, "Generated Once")
         }
+    }
+
+    func test_setSourceScopePersistsAcrossReload() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scope")
+            try service.saveStream(stream)
+
+            XCTAssertTrue(try service.setSourceScope(streamId: stream.id, scope: .all))
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sourceScope, .all)
+
+            XCTAssertTrue(try service.setSourceScope(streamId: stream.id, scope: .none))
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sourceScope, SourceScope.none)
+        }
+    }
+
+    func test_documentAICancelStopsSlowStreamingProvider() async throws {
+        let recorder = BridgeMessageRecorder()
+        let provider = SlowDocumentAIProvider()
+        let handler = AIMessageHandler(
+            sendToWeb: { recorder.send($0) },
+            routeDocumentAI: { _, _, _, _, systemPrompt, onChunk, onComplete, _, _ in
+                await provider.stream(
+                    systemPrompt: systemPrompt,
+                    onChunk: onChunk,
+                    onComplete: onComplete
+                )
+            }
+        )
+        let requestId = UUID().uuidString
+
+        await handler.handle(BridgeMessage(type: "thinkDocument", payload: [
+            "requestId": AnyCodable(requestId),
+            "streamId": AnyCodable(UUID().uuidString),
+            "query": AnyCodable("What is weak here?"),
+            "imageURLs": AnyCodable([]),
+            "verb": AnyCodable("challenge")
+        ]))
+
+        try await waitUntil {
+            recorder.messages(ofType: "documentAIChunk").contains { message in
+                message.payload?["requestId"]?.value as? String == requestId
+            }
+        }
+
+        await handler.handle(BridgeMessage(type: "cancelDocumentAI", payload: [
+            "requestId": AnyCodable(requestId)
+        ]))
+
+        try await waitUntil {
+            recorder.messages(ofType: "documentAIError").contains { message in
+                message.payload?["requestId"]?.value as? String == requestId
+                    && message.payload?["errorCode"]?.value as? String == "cancelled"
+            }
+        }
+        try await waitUntil {
+            await provider.cancelled()
+        }
+
+        let prompt = await provider.prompt()
+        XCTAssertEqual(prompt, Prompts.verbChallenge)
+        XCTAssertTrue(recorder.messages(ofType: "documentAIComplete").isEmpty)
     }
 
     func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
@@ -2683,6 +2789,20 @@ final class StreamDocumentTests: XCTestCase {
                 "Existing document\n\n## Recovered captures\n\nRecovered once"
             )
         }
+    }
+
+    private func waitUntil(
+        _ condition: @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<100 {
+            if await condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
     }
 
     private func withTempPersistenceService(_ body: (PersistenceService) throws -> Void) throws {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -906,6 +906,30 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_saveSourceLastPageIndexRoundTripsThroughPersistence() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "PDF Resume")
+            try service.saveStream(stream)
+            let source = SourceReference(
+                streamId: stream.id,
+                displayName: "Manual.pdf",
+                fileType: .pdf,
+                bookmarkData: Data(),
+                status: .ready
+            )
+            try service.saveSource(source)
+
+            XCTAssertNil(try service.loadSource(id: source.id)?.lastPageIndex)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: 117)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 117)
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sources.first?.lastPageIndex, 117)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: -4)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 0)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -865,6 +865,47 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
+        try withTempPersistenceServiceAndURL { _, dbURL, _ in
+            let dbQueue = try DatabaseQueue(path: dbURL.path)
+            let documentColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(stream_documents)").map { row -> String in
+                    row["name"]
+                }
+            }
+            let sourceColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(sources)").map { row -> String in
+                    row["name"]
+                }
+            }
+
+            XCTAssertTrue(documentColumns.contains("scroll_offset"))
+            XCTAssertTrue(sourceColumns.contains("last_page_index"))
+        }
+    }
+
+    func test_saveScrollOffsetRoundTripsWithoutBumpingRevision() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scroll Restore")
+            try service.saveStream(stream)
+            let revision = try service.saveStreamDocument(streamId: stream.id, markdown: "Line one\n\nLine two")
+            let before = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+
+            try service.saveScrollOffset(streamId: stream.id, offset: 512.5)
+
+            let after = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(revision, 1)
+            XCTAssertEqual(after.markdown, before.markdown)
+            XCTAssertEqual(after.revision, before.revision)
+            XCTAssertEqual(after.updatedAt, before.updatedAt)
+            XCTAssertEqual(after.scrollOffset, 512.5)
+
+            let payload = StreamCodec.encodeStream(stream, document: after)
+            let documentPayload = try XCTUnwrap(payload["document"] as? [String: Any])
+            XCTAssertEqual(documentPayload["scrollOffset"] as? Double, 512.5)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -167,8 +167,15 @@ export function App() {
           const payloadStream = message.payload?.stream as Stream | undefined;
           if (!payloadStream) break;
           const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
+          const payloadSourceScope = message.payload?.sourceScope;
+          const sourceScope: Stream['sourceScope'] = payloadSourceScope === 'auto'
+            || payloadSourceScope === 'all'
+            || payloadSourceScope === 'none'
+            ? payloadSourceScope
+            : payloadStream.sourceScope ?? 'auto';
           const loadedStream = {
             ...payloadStream,
+            sourceScope,
             document: {
               ...payloadStream.document,
               scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -164,7 +164,16 @@ export function App() {
           setIsLoading(false);
           break;
         case 'streamLoaded': {
-          const loadedStream = message.payload?.stream as Stream;
+          const payloadStream = message.payload?.stream as Stream | undefined;
+          if (!payloadStream) break;
+          const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
+          const loadedStream = {
+            ...payloadStream,
+            document: {
+              ...payloadStream.document,
+              scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,
+            },
+          };
           currentStreamIdRef.current = loadedStream?.id ?? null;
           viewRef.current = 'stream';
           setCurrentStream(loadedStream);

--- a/Web/src/components/StreamEditor.test.ts
+++ b/Web/src/components/StreamEditor.test.ts
@@ -1,10 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { nextSourceScope } from './StreamEditor';
+import { documentAIErrorRecovery, nextSourceScope, wrapChallengeOutput } from './StreamEditor';
 
 describe('nextSourceScope', () => {
   it('cycles auto to all to none to auto', () => {
     expect(nextSourceScope('auto')).toBe('all');
     expect(nextSourceScope('all')).toBe('none');
     expect(nextSourceScope('none')).toBe('auto');
+  });
+});
+
+describe('wrapChallengeOutput', () => {
+  it('quotes a single paragraph and tags the register', () => {
+    expect(wrapChallengeOutput('Weak premise. What follows?')).toBe(
+      '> Weak premise. What follows?\n\n*— Challenge*'
+    );
+  });
+
+  it('quotes multi-paragraph output line by line', () => {
+    expect(wrapChallengeOutput('First paragraph.\n\nSecond paragraph?')).toBe(
+      '> First paragraph.\n> \n> Second paragraph?\n\n*— Challenge*'
+    );
+  });
+});
+
+describe('documentAIErrorRecovery', () => {
+  it('restores cancelled output silently', () => {
+    expect(documentAIErrorRecovery('original text', 'cancelled')).toEqual({
+      restoreText: 'original text',
+      silent: true,
+    });
+  });
+
+  it('restores other errors with visible feedback', () => {
+    expect(documentAIErrorRecovery('original text', 'rate_limited')).toEqual({
+      restoreText: 'original text',
+      silent: false,
+    });
   });
 });

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -5,7 +5,7 @@ import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { bridge, type Stream, type SourceReference, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
 import { SourcesModal } from './SourcesModal';
@@ -138,6 +138,19 @@ function focusEditorAtDocumentEnd(view: EditorView) {
   view.focus();
 }
 
+function restoreViewportEnd(view: EditorView, scrollOffset: number): number {
+  const docLength = view.state.doc.length;
+  if (docLength === 0 || scrollOffset <= 0) return view.viewport.to;
+
+  const scrollHeight = view.scrollDOM.scrollHeight;
+  const clientHeight = view.scrollDOM.clientHeight;
+  if (scrollHeight <= clientHeight) return view.viewport.to;
+
+  // ponytail: pixel-to-doc estimate; upgrade to measured CodeMirror mapping if deep restores ever flash.
+  const ratio = Math.min(1, (scrollOffset + clientHeight) / scrollHeight);
+  return Math.max(view.viewport.to, Math.min(docLength, Math.ceil(docLength * ratio)));
+}
+
 const clickToDocumentEndExtension: Extension = EditorView.domEventHandlers({
   mousedown: (event, view) => {
     if (event.button !== 0 || event.defaultPrevented) return false;
@@ -233,6 +246,7 @@ export function StreamEditor({
   const [title, setTitle] = useState(stream.title);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isPrepaintHidden, setIsPrepaintHidden] = useState(true);
   const [showSourcesModal, setShowSourcesModal] = useState(false);
   const [highlightedSourceId, setHighlightedSourceId] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<'saved' | 'saving'>('saved');
@@ -270,6 +284,9 @@ export function StreamEditor({
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
   const sourceIndexNoticeTimerRef = useRef<number | null>(null);
+  const scrollSaveTimerRef = useRef<number | null>(null);
+  const scrollCleanupRef = useRef<(() => void) | null>(null);
+  const revealFrameRef = useRef<number | null>(null);
   const pendingPDFAnchorSelectionRef = useRef<PendingPDFAnchorSelection | null>(null);
   const sourcesRef = useRef<SourceReference[]>(stream.sources);
   const sourceIndexStatusesRef = useRef<Map<string, SourceReference['indexStatus']>>(new Map());
@@ -447,6 +464,46 @@ export function StreamEditor({
     }, AI_INDEXING_NOTICE_MS);
   }, [clearSourceIndexNoticeTimer]);
 
+  const clearScrollSaveTimer = useCallback(() => {
+    if (scrollSaveTimerRef.current !== null) {
+      window.clearTimeout(scrollSaveTimerRef.current);
+      scrollSaveTimerRef.current = null;
+    }
+  }, []);
+
+  const sendScrollPosition = useCallback((offset: number) => {
+    bridge.send({
+      type: 'saveScrollPosition',
+      payload: { streamId: stream.id, offset: Math.max(0, offset) },
+    });
+  }, [stream.id]);
+
+  const scheduleScrollPositionSave = useCallback(() => {
+    clearScrollSaveTimer();
+    scrollSaveTimerRef.current = window.setTimeout(() => {
+      scrollSaveTimerRef.current = null;
+      const view = editorViewRef.current;
+      if (view) {
+        sendScrollPosition(view.scrollDOM.scrollTop);
+      }
+    }, 1000);
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const flushScrollPosition = useCallback(() => {
+    clearScrollSaveTimer();
+    const view = editorViewRef.current;
+    if (view) {
+      sendScrollPosition(view.scrollDOM.scrollTop);
+    }
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const clearRevealFrame = useCallback(() => {
+    if (revealFrameRef.current !== null) {
+      window.cancelAnimationFrame(revealFrameRef.current);
+      revealFrameRef.current = null;
+    }
+  }, []);
+
   const cycleSourceScope = useCallback(() => {
     setSourceScope((previous) => {
       const next = nextSourceScope(previous);
@@ -488,17 +545,6 @@ export function StreamEditor({
       dispatchAiRangeClear(view);
     }
   }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const view = editorViewRef.current;
-      if (view) {
-        focusEditorAtDocumentEnd(view);
-      }
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [stream.id]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -1486,6 +1532,15 @@ export function StreamEditor({
   }, [clearSourceIndexNoticeTimer]);
 
   useEffect(() => {
+    return () => {
+      flushScrollPosition();
+      scrollCleanupRef.current?.();
+      scrollCleanupRef.current = null;
+      clearRevealFrame();
+    };
+  }, [clearRevealFrame, flushScrollPosition]);
+
+  useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       if (!isEditorActive()) return;
       if (!event.clipboardData?.items?.length) return;
@@ -1745,7 +1800,7 @@ export function StreamEditor({
         <div className="stream-content">
           <div
             ref={editorShellRef}
-            className="document-editor-shell"
+            className={`document-editor-shell ${isPrepaintHidden ? 'cm-prepaint' : ''}`}
             onDrop={handleDrop}
             onDragOver={handleDragOver}
           >
@@ -1777,11 +1832,25 @@ export function StreamEditor({
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
-                window.setTimeout(() => {
-                  if (editorViewRef.current === view) {
-                    focusEditorAtDocumentEnd(view);
-                  }
-                }, 0);
+
+                scrollCleanupRef.current?.();
+                const handleScroll = () => scheduleScrollPositionSave();
+                view.scrollDOM.addEventListener('scroll', handleScroll, { passive: true });
+                scrollCleanupRef.current = () => view.scrollDOM.removeEventListener('scroll', handleScroll);
+
+                clearRevealFrame();
+                const scrollOffset = Math.max(0, Number(stream.document?.scrollOffset ?? 0));
+                ensureSyntaxTree(view.state, restoreViewportEnd(view, scrollOffset), 50);
+                view.scrollDOM.scrollTop = scrollOffset;
+                revealFrameRef.current = window.requestAnimationFrame(() => {
+                  revealFrameRef.current = window.requestAnimationFrame(() => {
+                    revealFrameRef.current = null;
+                    if (editorViewRef.current === view) {
+                      setIsPrepaintHidden(false);
+                    }
+                  });
+                });
+
               }}
               onChange={(value) => {
                 setMarkdownContent(value);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -21,6 +21,7 @@ import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
 import {
+  beginPDFAnchorPick,
   buildPDFAnchorLinkEdit,
   buildTickerPDFLinkURL,
   mapPendingPDFAnchorSelection,
@@ -1652,6 +1653,26 @@ export function StreamEditor({
     view.focus();
   }, [hideSelectionMenu]);
 
+  const canLinkSelectionToPDF = pdfPaneState.visible && pdfPaneState.streamId === stream.id;
+
+  const handleSelectionLinkToPDF = useCallback(() => {
+    const context = getSelectionContext(false);
+    if (!context || !context.text.trim()) {
+      hideSelectionMenu();
+      return;
+    }
+    if (!canLinkSelectionToPDF) {
+      pendingPDFAnchorSelectionRef.current = null;
+      hideSelectionMenu();
+      addToast('Open a PDF source before linking to PDF.', 'info');
+      return;
+    }
+
+    pendingPDFAnchorSelectionRef.current = { from: context.from, to: context.to };
+    hideSelectionMenu();
+    beginPDFAnchorPick(stream.id);
+  }, [addToast, canLinkSelectionToPDF, getSelectionContext, hideSelectionMenu, stream.id]);
+
   const handleSelectionVerb = useCallback((verb: DocumentAIVerb) => {
     const context = getSelectionContext(false);
     if (!context || !context.text.trim()) {
@@ -2021,6 +2042,20 @@ export function StreamEditor({
           >
             &lt;/&gt;
           </button>
+          {canLinkSelectionToPDF && (
+            <button
+              type="button"
+              className="selection-action-button"
+              title="Link to PDF"
+              aria-label="Link to PDF"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleSelectionLinkToPDF}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path d="M8.8 12.9a1 1 0 010-1.4l3.7-3.7a3.4 3.4 0 114.8 4.8l-1.5 1.5-.7-.7 1.5-1.5a2.4 2.4 0 10-3.4-3.4l-3.7 3.7a1 1 0 001.4 1.4l2.5-2.5.7.7-2.5 2.5a2 2 0 01-2.8 0zm-2.1 7a3.4 3.4 0 010-4.8l1.5-1.5.7.7-1.5 1.5a2.4 2.4 0 103.4 3.4l3.7-3.7a1 1 0 00-1.4-1.4l-2.5 2.5-.7-.7 2.5-2.5a2 2 0 112.8 2.8l-3.7 3.7a3.4 3.4 0 01-4.8 0z" />
+              </svg>
+            </button>
+          )}
           <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -7,7 +7,7 @@ import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
 import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
-import { bridge, type Stream, type SourceReference, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
+import { bridge, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
 import { SourcesModal } from './SourcesModal';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
@@ -88,10 +88,6 @@ const SELECTION_MENU_DELAY_MS = 180;
 const AI_ERROR_FEEDBACK_MS = 2200;
 const AI_INDEXING_NOTICE_MS = 4000;
 
-export type SourceScope = 'auto' | 'all' | 'none';
-
-const sourceScopeByStreamId = new Map<string, SourceScope>();
-
 export function nextSourceScope(scope: SourceScope): SourceScope {
   switch (scope) {
     case 'auto':
@@ -115,6 +111,19 @@ function formatSourceScope(scope: SourceScope): string {
     default:
       return 'Auto';
   }
+}
+
+export function wrapChallengeOutput(text: string): string {
+  // Challenge renders inline-quoted until margin notes ship (Roadmap 4 P7); then it becomes a margin note. ponytail: inline placement is the ceiling here.
+  const quoted = text.trim().split(/\r?\n/).map((line) => `> ${line}`).join('\n');
+  return `${quoted}\n\n*— Challenge*`;
+}
+
+export function documentAIErrorRecovery(originalText: string, errorCode: string | undefined) {
+  return {
+    restoreText: originalText,
+    silent: errorCode === 'cancelled',
+  };
 }
 
 function parseDocumentAICitations(value: unknown): DocumentAICitation[] | null {
@@ -267,10 +276,9 @@ export function StreamEditor({
   const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
   const [promptValue, setPromptValue] = useState('');
-  const [sourceScope, setSourceScope] = useState<SourceScope>(
-    () => sourceScopeByStreamId.get(stream.id) ?? 'auto'
-  );
+  const [sourceScope, setSourceScope] = useState<SourceScope>(stream.sourceScope ?? 'auto');
   const [aiStatus, setAiStatus] = useState<'idle' | 'thinking'>('idle');
+  const [showRewriteMenu, setShowRewriteMenu] = useState(false);
   const [floatingMenu, setFloatingMenu] = useState<FloatingMenuState>({
     visible: false,
     left: 0,
@@ -321,6 +329,7 @@ export function StreamEditor({
     id: string;
     buffer: string;
     mode: 'replace' | 'after';
+    verb: DocumentAIVerb;
     originalText: string;
     prefix: string;
   } | null>(null);
@@ -532,7 +541,10 @@ export function StreamEditor({
   const cycleSourceScope = useCallback(() => {
     setSourceScope((previous) => {
       const next = nextSourceScope(previous);
-      sourceScopeByStreamId.set(stream.id, next);
+      bridge.send({
+        type: 'setSourceScope',
+        payload: { streamId: stream.id, scope: next },
+      });
       return next;
     });
   }, [stream.id]);
@@ -563,14 +575,15 @@ export function StreamEditor({
     setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
-    setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
+    setSourceScope(stream.sourceScope ?? 'auto');
+    setShowRewriteMenu(false);
     promptContextRef.current = null;
     aiRequestRef.current = null;
     const view = editorViewRef.current;
     if (view) {
       dispatchAiRangeClear(view);
     }
-  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
+  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.title]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -729,6 +742,7 @@ export function StreamEditor({
         if (!requestId || requestId !== active.id) return;
 
         const errorCode = message.payload?.errorCode as string | undefined;
+        const recovery = documentAIErrorRecovery(active.originalText, errorCode);
         const proxyRequestId = message.payload?.proxyRequestId as string | undefined;
         let displayError = error || 'AI request failed.';
 
@@ -762,8 +776,8 @@ export function StreamEditor({
         const range = view ? getAiWritingRange(view.state) : null;
         if (view && range) {
           view.dispatch({
-            changes: { from: range.from, to: range.to, insert: active.originalText },
-            selection: { anchor: range.from + active.originalText.length },
+            changes: { from: range.from, to: range.to, insert: recovery.restoreText },
+            selection: { anchor: range.from + recovery.restoreText.length },
             effects: setAiWritingRangeEffect.of(null),
             annotations: Transaction.addToHistory.of(false),
           });
@@ -774,8 +788,12 @@ export function StreamEditor({
 
         setAiStatus('idle');
         aiRequestRef.current = null;
-        showAiErrorFeedback(displayError);
-        addToast(displayError, 'error');
+        if (recovery.silent) {
+          hideAiFeedback();
+        } else {
+          showAiErrorFeedback(displayError);
+          addToast(displayError, 'error');
+        }
         return;
       }
 
@@ -835,6 +853,10 @@ export function StreamEditor({
 
         if (provenanceLine) {
           finalOutput = `${finalOutput}\n\n${provenanceLine}`;
+        }
+
+        if (active.verb === 'challenge') {
+          finalOutput = wrapChallengeOutput(finalOutput);
         }
 
         const suffix = active.mode === 'after' && !finalOutput.endsWith('\n') ? '\n' : '';
@@ -1145,6 +1167,7 @@ export function StreamEditor({
 
   const hideSelectionMenu = useCallback(() => {
     clearSelectionMenuTimer();
+    setShowRewriteMenu(false);
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
@@ -1485,6 +1508,7 @@ export function StreamEditor({
     from: number;
     to: number;
     mode: 'replace' | 'after';
+    verb?: DocumentAIVerb;
   }) => {
     if (isAiThinking) {
       addToast('AI is already running for this stream.', 'info');
@@ -1540,6 +1564,7 @@ export function StreamEditor({
       id: requestId,
       buffer: '',
       mode: options.mode,
+      verb: options.verb ?? 'develop',
       originalText,
       prefix,
     };
@@ -1562,6 +1587,7 @@ export function StreamEditor({
         query: options.query,
         context: options.context,
         sourceScope,
+        verb: options.verb ?? 'develop',
         imageURLs: options.imageUrls ?? [],
       },
     });
@@ -1580,6 +1606,7 @@ export function StreamEditor({
       from: context.from,
       to: context.to,
       mode: 'replace',
+      verb: 'develop',
     });
     hideSelectionMenu();
   }, [addToast, getSelectionContext, hideSelectionMenu, startDocumentAI]);
@@ -1604,8 +1631,6 @@ export function StreamEditor({
     openPromptWithContext(context);
   }, [addToast, getSelectionContext, isAiThinking, openPromptWithContext]);
 
-  const canLinkSelectionToPDF = pdfPaneState.visible && pdfPaneState.streamId === stream.id;
-
   const handleSelectionFormat = useCallback((marker: string) => {
     const view = editorViewRef.current;
     if (!view) {
@@ -1627,7 +1652,7 @@ export function StreamEditor({
     view.focus();
   }, [hideSelectionMenu]);
 
-  const handleSelectionSend = useCallback(() => {
+  const handleSelectionVerb = useCallback((verb: DocumentAIVerb) => {
     const context = getSelectionContext(false);
     if (!context || !context.text.trim()) {
       hideSelectionMenu();
@@ -1639,40 +1664,11 @@ export function StreamEditor({
       imageUrls: context.imageUrls,
       from: context.from,
       to: context.to,
-      mode: 'replace',
+      mode: verb === 'develop' ? 'replace' : 'after',
+      verb,
     });
     hideSelectionMenu();
   }, [getSelectionContext, hideSelectionMenu, startDocumentAI]);
-
-  const handleSelectionPrompt = useCallback(() => {
-    const context = getSelectionContext(false);
-    if (!context || !context.text.trim()) {
-      hideSelectionMenu();
-      return;
-    }
-    openPromptWithContext(context);
-  }, [getSelectionContext, hideSelectionMenu, openPromptWithContext]);
-
-  const handleSelectionLinkToPDF = useCallback(() => {
-    const context = getSelectionContext(false);
-    if (!context || !context.text.trim()) {
-      hideSelectionMenu();
-      return;
-    }
-    if (!canLinkSelectionToPDF) {
-      pendingPDFAnchorSelectionRef.current = null;
-      hideSelectionMenu();
-      addToast('Open a PDF source before linking to PDF.', 'info');
-      return;
-    }
-
-    pendingPDFAnchorSelectionRef.current = { from: context.from, to: context.to };
-    hideSelectionMenu();
-    bridge.send({
-      type: 'beginPdfAnchorPick',
-      payload: { streamId: stream.id },
-    });
-  }, [addToast, canLinkSelectionToPDF, getSelectionContext, hideSelectionMenu, stream.id]);
 
   const closePrompt = useCallback(() => {
     setShowPrompt(false);
@@ -1695,8 +1691,18 @@ export function StreamEditor({
       from: context.from,
       to: context.to,
       mode: 'after',
+      verb: 'ask',
     });
   }, [closePrompt, promptValue, startDocumentAI]);
+
+  const handleStopDocumentAI = useCallback(() => {
+    const active = aiRequestRef.current;
+    if (!active) return;
+    bridge.send({
+      type: 'cancelDocumentAI',
+      payload: { requestId: active.id },
+    });
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1869,8 +1875,8 @@ export function StreamEditor({
       {showPrompt && (
         <div className="ai-prompt-overlay" onClick={closePrompt}>
           <div className="ai-prompt-dialog" onClick={(e) => e.stopPropagation()}>
-            <h2>Send &amp; Prompt</h2>
-            <p>Selection will be attached as context. Write a prompt for the AI.</p>
+            <h2>Ask</h2>
+            <p>Selection will be attached as context.</p>
             <textarea
               className="ai-prompt-input"
               value={promptValue}
@@ -1884,7 +1890,7 @@ export function StreamEditor({
                   closePrompt();
                 }
               }}
-              placeholder="Ask the AI to summarize, rewrite, or expand the selected text…"
+              placeholder="Ask a question or continue the line of thought…"
               autoFocus
               rows={5}
             />
@@ -1910,7 +1916,7 @@ export function StreamEditor({
                 onClick={handlePromptSend}
                 disabled={!promptValue.trim()}
               >
-                Send
+                Ask
               </button>
             </div>
           </div>
@@ -1923,6 +1929,68 @@ export function StreamEditor({
           className="selection-action-menu"
           style={{ left: `${floatingMenu.left}px`, top: `${floatingMenu.top}px` }}
         >
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Ask"
+            aria-label="Ask"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('ask')}
+            disabled={isAiThinking}
+          >
+            Ask
+          </button>
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Challenge"
+            aria-label="Challenge"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('challenge')}
+            disabled={isAiThinking}
+          >
+            Challenge
+          </button>
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Define"
+            aria-label="Define"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('define')}
+            disabled={isAiThinking}
+          >
+            Define
+          </button>
+          <span className="selection-action-divider" aria-hidden="true" />
+          <div className="selection-action-submenu">
+            <button
+              type="button"
+              className="selection-action-button selection-action-button--text"
+              title="Rewrite"
+              aria-label="Rewrite"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => setShowRewriteMenu((value) => !value)}
+              disabled={isAiThinking}
+            >
+              Rewrite ▾
+            </button>
+            {showRewriteMenu && (
+              <div className="selection-action-submenu-panel">
+                <button
+                  type="button"
+                  className="selection-action-button selection-action-button--text selection-action-button--wide"
+                  title="Develop (replaces)"
+                  aria-label="Develop (replaces)"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => handleSelectionVerb('develop')}
+                >
+                  Develop (replaces)
+                </button>
+              </div>
+            )}
+          </div>
+          <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"
             className="selection-action-button selection-action-button--format selection-action-button--bold"
@@ -1956,44 +2024,14 @@ export function StreamEditor({
           <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"
-            className="selection-action-button"
-            title="Send"
-            aria-label="Send"
+            className="selection-action-button selection-action-button--text selection-action-source-scope"
+            title="Cycle source scope"
+            aria-label="Cycle source scope"
             onMouseDown={(event) => event.preventDefault()}
-            onClick={handleSelectionSend}
-            disabled={isAiThinking}
+            onClick={cycleSourceScope}
           >
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path d="M3.2 4.2l17.6 7.8-17.6 7.8 2.4-7-2.4-8.6zm2.8 2.7 1.3 4.7h7.8v1h-7.8L6 17.1l11.8-5.1L6 6.9z" />
-            </svg>
+            Sources: {formatSourceScope(sourceScope)}
           </button>
-          <button
-            type="button"
-            className="selection-action-button"
-            title="Send & Prompt"
-            aria-label="Send and prompt"
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={handleSelectionPrompt}
-            disabled={isAiThinking}
-          >
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path d="M4 3h16a1 1 0 011 1v11a1 1 0 01-1 1H8l-4 4v-4H4a1 1 0 01-1-1V4a1 1 0 011-1zm1 2v9h1v1.6L7.6 14H19V5H5zm3 2h8v1H8V7zm0 3h5v1H8v-1z" />
-            </svg>
-          </button>
-          {canLinkSelectionToPDF && (
-            <button
-              type="button"
-              className="selection-action-button"
-              title="Link to PDF"
-              aria-label="Link to PDF"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={handleSelectionLinkToPDF}
-            >
-              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                <path d="M8.8 12.9a1 1 0 010-1.4l3.7-3.7a3.4 3.4 0 114.8 4.8l-1.5 1.5-.7-.7 1.5-1.5a2.4 2.4 0 10-3.4-3.4l-3.7 3.7a1 1 0 001.4 1.4l2.5-2.5.7.7-2.5 2.5a2 2 0 01-2.8 0zm-2.1 7a3.4 3.4 0 010-4.8l1.5-1.5.7.7-1.5 1.5a2.4 2.4 0 103.4 3.4l3.7-3.7a1 1 0 00-1.4-1.4l-2.5 2.5-.7-.7 2.5-2.5a2 2 0 112.8 2.8l-3.7 3.7a3.4 3.4 0 01-4.8 0z" />
-              </svg>
-            </button>
-          )}
         </div>
       )}
 
@@ -2107,6 +2145,15 @@ export function StreamEditor({
               >
                 <span className="document-ai-status-dot" aria-hidden="true" />
                 <span>{aiFeedback.message}</span>
+                {isAiThinking && aiFeedback.kind === 'writing' && (
+                  <button
+                    type="button"
+                    className="document-ai-stop-button"
+                    onClick={handleStopDocumentAI}
+                  >
+                    × Stop
+                  </button>
+                )}
               </div>
             )}
             {sourceIndexNotice && (

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type FocusEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
@@ -15,6 +15,7 @@ import { AI_HISTORY_USER_EVENT, aiWritingExtension, getAiWritingRange, setAiWrit
 import { editorFindExtension } from '../extensions/EditorFindPanel';
 import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
+import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
@@ -52,6 +53,19 @@ interface FloatingMenuState {
   selectionFrom: number;
   selectionTo: number;
   selectionHead: number;
+  menuWidth?: number;
+  menuHeight?: number;
+}
+
+interface LinkPopoverState {
+  visible: boolean;
+  left: number;
+  top: number;
+  from: number;
+  to: number;
+  labelFrom: number;
+  label: string;
+  url: string;
   menuWidth?: number;
   menuHeight?: number;
 }
@@ -265,6 +279,16 @@ export function StreamEditor({
     selectionTo: 0,
     selectionHead: 0,
   });
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    from: 0,
+    to: 0,
+    labelFrom: 0,
+    label: '',
+    url: '',
+  });
   const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
     visible: false,
     kind: 'writing',
@@ -277,6 +301,7 @@ export function StreamEditor({
   const editorShellRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
   const selectionActionMenuRef = useRef<HTMLDivElement>(null);
+  const linkPopoverRef = useRef<HTMLDivElement>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
@@ -535,6 +560,7 @@ export function StreamEditor({
       selectionTo: 0,
       selectionHead: 0,
     });
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
     setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
@@ -1122,6 +1148,10 @@ export function StreamEditor({
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
+  const hideLinkPopover = useCallback(() => {
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+  }, []);
+
   const getSelectionMenuPlacement = useCallback((
     view: EditorView,
     measuredMenuSize?: { width: number; height: number }
@@ -1135,6 +1165,31 @@ export function StreamEditor({
 
     const shellRect = shell.getBoundingClientRect();
     const menu = selectionActionMenuRef.current;
+    return computeSelectionMenuPlacement({
+      coords,
+      shellRect,
+      menuSize: measuredMenuSize ?? {
+        width: menu?.offsetWidth,
+        height: menu?.offsetHeight,
+      },
+      viewportHeight: window.innerHeight,
+    });
+  }, []);
+
+  const getLinkPopoverPlacement = useCallback((
+    view: EditorView,
+    link: Pick<LinkPopoverState, 'from' | 'labelFrom'>,
+    measuredMenuSize?: { width: number; height: number }
+  ): { left: number; top: number } | null => {
+    const shell = editorShellRef.current;
+    if (!shell) return null;
+
+    const anchor = Math.min(Math.max(link.labelFrom, link.from), view.state.doc.length);
+    const coords = view.coordsAtPos(anchor) ?? view.coordsAtPos(link.from);
+    if (!coords) return null;
+
+    const shellRect = shell.getBoundingClientRect();
+    const menu = linkPopoverRef.current;
     return computeSelectionMenuPlacement({
       coords,
       shellRect,
@@ -1197,6 +1252,50 @@ export function StreamEditor({
     stream.id,
   ]);
 
+  useLayoutEffect(() => {
+    if (!linkPopover.visible) return;
+
+    const menu = linkPopoverRef.current;
+    const view = editorViewRef.current;
+    if (!menu || !view) return;
+
+    const measuredMenuSize = {
+      width: menu.offsetWidth,
+      height: menu.offsetHeight,
+    };
+    if (measuredMenuSize.width <= 0 || measuredMenuSize.height <= 0) return;
+
+    const placement = getLinkPopoverPlacement(view, linkPopover, measuredMenuSize);
+    if (!placement) return;
+
+    setLinkPopover((previous) => {
+      if (!previous.visible) return previous;
+
+      const sameSize = previous.menuWidth === measuredMenuSize.width &&
+        previous.menuHeight === measuredMenuSize.height;
+      const samePlacement = Math.abs(previous.left - placement.left) < 0.5 &&
+        Math.abs(previous.top - placement.top) < 0.5;
+
+      if (sameSize && samePlacement) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        left: placement.left,
+        top: placement.top,
+        menuWidth: measuredMenuSize.width,
+        menuHeight: measuredMenuSize.height,
+      };
+    });
+  }, [
+    getLinkPopoverPlacement,
+    linkPopover,
+    pdfPaneState.streamId,
+    pdfPaneState.visible,
+    stream.id,
+  ]);
+
   const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
 
@@ -1239,14 +1338,116 @@ export function StreamEditor({
     }, SELECTION_MENU_DELAY_MS);
   }, [clearSelectionMenuTimer, getSelectionMenuPlacement, hideSelectionMenu]);
 
+  const openLinkPopover = useCallback((view: EditorView, link: MarkdownLinkInfo | null) => {
+    if (!link) {
+      hideLinkPopover();
+      return;
+    }
+
+    const placement = getLinkPopoverPlacement(view, link);
+    if (!placement) {
+      hideLinkPopover();
+      return;
+    }
+
+    hideSelectionMenu();
+    setLinkPopover({
+      visible: true,
+      left: placement.left,
+      top: placement.top,
+      from: link.from,
+      to: link.to,
+      labelFrom: link.labelFrom,
+      label: link.label,
+      url: link.url,
+    });
+  }, [getLinkPopoverPlacement, hideLinkPopover, hideSelectionMenu]);
+
+  const linkInteraction = useMemo<Extension>(
+    () => linkInteractionExtension(openLinkPopover),
+    [openLinkPopover]
+  );
+
+  const commitLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    const change = buildLinkEditChange(linkPopover, linkPopover.label, linkPopover.url);
+    if (view && change) {
+      view.dispatch({
+        changes: change,
+        selection: { anchor: change.from + change.insert.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const unlinkLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: linkPopover.label },
+        selection: { anchor: linkPopover.from + linkPopover.label.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const removeLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: '' },
+        selection: { anchor: linkPopover.from },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const handleLinkPopoverBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+
+    window.setTimeout(() => {
+      const menu = linkPopoverRef.current;
+      if (menu && document.activeElement instanceof Node && menu.contains(document.activeElement)) return;
+      commitLinkPopover();
+    }, 0);
+  }, [commitLinkPopover]);
+
+  const handleLinkPopoverKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitLinkPopover();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      hideLinkPopover();
+      editorViewRef.current?.focus();
+    }
+  }, [commitLinkPopover, hideLinkPopover]);
+
   useEffect(() => {
     showPromptRef.current = showPrompt;
     isAiThinkingRef.current = isAiThinking;
 
     if (showPrompt || isAiThinking) {
       hideSelectionMenu();
+      hideLinkPopover();
     }
-  }, [hideSelectionMenu, isAiThinking, showPrompt]);
+  }, [hideLinkPopover, hideSelectionMenu, isAiThinking, showPrompt]);
 
   const selectionMenuExtension = useMemo<Extension>(() => [
     EditorView.updateListener.of((update) => {
@@ -1796,6 +1997,46 @@ export function StreamEditor({
         </div>
       )}
 
+      {linkPopover.visible && (
+        <div
+          ref={linkPopoverRef}
+          className="link-edit-popover"
+          style={{ left: `${linkPopover.left}px`, top: `${linkPopover.top}px` }}
+          onBlur={handleLinkPopoverBlur}
+        >
+          <input
+            className="link-edit-input link-edit-input--label"
+            value={linkPopover.label}
+            aria-label="Link label"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, label: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <input
+            className="link-edit-input link-edit-input--url"
+            value={linkPopover.url}
+            aria-label="Link URL"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, url: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <button
+            type="button"
+            className="link-edit-button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={unlinkLinkPopover}
+          >
+            Unlink
+          </button>
+          <button
+            type="button"
+            className="link-edit-button link-edit-button--remove"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={removeLinkPopover}
+          >
+            Remove
+          </button>
+        </div>
+      )}
+
       <div className="stream-body">
         <div className="stream-content">
           <div
@@ -1829,6 +2070,7 @@ export function StreamEditor({
                 markdownConcealExtension,
                 markdownImageWidgetExtension,
                 tickerPDFLinkExtension(stream.id),
+                linkInteraction,
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;

--- a/Web/src/extensions/LinkInteraction.test.ts
+++ b/Web/src/extensions/LinkInteraction.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildLinkEditChange, isAllowedExternalURL } from './LinkInteraction';
+
+describe('link interaction helpers', () => {
+  it('builds a markdown link replacement change', () => {
+    expect(buildLinkEditChange({ from: 4, to: 28 }, 'Example', 'https://example.com')).toEqual({
+      from: 4,
+      to: 28,
+      insert: '[Example](https://example.com)',
+    });
+  });
+
+  it('escapes edited link labels and trims URL fields', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'A ] B', ' https://example.com/path ')).toEqual({
+      from: 0,
+      to: 10,
+      insert: '[A \\] B](https://example.com/path)',
+    });
+  });
+
+  it('rejects empty edited links', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, '', 'https://example.com')).toBeNull();
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'Example', '')).toBeNull();
+  });
+
+  it('allows only http and https external URLs', () => {
+    expect(isAllowedExternalURL('https://example.com/path')).toBe(true);
+    expect(isAllowedExternalURL('http://example.com')).toBe(true);
+    expect(isAllowedExternalURL('ticker-pdf://source?page=1')).toBe(false);
+    expect(isAllowedExternalURL('file:///etc/passwd')).toBe(false);
+    expect(isAllowedExternalURL('javascript:alert(1)')).toBe(false);
+    expect(isAllowedExternalURL('https:example.com')).toBe(false);
+  });
+});

--- a/Web/src/extensions/LinkInteraction.ts
+++ b/Web/src/extensions/LinkInteraction.ts
@@ -1,0 +1,184 @@
+import { syntaxTree } from '@codemirror/language';
+import { type Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type { SyntaxNode } from '@lezer/common';
+import { bridge } from '../types';
+import { rawLinksAreRevealedOnLine, revealRawLinksEffect } from './MarkdownConceal';
+
+export interface MarkdownLinkInfo {
+  from: number;
+  to: number;
+  labelFrom: number;
+  labelTo: number;
+  label: string;
+  url: string;
+  lineFrom: number;
+}
+
+export interface LinkEditRange {
+  from: number;
+  to: number;
+}
+
+export interface LinkEditChange extends LinkEditRange {
+  insert: string;
+}
+
+export function isAllowedExternalURL(rawURL: string): boolean {
+  if (!/^https?:\/\//i.test(rawURL)) return false;
+
+  try {
+    const url = new URL(rawURL);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function buildLinkEditChange(oldRange: LinkEditRange, label: string, url: string): LinkEditChange | null {
+  const nextLabel = label.trim().replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
+  const nextURL = url.trim();
+  if (!nextLabel || !nextURL) return null;
+  return {
+    from: oldRange.from,
+    to: oldRange.to,
+    insert: `[${nextLabel}](${nextURL})`,
+  };
+}
+
+function linkInfoFromNode(view: EditorView, linkNode: SyntaxNode): MarkdownLinkInfo | null {
+  const marks: Array<{ from: number; to: number }> = [];
+  let urlFrom = -1;
+  let urlTo = -1;
+  const cursor = linkNode.cursor();
+  if (!cursor.firstChild()) return null;
+
+  do {
+    if (cursor.name === 'LinkMark') {
+      marks.push({ from: cursor.from, to: cursor.to });
+    } else if (cursor.name === 'URL') {
+      urlFrom = cursor.from;
+      urlTo = cursor.to;
+    }
+  } while (cursor.nextSibling());
+
+  if (marks.length < 2 || urlFrom < 0 || urlTo <= urlFrom) return null;
+
+  const labelFrom = marks[0].to;
+  const labelTo = marks[1].from;
+  const line = view.state.doc.lineAt(linkNode.from);
+  return {
+    from: linkNode.from,
+    to: linkNode.to,
+    labelFrom,
+    labelTo,
+    label: view.state.doc.sliceString(labelFrom, labelTo),
+    url: view.state.doc.sliceString(urlFrom, urlTo),
+    lineFrom: line.from,
+  };
+}
+
+function linkInfoAt(view: EditorView, pos: number): MarkdownLinkInfo | null {
+  for (let node: SyntaxNode | null = syntaxTree(view.state).resolveInner(pos, -1); node; node = node.parent) {
+    if (node.name === 'Link') return linkInfoFromNode(view, node);
+  }
+  return null;
+}
+
+function sameLink(left: MarkdownLinkInfo | null, right: MarkdownLinkInfo | null): boolean {
+  return Boolean(left && right && left.from === right.from && left.to === right.to);
+}
+
+export function linkInteractionExtension(
+  onEditLink: (view: EditorView, link: MarkdownLinkInfo | null) => void
+): Extension {
+  let clickStartedInsideLink: MarkdownLinkInfo | null = null;
+  let suppressSelectionPopover = false;
+
+  return [
+    EditorView.updateListener.of((update) => {
+      if (!update.selectionSet && !update.docChanged) return;
+
+      const selection = update.state.selection.main;
+      if (!selection.empty) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      const link = linkInfoAt(update.view, selection.head);
+      if (!link || rawLinksAreRevealedOnLine(update.state, link.lineFrom) || suppressSelectionPopover) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      onEditLink(update.view, link);
+    }),
+    EditorView.domEventHandlers({
+      mousedown: (event, view) => {
+        clickStartedInsideLink = null;
+        suppressSelectionPopover = false;
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        if (pos == null) return false;
+
+        const clickedLink = linkInfoAt(view, pos);
+        const selection = view.state.selection.main;
+        const currentLink = selection.empty ? linkInfoAt(view, selection.head) : null;
+        clickStartedInsideLink = sameLink(clickedLink, currentLink) ? clickedLink : null;
+        suppressSelectionPopover = Boolean(clickedLink && !clickStartedInsideLink);
+        return false;
+      },
+      click: (event, view) => {
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        const link = pos == null ? null : linkInfoAt(view, pos);
+        if (!link) {
+          suppressSelectionPopover = false;
+          onEditLink(view, null);
+          return false;
+        }
+
+        if (event.altKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = true;
+          onEditLink(view, null);
+          view.dispatch({
+            selection: { anchor: Math.min(pos ?? link.from, view.state.doc.length) },
+            effects: revealRawLinksEffect.of(link.lineFrom),
+          });
+          window.setTimeout(() => {
+            suppressSelectionPopover = false;
+          }, 0);
+          return true;
+        }
+
+        if (link.url.startsWith('ticker-pdf://')) {
+          suppressSelectionPopover = false;
+          return false;
+        }
+
+        if (sameLink(clickStartedInsideLink, link)) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = false;
+          onEditLink(view, link);
+          return true;
+        }
+
+        suppressSelectionPopover = false;
+        if (!isAllowedExternalURL(link.url)) return false;
+
+        event.preventDefault();
+        event.stopPropagation();
+        bridge.send({
+          type: 'openExternalURL',
+          payload: { url: link.url },
+        });
+        return true;
+      },
+    }),
+  ];
+}

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -1,10 +1,12 @@
-import { type Extension, type Range } from '@codemirror/state';
+import { EditorState, StateEffect, StateField, type Extension, type Range } from '@codemirror/state';
 import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
 const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark', 'CodeInfo']);
 const LINK_CONCEAL_NODE_NAMES = new Set(['LinkMark', 'URL', 'LinkTitle']);
 const INITIAL_MARKDOWN_PARSE_TIMEOUT_MS = 20;
+
+export const revealRawLinksEffect = StateEffect.define<number | null>();
 
 function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boolean {
   const doc = view.state.doc;
@@ -21,6 +23,52 @@ function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boo
 
     return lineFrom < to && lineEnd > from;
   });
+}
+
+function selectionIntersectsLine(state: EditorState, lineFrom: number, lineTo: number): boolean {
+  const lineEnd = lineTo < state.doc.length ? lineTo + 1 : lineTo;
+
+  return state.selection.ranges.some((range) => {
+    const from = Math.min(range.from, range.to);
+    const to = Math.max(range.from, range.to);
+
+    if (from === to) {
+      return state.doc.lineAt(from).from === lineFrom;
+    }
+
+    return lineFrom < to && lineEnd > from;
+  });
+}
+
+const revealRawLinksField = StateField.define<number | null>({
+  create: () => null,
+  update(value, transaction) {
+    let next = value;
+    if (next !== null && transaction.docChanged) {
+      next = transaction.changes.mapPos(next);
+    }
+
+    for (const effect of transaction.effects) {
+      if (effect.is(revealRawLinksEffect)) {
+        next = effect.value;
+      }
+    }
+
+    if (next !== null && (transaction.selection || transaction.docChanged)) {
+      const line = transaction.state.doc.lineAt(Math.min(next, transaction.state.doc.length));
+      if (!selectionIntersectsLine(transaction.state, line.from, line.to)) {
+        next = null;
+      } else {
+        next = line.from;
+      }
+    }
+
+    return next;
+  },
+});
+
+export function rawLinksAreRevealedOnLine(state: EditorState, lineFrom: number): boolean {
+  return state.field(revealRawLinksField, false) === lineFrom;
 }
 
 function rangeWithFollowingSpace(view: EditorView, from: number, to: number): { from: number; to: number } {
@@ -56,6 +104,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
   const decorations: Array<Range<Decoration>> = [];
   const blockquoteLineStarts = new Set<number>();
   const tree = markdownTreeForDecorations(view, ensureInitialParse);
+  const rawLinksLineFrom = view.state.field(revealRawLinksField, false);
 
   for (const visibleRange of view.visibleRanges) {
     tree.iterate({
@@ -63,7 +112,10 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
       to: visibleRange.to,
       enter: (node) => {
         const line = view.state.doc.lineAt(node.from);
-        if (isLineSelected(view, line.from, line.to)) return;
+        const isLinkConcealNode = LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link']);
+        if (isLineSelected(view, line.from, line.to) && (!isLinkConcealNode || rawLinksLineFrom === line.from)) {
+          return;
+        }
 
         if (node.name === 'HeaderMark') {
           const range = rangeWithFollowingSpace(view, node.from, node.to);
@@ -90,7 +142,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
           return;
         }
 
-        if (LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link'])) {
+        if (isLinkConcealNode) {
           const range = node.name === 'URL' ? rangeWithFollowingSpaces(view, node.from, node.to) : { from: node.from, to: node.to };
           const decoration = concealRange(range.from, range.to);
           if (decoration) decorations.push(decoration);
@@ -110,7 +162,9 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   }
 
   update(update: ViewUpdate): void {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    const rawLinksChanged = update.startState.field(revealRawLinksField, false) !==
+      update.state.field(revealRawLinksField, false);
+    if (update.docChanged || update.viewportChanged || update.selectionSet || rawLinksChanged) {
       this.decorations = buildMarkdownConcealDecorations(update.view);
     }
   }
@@ -118,4 +172,4 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   decorations: (value) => value.decorations,
 });
 
-export const markdownConcealExtension: Extension = markdownConcealPlugin;
+export const markdownConcealExtension: Extension = [revealRawLinksField, markdownConcealPlugin];

--- a/Web/src/extensions/PDFHighlightLink.ts
+++ b/Web/src/extensions/PDFHighlightLink.ts
@@ -129,6 +129,7 @@ export function tickerPDFLinkExtension(streamId: string): Extension {
     EditorView.domEventHandlers({
       click: (event, view) => {
         if (event.button !== 0 || event.defaultPrevented) return false;
+        if (event.altKey) return false;
         const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
         if (pos == null) return false;
 

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -819,6 +819,18 @@ body {
   transition: color 0.12s ease, background 0.12s ease, transform 0.12s ease;
 }
 
+.selection-action-button--text {
+  width: auto;
+  min-width: 30px;
+  padding: 0 var(--space-2);
+  font-size: var(--type-ui-small);
+  white-space: nowrap;
+}
+
+.selection-action-button--wide {
+  min-width: max-content;
+}
+
 .selection-action-button svg {
   fill: currentColor;
 }
@@ -842,6 +854,28 @@ body {
   height: 18px;
   background: var(--border-subtle);
   margin: 0 var(--space-1);
+}
+
+.selection-action-submenu {
+  position: relative;
+}
+
+.selection-action-submenu-panel {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + var(--space-1));
+  transform: translateX(-50%);
+  z-index: 1;
+  display: inline-flex;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--overlay-shadow);
+}
+
+.selection-action-source-scope {
+  color: var(--color-text-tertiary);
 }
 
 .selection-action-button:hover:not(:disabled) {
@@ -1102,7 +1136,7 @@ body {
   color: var(--color-text-secondary);
   font-size: var(--type-ui-small);
   line-height: 1;
-  pointer-events: none;
+  pointer-events: auto;
   backdrop-filter: var(--overlay-backdrop);
   animation: ai-status-enter 0.12s ease-out;
 }
@@ -1124,6 +1158,23 @@ body {
 
 .document-ai-status-pill--error .document-ai-status-dot {
   animation: none;
+}
+
+.document-ai-stop-button {
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--type-ui-small);
+  line-height: 1;
+  padding: var(--space-1);
+}
+
+.document-ai-stop-button:hover {
+  background: var(--accent-soft);
+  color: var(--color-accent);
 }
 
 .document-ai-indexing-notice {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -855,6 +855,69 @@ body {
   opacity: 0.5;
 }
 
+.link-edit-popover {
+  position: fixed;
+  z-index: 930;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
+}
+
+.link-edit-input {
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  outline: none;
+}
+
+.link-edit-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.link-edit-input--label {
+  width: 150px;
+}
+
+.link-edit-input--url {
+  width: 260px;
+}
+
+.link-edit-button {
+  height: 30px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  transition: color 0.12s ease, background 0.12s ease;
+}
+
+.link-edit-button:hover {
+  color: var(--color-accent);
+  background: var(--accent-soft);
+}
+
+.link-edit-button--remove:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
 .document-editor-shell {
   position: relative;
   width: 100%;

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -868,6 +868,10 @@ body {
   overflow: visible;
 }
 
+.document-editor-shell.cm-prepaint {
+  visibility: hidden;
+}
+
 .document-editor-codemirror {
   min-height: inherit;
 }

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -51,6 +51,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadSettings',
   'loadStream',
   'loadStreams',
+  'openExternalURL',
   'openPdfDestination',
   'openSource',
   'refreshProxyAuth',

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -41,6 +41,7 @@ export type SwiftToWebMessageType = (typeof SWIFT_TO_WEB_MESSAGE_TYPES)[number];
 export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'addSource',
   'beginPdfAnchorPick',
+  'cancelDocumentAI',
   'clearProxyDeviceKey',
   'createStream',
   'deleteStream',
@@ -63,6 +64,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'saveStreamDocument',
   'setFileDropContext',
   'setSourceAIExclusion',
+  'setSourceScope',
   'setProxyDeviceKey',
   'submitFeedback',
   'thinkDocument',
@@ -70,6 +72,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
 ] as const;
 
 export type WebToSwiftMessageType = (typeof WEB_TO_SWIFT_MESSAGE_TYPES)[number];
+export type DocumentAIVerb = 'develop' | 'ask' | 'challenge' | 'define';
 
 export interface BridgeMessage {
   type: string;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -58,6 +58,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'retrySourceIndexing',
   'saveImage',
   'saveSettings',
+  'saveScrollPosition',
   'saveStreamDocument',
   'setFileDropContext',
   'setSourceAIExclusion',

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -2,11 +2,14 @@
 export interface Stream {
   id: string;
   title: string;
+  sourceScope: SourceScope;
   sources: SourceReference[];
   document: StreamDocument;
   createdAt: string;
   updatedAt: string;
 }
+
+export type SourceScope = 'auto' | 'all' | 'none';
 
 /** Canonical Markdown document for a stream */
 export interface StreamDocument {

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -13,6 +13,7 @@ export interface StreamDocument {
   streamId: string;
   markdown: string;
   revision: number;
+  scrollOffset: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -28,7 +28,6 @@ export function buildTickerPDFLinkURL(args: { sourceId: string; highlightId: str
 }
 
 export function beginPDFAnchorPick(streamId: string): void {
-  // ponytail: contract-retained sender while Task 3.2 removes the PDF action from the verb menu; wire to a new visible PDF command if anchoring returns there.
   bridge.send({
     type: 'beginPdfAnchorPick',
     payload: { streamId },

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -1,4 +1,5 @@
 import type { ChangeDesc } from '@codemirror/state';
+import { bridge } from '../types/bridge';
 
 export interface PendingPDFAnchorSelection {
   from: number;
@@ -24,6 +25,14 @@ export function mapPendingPDFAnchorSelection(
 
 export function buildTickerPDFLinkURL(args: { sourceId: string; highlightId: string; page: number }): string {
   return `ticker-pdf://${args.sourceId}?highlight=${encodeURIComponent(args.highlightId)}&page=${args.page}`;
+}
+
+export function beginPDFAnchorPick(streamId: string): void {
+  // ponytail: contract-retained sender while Task 3.2 removes the PDF action from the verb menu; wire to a new visible PDF command if anchoring returns there.
+  bridge.send({
+    type: 'beginPdfAnchorPick',
+    payload: { streamId },
+  });
 }
 
 export function buildPDFAnchorLinkEdit(

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -21,8 +21,9 @@
         "optionalPayloadKeys": ["citations", "sourceContextMode"]
       },
       "documentAIError": {
-        "requiredPayloadKeys": ["requestId", "error"],
+        "requiredPayloadKeys": ["requestId"],
         "optionalPayloadKeys": [
+          "error",
           "errorCode",
           "proxyRequestId",
           "quotaScope",
@@ -102,7 +103,7 @@
       },
       "streamLoaded": {
         "requiredPayloadKeys": ["stream"],
-        "optionalPayloadKeys": ["scrollOffset"]
+        "optionalPayloadKeys": ["scrollOffset", "sourceScope"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -122,6 +123,9 @@
       },
       "beginPdfAnchorPick": {
         "requiredPayloadKeys": ["streamId"]
+      },
+      "cancelDocumentAI": {
+        "requiredPayloadKeys": ["requestId"]
       },
       "clearProxyDeviceKey": {
         "requiredPayloadKeys": [],
@@ -209,6 +213,9 @@
         "requiredPayloadKeys": ["mode"],
         "optionalPayloadKeys": ["streamId"]
       },
+      "setSourceScope": {
+        "requiredPayloadKeys": ["streamId", "scope"]
+      },
       "setProxyDeviceKey": {
         "requiredPayloadKeys": ["key"],
         "requiredCallbackId": true
@@ -220,7 +227,7 @@
       },
       "thinkDocument": {
         "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
-        "optionalPayloadKeys": ["context", "sourceScope"]
+        "optionalPayloadKeys": ["context", "sourceScope", "verb"]
       },
       "updateStreamTitle": {
         "requiredPayloadKeys": ["id", "title"]

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -101,7 +101,8 @@
         "requiredPayloadKeys": ["streamId", "markdown", "revision"]
       },
       "streamLoaded": {
-        "requiredPayloadKeys": ["stream"]
+        "requiredPayloadKeys": ["stream"],
+        "optionalPayloadKeys": ["scrollOffset"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -197,6 +198,9 @@
       "saveStreamDocument": {
         "requiredPayloadKeys": ["streamId", "markdown", "baseRevision"],
         "requiredCallbackId": true
+      },
+      "saveScrollPosition": {
+        "requiredPayloadKeys": ["streamId", "offset"]
       },
       "setFileDropContext": {
         "requiredPayloadKeys": ["mode"],

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -157,6 +157,9 @@
       "loadStreams": {
         "requiredPayloadKeys": []
       },
+      "openExternalURL": {
+        "requiredPayloadKeys": ["url"]
+      },
       "openSource": {
         "requiredPayloadKeys": ["sourceId"]
       },


### PR DESCRIPTION
Phase P3 of docs/IA_CORE_PLAN.md, stacked on #42.

- **3.1 Prompt rewrite** (`6b2571a`) — `thinkingPartner`/`thinkingPartnerWithHeading` replaced verbatim with the document-prose prompt: flowing paragraphs, lists only for genuinely enumerable content, no bolded term-colon walls, no chat framing.
- **3.2 The verb menu** (`a0360e1`) — selection menu is now `Ask · Challenge · Define │ Rewrite ▾ │ B · I · </> · [Link-to-PDF] │ Sources chip`. Only Rewrite▾Develop replaces (⌘↩ keeps its muscle memory); Ask/Define append; Challenge appends in the quoted register (`> …` + `*— Challenge*`, pure wrapper unit-tested, ponytail comment marks the P7 migration). All verbs flow through the one `thinkDocument` funnel with verbatim per-verb system prompts; `priorCells: []` per D1. Source scope now persists in `streams.source_scope` (in-memory Map deleted; `setSourceScope` message; chip visible in the menu and the prompt popover). Stop button: `cancelDocumentAI` cancels the in-flight Task, web restores the original text silently (no toast) — cancelled-mid-stream covered by a mock-provider Swift test and a web vitest; proxy streaming loop checks `Task.isCancelled` between lines.
- **Governor fix** (`a67f79f`) — the menu rework dropped the shipped Link-to-PDF anchor button (the plan's layout didn't list it); restored with its original gating (PDF pane open, same stream).

Gates green after each commit. **Live verification queued** (needs screen + real proxy): four verbs + one-⌘Z each, stop mid-stream, scope cycle → reload persistence, prose-not-bullets output check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)