### PR TITLE
Roadmap 4 P4: the provenance layer (sidecar spans, x-ray, receipts, re-develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- PDF sources now reopen to the last-read page, expose document outlines when available, and describe pane failures in text.
 - Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.
 - Quick Panel can now attach recently copied clipboard text as context when no live selection is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Markdown links now open on click and can be edited from a compact popover without exposing raw URL markup.
 - Streams now restore editor scroll position and hide the first frame until markdown concealment is ready.
 - Stream list cards now show content previews, word counts, and global search from the list.
 - Untitled streams can now keep their titles updated from document text until renamed manually.

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -42,23 +42,103 @@ enum DocumentAICitationManifest {
     }
 }
 
+private enum DocumentAIVerb: String {
+    case develop
+    case ask
+    case challenge
+    case define
+
+    var systemPrompt: String {
+        switch self {
+        case .develop:
+            return Prompts.verbDevelop
+        case .ask:
+            return Prompts.verbAsk
+        case .challenge:
+            return Prompts.verbChallenge
+        case .define:
+            return Prompts.verbDefine
+        }
+    }
+}
+
 final class AIMessageHandler: BridgeMessageHandler {
     let handledTypes: Set<String> = [
-        "thinkDocument"
+        "thinkDocument",
+        "cancelDocumentAI"
     ]
 
-    private let bridgeService: BridgeService
     private let assetService: AssetService
-    private let orchestrator: AIOrchestrator
-    private let deviceKeyService: DeviceKeyService
     private let persistence: PersistenceService?
+    private let sendToWeb: (BridgeMessage) -> Void
+    private let sendBridgeErrorMessage: (String, String) async -> Void
+    private let isProxyUsable: () async -> Bool
+    private let routeDocumentAI: (
+        _ query: String,
+        _ queryImages: [String],
+        _ streamId: UUID?,
+        _ sourceScope: SourceScope,
+        _ systemPromptOverride: String,
+        _ onChunk: @escaping (String) -> Void,
+        _ onComplete: @escaping (SourceContext?) -> Void,
+        _ onError: @escaping (Error) -> Void,
+        _ onModelSelected: ((String) -> Void)?
+    ) async -> Void
+    private var inFlightRequests: [String: Task<Void, Never>] = [:]
 
     init?(container: ServiceContainer) {
-        self.bridgeService = container.bridgeService
         self.assetService = container.assetService
-        self.orchestrator = container.orchestrator
-        self.deviceKeyService = container.deviceKeyService
         self.persistence = container.persistence
+        self.sendToWeb = { [bridgeService = container.bridgeService] message in
+            bridgeService.send(message)
+        }
+        self.sendBridgeErrorMessage = { [bridgeService = container.bridgeService] type, reason in
+            await bridgeService.sendBridgeError(type: type, reason: reason)
+        }
+        self.isProxyUsable = { [deviceKeyService = container.deviceKeyService] in
+            await deviceKeyService.currentState.isUsable
+        }
+        self.routeDocumentAI = { [orchestrator = container.orchestrator] query, queryImages, streamId, sourceScope, systemPromptOverride, onChunk, onComplete, onError, onModelSelected in
+            await orchestrator.route(
+                query: query,
+                queryImages: queryImages,
+                streamId: streamId,
+                sourceScope: sourceScope,
+                priorCells: [],
+                systemPromptOverride: systemPromptOverride,
+                includeHeading: false,
+                onChunk: onChunk,
+                onComplete: onComplete,
+                onError: onError,
+                onModelSelected: onModelSelected
+            )
+        }
+    }
+
+    init(
+        assetService: AssetService = AssetService(),
+        persistence: PersistenceService? = nil,
+        sendToWeb: @escaping (BridgeMessage) -> Void,
+        sendBridgeErrorMessage: @escaping (String, String) async -> Void = { _, _ in },
+        isProxyUsable: @escaping () async -> Bool = { true },
+        routeDocumentAI: @escaping (
+            _ query: String,
+            _ queryImages: [String],
+            _ streamId: UUID?,
+            _ sourceScope: SourceScope,
+            _ systemPromptOverride: String,
+            _ onChunk: @escaping (String) -> Void,
+            _ onComplete: @escaping (SourceContext?) -> Void,
+            _ onError: @escaping (Error) -> Void,
+            _ onModelSelected: ((String) -> Void)?
+        ) async -> Void
+    ) {
+        self.assetService = assetService
+        self.persistence = persistence
+        self.sendToWeb = sendToWeb
+        self.sendBridgeErrorMessage = sendBridgeErrorMessage
+        self.isProxyUsable = isProxyUsable
+        self.routeDocumentAI = routeDocumentAI
     }
 
     func handle(_ message: BridgeMessage) async {
@@ -68,7 +148,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                   let requestId = payload["requestId"]?.value as? String,
                   let query = payload["query"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid thinkDocument payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid thinkDocument payload")
+                await sendBridgeErrorMessage(message.type, "Invalid thinkDocument payload")
                 return
             }
 
@@ -79,6 +159,8 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
             let sourceScopeRaw = payload["sourceScope"]?.value as? String
             let sourceScope = SourceScope(rawValue: sourceScopeRaw ?? "") ?? .auto
+            let verbRaw = payload["verb"]?.value as? String
+            let verb = DocumentAIVerb(rawValue: verbRaw ?? "") ?? .develop
 
             var streamIdForRAG: UUID? = nil
 
@@ -105,12 +187,14 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
 
             let onChunk: (String) -> Void = { [weak self] chunk in
-                self?.bridgeService.send(BridgeMessage(
+                guard !Task.isCancelled else { return }
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIChunk",
                     payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
                 ))
             }
             let onComplete: (SourceContext?) -> Void = { [weak self] sourceContext in
+                guard !Task.isCancelled else { return }
                 var payload: [String: AnyCodable] = ["requestId": AnyCodable(requestId)]
                 if let citations = DocumentAICitationManifest.bridgePayload(from: sourceContext) {
                     payload["citations"] = AnyCodable(citations)
@@ -120,12 +204,13 @@ final class AIMessageHandler: BridgeMessageHandler {
                 } else if sourceContext == nil, hasStreamSources {
                     payload["sourceContextMode"] = AnyCodable("none")
                 }
-                self?.bridgeService.send(BridgeMessage(
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIComplete",
                     payload: payload
                 ))
             }
             let onError: (Error) -> Void = { [weak self] error in
+                guard !Task.isCancelled else { return }
                 var payload: [String: AnyCodable] = [
                     "requestId": AnyCodable(requestId),
                     "error": AnyCodable(error.localizedDescription)
@@ -151,16 +236,19 @@ final class AIMessageHandler: BridgeMessageHandler {
                     }
                 }
 
-                self?.bridgeService.send(BridgeMessage(
+                self?.sendToWeb(BridgeMessage(
                     type: "documentAIError",
                     payload: payload
                 ))
             }
 
-            Task { [weak self] in
+            let task = Task { [weak self] in
                 guard let self else { return }
+                defer {
+                    self.inFlightRequests[requestId] = nil
+                }
 
-                let proxyUsable = await self.deviceKeyService.currentState.isUsable
+                let proxyUsable = await self.isProxyUsable()
 
                 guard proxyUsable else {
                     await MainActor.run {
@@ -169,24 +257,46 @@ final class AIMessageHandler: BridgeMessageHandler {
                     return
                 }
 
-                await self.orchestrator.route(
-                    query: resolvedQuery,
-                    queryImages: imageDataURLs,
-                    streamId: streamIdForRAG,
-                    sourceScope: sourceScope,
-                    priorCells: [],
-                    includeHeading: false,
-                    onChunk: onChunk,
-                    onComplete: onComplete,
-                    onError: onError,
-                    onModelSelected: { [weak self] modelId in
-                        self?.bridgeService.send(BridgeMessage(
+                if Task.isCancelled {
+                    return
+                }
+
+                await self.routeDocumentAI(
+                    resolvedQuery,
+                    imageDataURLs,
+                    streamIdForRAG,
+                    sourceScope,
+                    verb.systemPrompt,
+                    onChunk,
+                    onComplete,
+                    onError,
+                    { [weak self] modelId in
+                        guard !Task.isCancelled else { return }
+                        self?.sendToWeb(BridgeMessage(
                             type: "documentModelSelected",
                             payload: ["requestId": AnyCodable(requestId), "modelId": AnyCodable(modelId)]
                         ))
                     }
                 )
             }
+            inFlightRequests[requestId] = task
+
+        case "cancelDocumentAI":
+            guard let payload = message.payload,
+                  let requestId = payload["requestId"]?.value as? String else {
+                DebugLog.log("[WebViewManager] Invalid cancelDocumentAI payload")
+                await sendBridgeErrorMessage(message.type, "Invalid cancelDocumentAI payload")
+                return
+            }
+            inFlightRequests.removeValue(forKey: requestId)?.cancel()
+            sendToWeb(BridgeMessage(
+                type: "documentAIError",
+                payload: [
+                    "requestId": AnyCodable(requestId),
+                    "error": AnyCodable("Cancelled"),
+                    "errorCode": AnyCodable("cancelled")
+                ]
+            ))
 
         default:
             DebugLog.log("[AIMessageHandler] Unknown message type: \(message.type)")

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -40,6 +40,16 @@ enum DocumentAICitationManifest {
     static func bridgePayload(from context: SourceContext?) -> [[String: Any]]? {
         entries(from: context)?.map(\.bridgePayload)
     }
+
+    static func jsonString(from context: SourceContext?) -> String {
+        guard let payload = bridgePayload(from: context),
+              JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
 }
 
 private enum DocumentAIVerb: String {
@@ -171,23 +181,19 @@ final class AIMessageHandler: BridgeMessageHandler {
             let hasStreamSources = streamHasSources(streamIdForRAG)
 
             var resolvedQuery = query
+            let cleanedContext = (payload["context"]?.value as? String).flatMap(Self.cleanedDocumentContext)
             if let context = payload["context"]?.value as? String, !context.isEmpty {
-                let cleanContext = context
-                    .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-                    .replacingOccurrences(of: "&nbsp;", with: " ")
-                    .replacingOccurrences(of: "&amp;", with: "&")
-                    .replacingOccurrences(of: "&lt;", with: "<")
-                    .replacingOccurrences(of: "&gt;", with: ">")
-                    .replacingOccurrences(of: "&quot;", with: "\"")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if !cleanContext.isEmpty {
+                if let cleanContext = Self.cleanedDocumentContext(context) {
                     resolvedQuery = "Regarding this context:\n\"\"\"\n\(cleanContext)\n\"\"\"\n\n\(resolvedQuery)"
                 }
             }
+            let userInput = Self.userInput(selection: cleanedContext ?? query, prompt: cleanedContext == nil ? "" : query)
 
+            var responseRaw = ""
+            var selectedModel: String?
             let onChunk: (String) -> Void = { [weak self] chunk in
                 guard !Task.isCancelled else { return }
+                responseRaw += chunk
                 self?.sendToWeb(BridgeMessage(
                     type: "documentAIChunk",
                     payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
@@ -195,6 +201,22 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
             let onComplete: (SourceContext?) -> Void = { [weak self] sourceContext in
                 guard !Task.isCancelled else { return }
+                if let streamId = streamIdForRAG, let persistence = self?.persistence {
+                    do {
+                        try persistence.saveExchange(AIExchange(
+                            requestId: requestId,
+                            streamId: streamId,
+                            verb: verb.rawValue,
+                            userInput: userInput,
+                            sourceManifest: DocumentAICitationManifest.jsonString(from: sourceContext),
+                            responseRaw: responseRaw,
+                            model: selectedModel
+                        ))
+                    } catch {
+                        DebugLog.log("[AIMessageHandler] Failed to save exchange (\(DebugLog.errorSummary(error)))")
+                    }
+                }
+
                 var payload: [String: AnyCodable] = ["requestId": AnyCodable(requestId)]
                 if let citations = DocumentAICitationManifest.bridgePayload(from: sourceContext) {
                     payload["citations"] = AnyCodable(citations)
@@ -272,6 +294,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                     onError,
                     { [weak self] modelId in
                         guard !Task.isCancelled else { return }
+                        selectedModel = modelId
                         self?.sendToWeb(BridgeMessage(
                             type: "documentModelSelected",
                             payload: ["requestId": AnyCodable(requestId), "modelId": AnyCodable(modelId)]
@@ -314,5 +337,21 @@ final class AIMessageHandler: BridgeMessageHandler {
             DebugLog.log("[AIMessageHandler] Failed to load stream sources (\(DebugLog.errorSummary(error)))")
             return false
         }
+    }
+
+    private static func cleanedDocumentContext(_ context: String) -> String? {
+        let cleaned = context
+            .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private static func userInput(selection: String, prompt: String) -> String {
+        "Selection:\n\(selection)\n\nPrompt:\n\(prompt)"
     }
 }

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -30,6 +30,7 @@ enum StreamCodec {
                 "streamId": document.streamId.uuidString,
                 "markdown": document.markdown,
                 "revision": document.revision,
+                "scrollOffset": document.scrollOffset,
                 "createdAt": formatter.string(from: document.createdAt),
                 "updatedAt": formatter.string(from: document.updatedAt)
             ]

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -6,6 +6,7 @@ enum StreamCodec {
         return [
             "id": stream.id.uuidString,
             "title": stream.title,
+            "sourceScope": stream.sourceScope.rawValue,
             "sources": stream.sources.map { source -> [String: Any] in
                 var dict: [String: Any] = [
                     "id": source.id.uuidString,

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -38,6 +38,41 @@ enum StreamCodec {
         ]
     }
 
+    static func encodeSpans(_ spans: [ProvenanceSpan]) -> [[String: Any]] {
+        let formatter = ISO8601DateFormatter()
+        return spans.map { span in
+            var dict: [String: Any] = [
+                "spanId": span.spanId,
+                "start": span.start,
+                "end": span.end,
+                "origin": span.origin,
+                "meta": span.meta,
+                "textHash": span.textHash,
+                "createdAt": formatter.string(from: span.createdAt)
+            ]
+            if let requestId = span.requestId {
+                dict["requestId"] = requestId
+            }
+            if let sourceId = span.sourceId {
+                dict["sourceId"] = sourceId
+            }
+            return dict
+        }
+    }
+
+    static func encodeExchange(_ exchange: AIExchange) -> [String: Any] {
+        [
+            "requestId": exchange.requestId,
+            "streamId": exchange.streamId.uuidString,
+            "verb": exchange.verb,
+            "userInput": exchange.userInput,
+            "sourceManifest": exchange.sourceManifest,
+            "responseRaw": exchange.responseRaw,
+            "model": exchange.model as Any,
+            "createdAt": ISO8601DateFormatter().string(from: exchange.createdAt)
+        ]
+    }
+
     static func encodeSource(_ source: SourceReference) -> [String: Any] {
         let formatter = ISO8601DateFormatter()
         var dict: [String: Any] = [

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -49,6 +49,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "updateStreamTitle",
         "deleteStream",
         "saveStreamDocument",
+        "saveScrollPosition",
         "exportStream"
     ]
 
@@ -97,7 +98,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     let document = try persistence.loadOrCreateStreamDocument(streamId: id)
 
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                    let payload: [String: AnyCodable] = [
+                        "stream": AnyCodable(streamPayload),
+                        "scrollOffset": AnyCodable(document.scrollOffset)
+                    ]
+                    bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
                     ingestService?.enqueuePendingSources(for: id)
                 }
             } catch {
@@ -111,7 +116,11 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 delegate?.setCurrentStreamIdForFileDrops(stream.id)
                 let document = try persistence.loadOrCreateStreamDocument(streamId: stream.id)
                 let streamPayload = StreamCodec.encodeStream(stream, document: document)
-                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: ["stream": AnyCodable(streamPayload)]))
+                let payload: [String: AnyCodable] = [
+                    "stream": AnyCodable(streamPayload),
+                    "scrollOffset": AnyCodable(document.scrollOffset)
+                ]
+                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
             }
@@ -192,6 +201,21 @@ final class StreamMessageHandler: BridgeMessageHandler {
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save stream document (\(DebugLog.errorSummary(error)))")
                 await bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+            }
+
+        case "saveScrollPosition":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let offset = payload["offset"]?.doubleValue else {
+                DebugLog.log("[WebViewManager] Invalid saveScrollPosition payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveScrollPosition payload")
+                return
+            }
+            do {
+                try persistence.saveScrollOffset(streamId: streamId, offset: offset)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -50,6 +50,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "deleteStream",
         "saveStreamDocument",
         "saveScrollPosition",
+        "openExternalURL",
         "exportStream"
     ]
 
@@ -216,6 +217,23 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 try persistence.saveScrollOffset(streamId: streamId, offset: offset)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "openExternalURL":
+            guard let payload = message.payload,
+                  let rawURL = payload["url"]?.value as? String,
+                  rawURL.range(of: #"^https?://"#, options: [.regularExpression, .caseInsensitive]) != nil,
+                  let components = URLComponents(string: rawURL),
+                  let scheme = components.scheme?.lowercased(),
+                  (scheme == "http" || scheme == "https"),
+                  components.host != nil,
+                  let url = components.url else {
+                DebugLog.log("[StreamMessageHandler] Rejected external URL")
+                return
+            }
+
+            await MainActor.run {
+                _ = NSWorkspace.shared.open(url)
             }
 
         case "exportStream":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -50,6 +50,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "deleteStream",
         "saveStreamDocument",
         "saveScrollPosition",
+        "setSourceScope",
         "openExternalURL",
         "exportStream"
     ]
@@ -101,6 +102,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
                     let payload: [String: AnyCodable] = [
                         "stream": AnyCodable(streamPayload),
+                        "sourceScope": AnyCodable(stream.sourceScope.rawValue),
                         "scrollOffset": AnyCodable(document.scrollOffset)
                     ]
                     bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
@@ -119,6 +121,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 let streamPayload = StreamCodec.encodeStream(stream, document: document)
                 let payload: [String: AnyCodable] = [
                     "stream": AnyCodable(streamPayload),
+                    "sourceScope": AnyCodable(stream.sourceScope.rawValue),
                     "scrollOffset": AnyCodable(document.scrollOffset)
                 ]
                 bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
@@ -217,6 +220,22 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 try persistence.saveScrollOffset(streamId: streamId, offset: offset)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save scroll position (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "setSourceScope":
+            guard let payload = message.payload,
+                  let streamIdValue = payload["streamId"]?.value as? String,
+                  let streamId = UUID(uuidString: streamIdValue),
+                  let scopeValue = payload["scope"]?.value as? String,
+                  let scope = SourceScope(rawValue: scopeValue) else {
+                DebugLog.log("[WebViewManager] Invalid setSourceScope payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid setSourceScope payload")
+                return
+            }
+            do {
+                _ = try persistence.setSourceScope(streamId: streamId, scope: scope)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to set source scope (\(DebugLog.errorSummary(error)))")
             }
 
         case "openExternalURL":

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -52,6 +52,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         "saveScrollPosition",
         "setSourceScope",
         "openExternalURL",
+        "getExchange",
         "exportStream"
     ]
 
@@ -98,12 +99,13 @@ final class StreamMessageHandler: BridgeMessageHandler {
             do {
                 if let stream = try persistence.loadStream(id: id) {
                     let document = try persistence.loadOrCreateStreamDocument(streamId: id)
-
+                    let spans = try persistence.loadSpans(streamId: id)
                     let streamPayload = StreamCodec.encodeStream(stream, document: document)
                     let payload: [String: AnyCodable] = [
                         "stream": AnyCodable(streamPayload),
                         "sourceScope": AnyCodable(stream.sourceScope.rawValue),
-                        "scrollOffset": AnyCodable(document.scrollOffset)
+                        "scrollOffset": AnyCodable(document.scrollOffset),
+                        "spans": AnyCodable(StreamCodec.encodeSpans(spans))
                     ]
                     bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
                     ingestService?.enqueuePendingSources(for: id)
@@ -122,7 +124,8 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 let payload: [String: AnyCodable] = [
                     "stream": AnyCodable(streamPayload),
                     "sourceScope": AnyCodable(stream.sourceScope.rawValue),
-                    "scrollOffset": AnyCodable(document.scrollOffset)
+                    "scrollOffset": AnyCodable(document.scrollOffset),
+                    "spans": AnyCodable(StreamCodec.encodeSpans([]))
                 ]
                 bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
             } catch {
@@ -175,6 +178,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                   let streamId = UUID(uuidString: streamIdValue),
                   let markdown = payload["markdown"]?.value as? String,
                   let baseRevision = payload["baseRevision"]?.intValue,
+                  let spans = decodeSpans(payload["spans"]?.value, streamId: streamId),
                   let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
                 await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveStreamDocument payload")
@@ -184,7 +188,8 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 let revision = try persistence.saveStreamDocument(
                     streamId: streamId,
                     markdown: markdown,
-                    baseRevision: baseRevision
+                    baseRevision: baseRevision,
+                    spans: spans
                 )
                 await pruneUnreferencedPDFHighlights(streamId: streamId, markdown: markdown)
                 await bridgeService.respond(to: callbackId, with: [
@@ -199,7 +204,8 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 await bridgeService.send(BridgeMessage(type: "streamDocumentConflict", payload: [
                     "streamId": AnyCodable(conflict.streamId.uuidString),
                     "markdown": AnyCodable(conflict.markdown),
-                    "revision": AnyCodable(conflict.revision)
+                    "revision": AnyCodable(conflict.revision),
+                    "spans": AnyCodable(StreamCodec.encodeSpans(conflict.spans))
                 ]))
                 await bridgeService.respondWithError(to: callbackId, error: "Stream document revision conflict")
             } catch {
@@ -236,6 +242,24 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 _ = try persistence.setSourceScope(streamId: streamId, scope: scope)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to set source scope (\(DebugLog.errorSummary(error)))")
+            }
+
+        case "getExchange":
+            guard let payload = message.payload,
+                  let requestId = payload["requestId"]?.value as? String,
+                  let callbackId = message.callbackId else {
+                DebugLog.log("[WebViewManager] Invalid getExchange payload")
+                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid getExchange payload")
+                return
+            }
+            do {
+                let exchange = try persistence.loadExchange(requestId: requestId)
+                await bridgeService.respond(to: callbackId, with: [
+                    "exchange": AnyCodable(exchange.map(StreamCodec.encodeExchange) as Any)
+                ])
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to load exchange (\(DebugLog.errorSummary(error)))")
+                await bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
             }
 
         case "openExternalURL":
@@ -326,6 +350,81 @@ final class StreamMessageHandler: BridgeMessageHandler {
         default:
             DebugLog.log("[StreamMessageHandler] Unknown message type: \(message.type)")
         }
+    }
+
+    private func decodeSpans(_ value: Any?, streamId: UUID) -> [ProvenanceSpan]? {
+        guard let items = value as? [[String: Any]] else { return nil }
+        var dropped = 0
+        let spans = items.compactMap { item -> ProvenanceSpan? in
+            guard let spanId = item["spanId"] as? String,
+                  let start = intValue(item["start"]),
+                  let end = intValue(item["end"]),
+                  let origin = item["origin"] as? String,
+                  let meta = metaString(item["meta"]),
+                  let textHash = item["textHash"] as? String,
+                  let createdAt = dateValue(item["createdAt"]) else {
+                dropped += 1
+                return nil
+            }
+
+            return ProvenanceSpan(
+                spanId: spanId,
+                streamId: streamId,
+                start: start,
+                end: end,
+                origin: origin,
+                requestId: optionalString(item["requestId"]),
+                sourceId: optionalString(item["sourceId"]),
+                meta: meta,
+                textHash: textHash,
+                createdAt: createdAt
+            )
+        }
+        if dropped > 0 {
+            DebugLog.log("[StreamMessageHandler] Dropped \(dropped) malformed provenance span(s)")
+        }
+        return spans
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let double = value as? Double,
+           double.rounded(.towardZero) == double,
+           double >= Double(Int.min),
+           double <= Double(Int.max) {
+            return Int(double)
+        }
+        return nil
+    }
+
+    private func optionalString(_ value: Any?) -> String? {
+        if value == nil || value is NSNull { return nil }
+        return value as? String
+    }
+
+    private func metaString(_ value: Any?) -> String? {
+        if let string = value as? String { return string }
+        guard let value,
+              !(value is NSNull),
+              JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    private func dateValue(_ value: Any?) -> Date? {
+        if let string = value as? String {
+            return ISO8601DateFormatter().date(from: string)
+        }
+        if let double = value as? Double {
+            return Date(timeIntervalSince1970: double)
+        }
+        if let int = value as? Int {
+            return Date(timeIntervalSince1970: Double(int))
+        }
+        return nil
     }
 
     private func pruneUnreferencedPDFHighlights(streamId: UUID, markdown: String) async {

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -381,10 +381,17 @@ private final class PDFPaneFindSearchField: NSSearchField {
     }
 }
 
+private struct PDFOutlineSidebarEntry {
+    let title: String
+    let destination: PDFDestination?
+    let depth: Int
+}
+
 final class PDFReaderPaneController: NSViewController {
     var onLinkSelection: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPlaced: ((PDFHighlightLinkPayload) -> Void)?
     var onAnchorPickCancelled: ((UUID) -> Void)?
+    var onPageChanged: ((UUID, Int) -> Void)?
     var highlightsProvider: ((UUID) -> [PDFHighlightRecord])?
     var onClose: (() -> Void)?
 
@@ -394,6 +401,7 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfPaneTitleField = NSTextField(labelWithString: "")
     private let pdfPaneStatusField = NSTextField(labelWithString: "")
     private let pdfPaneHintIconView = NSImageView(frame: .zero)
+    private let pdfPaneOutlineButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneLinkButton = NSButton(title: "", target: nil, action: nil)
     private let pdfPaneCloseButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindBarView = NSView(frame: .zero)
@@ -401,9 +409,13 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfFindCounterField = NSTextField(labelWithString: "")
     private let pdfFindPreviousButton = NSButton(title: "", target: nil, action: nil)
     private let pdfFindNextButton = NSButton(title: "", target: nil, action: nil)
+    private let pdfOutlineScrollView = NSScrollView(frame: .zero)
+    private let pdfOutlineStackView = NSStackView(frame: .zero)
     private let pdfPanePDFView = PDFView(frame: .zero)
     private var pdfPaneWidthConstraint: NSLayoutConstraint?
     private var pdfFindBarHeightConstraint: NSLayoutConstraint?
+    private var pdfOutlineWidthConstraint: NSLayoutConstraint?
+    private var pdfPaneOutlineButtonWidthConstraint: NSLayoutConstraint?
     private var pdfPaneStatusLeadingConstraint: NSLayoutConstraint?
     private var pdfPaneStatusHintLeadingConstraint: NSLayoutConstraint?
     private var isPDFPaneVisible = false
@@ -423,9 +435,16 @@ final class PDFReaderPaneController: NSViewController {
     private var pdfFindMatches: [PDFSelection] = []
     private var pdfFindCurrentIndex: Int?
     private var pdfFindIsCapped = false
+    private var pdfPageSaveWorkItem: DispatchWorkItem?
+    private var pdfPaneMessageWorkItem: DispatchWorkItem?
+    private var pdfPaneTransientMessage: String?
+    private var pdfOutlineEntries: [PDFOutlineSidebarEntry] = []
+    private var isPDFOutlineVisible = false
 
     deinit {
         pdfFindDebounceWorkItem?.cancel()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self)
         exitAnchorPickMode(notifyCancelled: false)
         releaseActivePDFContext()
@@ -436,7 +455,7 @@ final class PDFReaderPaneController: NSViewController {
         configurePDFPane()
     }
 
-    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String) throws {
+    func present(url: URL, streamId: UUID, sourceId: UUID, displayName: String, lastPageIndex: Int? = nil) throws {
         if let existing = activePDFContext, existing.sourceId != sourceId {
             exitAnchorPickMode(notifyCancelled: true)
             releaseActivePDFContext()
@@ -460,6 +479,7 @@ final class PDFReaderPaneController: NSViewController {
         }
 
         pdfPanePDFView.document = document
+        configurePDFOutline(document: document)
         setPDFPaneHeader(displayName: displayName)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -470,6 +490,9 @@ final class PDFReaderPaneController: NSViewController {
             fileURL: url
         )
         applySavedHighlights(sourceId: sourceId)
+        if let lastPageIndex {
+            navigate(toPageIndex: lastPageIndex)
+        }
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -691,6 +714,7 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneTitleField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneStatusField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneHintIconView.translatesAutoresizingMaskIntoConstraints = false
+        pdfPaneOutlineButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneLinkButton.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneCloseButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindBarView.translatesAutoresizingMaskIntoConstraints = false
@@ -698,6 +722,8 @@ final class PDFReaderPaneController: NSViewController {
         pdfFindCounterField.translatesAutoresizingMaskIntoConstraints = false
         pdfFindPreviousButton.translatesAutoresizingMaskIntoConstraints = false
         pdfFindNextButton.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineScrollView.translatesAutoresizingMaskIntoConstraints = false
+        pdfOutlineStackView.translatesAutoresizingMaskIntoConstraints = false
         pdfPanePDFView.translatesAutoresizingMaskIntoConstraints = false
 
         pdfPaneResizeHandle.wantsLayer = true
@@ -729,6 +755,23 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneHintIconView.imageScaling = .scaleProportionallyDown
         pdfPaneHintIconView.contentTintColor = PDFPaneStyle.accent
         pdfPaneHintIconView.isHidden = true
+
+        pdfPaneOutlineButton.target = self
+        pdfPaneOutlineButton.action = #selector(handlePDFOutlineToggle)
+        pdfPaneOutlineButton.bezelStyle = .texturedRounded
+        pdfPaneOutlineButton.controlSize = .small
+        pdfPaneOutlineButton.image = NSImage(systemSymbolName: "list.bullet", accessibilityDescription: nil)
+        pdfPaneOutlineButton.imagePosition = .imageOnly
+        pdfPaneOutlineButton.imageScaling = .scaleProportionallyDown
+        pdfPaneOutlineButton.isBordered = true
+        pdfPaneOutlineButton.showsBorderOnlyWhileMouseInside = true
+        pdfPaneOutlineButton.contentTintColor = PDFPaneStyle.textMuted
+        pdfPaneOutlineButton.toolTip = "Show outline"
+        pdfPaneOutlineButton.setAccessibilityLabel("Toggle PDF outline")
+        pdfPaneOutlineButton.setButtonType(.toggle)
+        pdfPaneOutlineButton.isHidden = true
+        pdfPaneOutlineButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        pdfPaneOutlineButton.setContentHuggingPriority(.required, for: .horizontal)
 
         pdfPaneLinkButton.target = self
         pdfPaneLinkButton.action = #selector(handlePDFPaneLinkSelection)
@@ -799,6 +842,19 @@ final class PDFReaderPaneController: NSViewController {
             action: #selector(handlePDFFindNext)
         )
 
+        pdfOutlineScrollView.drawsBackground = true
+        pdfOutlineScrollView.backgroundColor = PDFPaneStyle.surface
+        pdfOutlineScrollView.hasVerticalScroller = true
+        pdfOutlineScrollView.hasHorizontalScroller = false
+        pdfOutlineScrollView.borderType = .noBorder
+        pdfOutlineScrollView.isHidden = true
+        pdfOutlineScrollView.documentView = pdfOutlineStackView
+
+        pdfOutlineStackView.orientation = .vertical
+        pdfOutlineStackView.alignment = .leading
+        pdfOutlineStackView.distribution = .gravityAreas
+        pdfOutlineStackView.spacing = 0
+
         pdfPanePDFView.autoScales = true
         pdfPanePDFView.displayMode = .singlePageContinuous
         pdfPanePDFView.displayDirection = .vertical
@@ -823,10 +879,12 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneView.addSubview(pdfPaneResizeHandle)
         pdfPaneView.addSubview(pdfPaneHeaderView)
         pdfPaneView.addSubview(pdfFindBarView)
+        pdfPaneView.addSubview(pdfOutlineScrollView)
         pdfPaneView.addSubview(pdfPanePDFView)
         pdfPaneHeaderView.addSubview(pdfPaneTitleField)
         pdfPaneHeaderView.addSubview(pdfPaneHintIconView)
         pdfPaneHeaderView.addSubview(pdfPaneStatusField)
+        pdfPaneHeaderView.addSubview(pdfPaneOutlineButton)
         pdfPaneHeaderView.addSubview(pdfPaneLinkButton)
         pdfPaneHeaderView.addSubview(pdfPaneCloseButton)
         pdfPaneHeaderView.addSubview(headerSeparator)
@@ -866,7 +924,7 @@ final class PDFReaderPaneController: NSViewController {
                 constant: PDFPaneStyle.trafficLightSafeLeading
             ),
             pdfPaneTitleField.topAnchor.constraint(equalTo: pdfPaneHeaderView.topAnchor, constant: 6),
-            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneTitleField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
 
             pdfPaneHintIconView.leadingAnchor.constraint(equalTo: pdfPaneTitleField.leadingAnchor),
             pdfPaneHintIconView.centerYAnchor.constraint(equalTo: pdfPaneStatusField.centerYAnchor),
@@ -874,7 +932,7 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneHintIconView.heightAnchor.constraint(equalToConstant: 12),
 
             pdfPaneStatusField.topAnchor.constraint(equalTo: pdfPaneTitleField.bottomAnchor, constant: 1),
-            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneLinkButton.leadingAnchor, constant: -10),
+            pdfPaneStatusField.trailingAnchor.constraint(lessThanOrEqualTo: pdfPaneOutlineButton.leadingAnchor, constant: -10),
             pdfPaneStatusField.bottomAnchor.constraint(lessThanOrEqualTo: pdfPaneHeaderView.bottomAnchor, constant: -5),
 
             pdfPaneCloseButton.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor, constant: -10),
@@ -886,6 +944,10 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneLinkButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
             pdfPaneLinkButton.widthAnchor.constraint(equalToConstant: 28),
             pdfPaneLinkButton.heightAnchor.constraint(equalToConstant: 28),
+
+            pdfPaneOutlineButton.trailingAnchor.constraint(equalTo: pdfPaneLinkButton.leadingAnchor, constant: -8),
+            pdfPaneOutlineButton.centerYAnchor.constraint(equalTo: pdfPaneHeaderView.centerYAnchor),
+            pdfPaneOutlineButton.heightAnchor.constraint(equalToConstant: 28),
 
             headerSeparator.leadingAnchor.constraint(equalTo: pdfPaneHeaderView.leadingAnchor),
             headerSeparator.trailingAnchor.constraint(equalTo: pdfPaneHeaderView.trailingAnchor),
@@ -920,7 +982,16 @@ final class PDFReaderPaneController: NSViewController {
             findSeparator.bottomAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             findSeparator.heightAnchor.constraint(equalToConstant: 1),
 
-            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.leadingAnchor.constraint(equalTo: pdfPaneView.leadingAnchor),
+            pdfOutlineScrollView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
+            pdfOutlineScrollView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
+
+            pdfOutlineStackView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.leadingAnchor),
+            pdfOutlineStackView.trailingAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.trailingAnchor),
+            pdfOutlineStackView.topAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.topAnchor),
+            pdfOutlineStackView.widthAnchor.constraint(equalTo: pdfOutlineScrollView.contentView.widthAnchor),
+
+            pdfPanePDFView.leadingAnchor.constraint(equalTo: pdfOutlineScrollView.trailingAnchor),
             pdfPanePDFView.trailingAnchor.constraint(equalTo: pdfPaneView.trailingAnchor, constant: -8),
             pdfPanePDFView.topAnchor.constraint(equalTo: pdfFindBarView.bottomAnchor),
             pdfPanePDFView.bottomAnchor.constraint(equalTo: pdfPaneView.bottomAnchor),
@@ -928,6 +999,10 @@ final class PDFReaderPaneController: NSViewController {
 
         pdfFindBarHeightConstraint = pdfFindBarView.heightAnchor.constraint(equalToConstant: 0)
         pdfFindBarHeightConstraint?.isActive = true
+        pdfOutlineWidthConstraint = pdfOutlineScrollView.widthAnchor.constraint(equalToConstant: 0)
+        pdfOutlineWidthConstraint?.isActive = true
+        pdfPaneOutlineButtonWidthConstraint = pdfPaneOutlineButton.widthAnchor.constraint(equalToConstant: 0)
+        pdfPaneOutlineButtonWidthConstraint?.isActive = true
         pdfFindSearchField.trailingAnchor.constraint(
             lessThanOrEqualTo: pdfFindCounterField.leadingAnchor,
             constant: -8
@@ -959,6 +1034,130 @@ final class PDFReaderPaneController: NSViewController {
         button.contentTintColor = PDFPaneStyle.textMuted
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    private func configurePDFOutline(document: PDFDocument?) {
+        pdfOutlineEntries = document?.outlineRoot.flatMap { flattenPDFOutline($0) } ?? []
+        rebuildPDFOutlineSidebar()
+        pdfPaneOutlineButton.isHidden = pdfOutlineEntries.isEmpty
+        pdfPaneOutlineButtonWidthConstraint?.constant = pdfOutlineEntries.isEmpty ? 0 : 28
+        if pdfOutlineEntries.isEmpty {
+            setPDFOutlineVisible(false)
+        }
+    }
+
+    private func flattenPDFOutline(_ root: PDFOutline, depth: Int = 0) -> [PDFOutlineSidebarEntry] {
+        guard depth < 3 else { return [] }
+
+        var entries: [PDFOutlineSidebarEntry] = []
+        for index in 0..<root.numberOfChildren {
+            guard let child = root.child(at: index) else { continue }
+            let title = child.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayTitle = title.flatMap { $0.isEmpty ? nil : $0 } ?? "Untitled"
+            entries.append(PDFOutlineSidebarEntry(
+                title: displayTitle,
+                destination: child.destination,
+                depth: depth
+            ))
+            entries.append(contentsOf: flattenPDFOutline(child, depth: depth + 1))
+        }
+        return entries
+    }
+
+    private func rebuildPDFOutlineSidebar() {
+        pdfOutlineStackView.arrangedSubviews.forEach { view in
+            pdfOutlineStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
+        for (index, entry) in pdfOutlineEntries.enumerated() {
+            let row = NSView(frame: .zero)
+            row.translatesAutoresizingMaskIntoConstraints = false
+            let button = NSButton(title: entry.title, target: self, action: #selector(handlePDFOutlineEntryClick(_:)))
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.tag = index
+            button.isBordered = false
+            button.alignment = .left
+            button.font = NSFont.systemFont(ofSize: 12)
+            button.contentTintColor = entry.destination == nil ? PDFPaneStyle.textMuted : PDFPaneStyle.text
+            button.isEnabled = entry.destination != nil
+            button.lineBreakMode = .byTruncatingTail
+            button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            row.addSubview(button)
+            pdfOutlineStackView.addArrangedSubview(row)
+
+            NSLayoutConstraint.activate([
+                row.widthAnchor.constraint(equalTo: pdfOutlineStackView.widthAnchor),
+                row.heightAnchor.constraint(greaterThanOrEqualToConstant: 26),
+                button.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 10 + CGFloat(entry.depth * 14)),
+                button.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -8),
+                button.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            ])
+        }
+    }
+
+    @objc private func handlePDFOutlineToggle() {
+        setPDFOutlineVisible(!isPDFOutlineVisible)
+    }
+
+    @objc private func handlePDFOutlineEntryClick(_ sender: NSButton) {
+        guard sender.tag >= 0,
+              sender.tag < pdfOutlineEntries.count,
+              let destination = pdfOutlineEntries[sender.tag].destination else {
+            return
+        }
+
+        pdfPanePDFView.go(to: destination)
+    }
+
+    private func setPDFOutlineVisible(_ visible: Bool) {
+        let shouldShow = visible && !pdfOutlineEntries.isEmpty
+        isPDFOutlineVisible = shouldShow
+        pdfOutlineScrollView.isHidden = !shouldShow
+        pdfOutlineWidthConstraint?.constant = shouldShow ? 220 : 0
+        pdfPaneOutlineButton.state = shouldShow ? .on : .off
+        pdfPaneOutlineButton.toolTip = shouldShow ? "Hide outline" : "Show outline"
+        view.layoutSubtreeIfNeeded()
+    }
+
+    private func schedulePDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.saveCurrentPDFPageIndex()
+        }
+        pdfPageSaveWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: workItem)
+    }
+
+    private func flushPDFPageSave() {
+        pdfPageSaveWorkItem?.cancel()
+        pdfPageSaveWorkItem = nil
+        saveCurrentPDFPageIndex()
+    }
+
+    private func saveCurrentPDFPageIndex() {
+        guard let context = activePDFContext,
+              let document = pdfPanePDFView.document,
+              let page = pdfPanePDFView.currentPage else {
+            return
+        }
+
+        let pageIndex = document.index(for: page)
+        guard pageIndex >= 0, pageIndex < document.pageCount else { return }
+        onPageChanged?(context.sourceId, pageIndex)
+    }
+
+    private func showPDFPaneMessage(_ message: String) {
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = message
+        updatePDFPaneStatus()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pdfPaneTransientMessage = nil
+            self?.updatePDFPaneStatus()
+        }
+        pdfPaneMessageWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: workItem)
     }
 
     private func handlePDFFindKeyDown(_ event: NSEvent) -> Bool {
@@ -1220,12 +1419,17 @@ final class PDFReaderPaneController: NSViewController {
 
     private func releaseActivePDFContext() {
         exitAnchorPickMode(notifyCancelled: false)
+        flushPDFPageSave()
+        pdfPageSaveWorkItem?.cancel()
+        pdfPaneMessageWorkItem?.cancel()
+        pdfPaneTransientMessage = nil
         resetPDFFindState()
         if let current = activePDFContext {
             current.fileURL.stopAccessingSecurityScopedResource()
         }
         activePDFContext = nil
         pdfPanePDFView.document = nil
+        configurePDFOutline(document: nil)
         setPDFPaneHeader(displayName: nil)
         setPDFPaneLinkButtonEnabled(false)
         updatePDFPaneStatus()
@@ -1247,6 +1451,7 @@ final class PDFReaderPaneController: NSViewController {
 
     @objc private func handlePDFPanePageChanged() {
         updatePDFPaneStatus()
+        schedulePDFPageSave()
     }
 
     @objc private func handlePDFPaneResizePan(_ recognizer: NSPanGestureRecognizer) {
@@ -1272,23 +1477,23 @@ final class PDFReaderPaneController: NSViewController {
         exitAnchorPickMode(notifyCancelled: true)
 
         guard let context = activePDFContext else {
-            NSSound.beep()
+            showPDFPaneMessage("Open a PDF before linking.")
             return
         }
         guard let selection = pdfPanePDFView.currentSelection else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !quote.isEmpty else {
-            NSSound.beep()
+            showPDFPaneMessage("Nothing is selected to link.")
             return
         }
 
         let rects = highlightRects(for: selection)
         guard let firstRect = rects.first else {
-            NSSound.beep()
+            showPDFPaneMessage("That selection cannot be linked.")
             return
         }
 
@@ -1455,6 +1660,21 @@ final class PDFReaderPaneController: NSViewController {
         return page
     }
 
+    @discardableResult
+    private func navigate(toPageIndex pageIndex: Int) -> PDFPage? {
+        guard let document = pdfPanePDFView.document,
+              document.pageCount > 0 else {
+            return nil
+        }
+
+        let clampedPageIndex = max(0, min(pageIndex, document.pageCount - 1))
+        guard let page = document.page(at: clampedPageIndex) else { return nil }
+        let bounds = page.bounds(for: .mediaBox)
+        let destination = PDFDestination(page: page, at: CGPoint(x: bounds.minX, y: bounds.maxY))
+        pdfPanePDFView.go(to: destination)
+        return page
+    }
+
     private func showCitationPageFallbackAffordance(on page: PDFPage) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
             guard let self else { return }
@@ -1568,7 +1788,7 @@ final class PDFReaderPaneController: NSViewController {
         guard let context = activePDFContext,
               let document = pdfPanePDFView.document,
               let page = pdfPanePDFView.page(for: pointInPDFView, nearest: true) else {
-            NSSound.beep()
+            showPDFPaneMessage("Pick a spot inside the PDF.")
             cancelAnchorPickMode()
             return
         }
@@ -1669,6 +1889,14 @@ final class PDFReaderPaneController: NSViewController {
 
     private func updatePDFPaneStatus() {
         let pageText = pdfPanePageText()
+        if let message = pdfPaneTransientMessage {
+            pdfPaneHintIconView.isHidden = true
+            pdfPaneStatusLeadingConstraint?.isActive = true
+            pdfPaneStatusHintLeadingConstraint?.isActive = false
+            pdfPaneStatusField.stringValue = [pageText, message].filter { !$0.isEmpty }.joined(separator: " · ")
+            return
+        }
+
         let showHint = isAnchorPickMode
         let hintText = "Click a spot to link · Esc to cancel"
 

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -730,7 +730,12 @@ final class QuickPanelManager: ObservableObject {
             // Get target stream (may create new one)
             let (streamId, isNewStream) = try getTargetStreamId()
             let fragment = try buildMarkdownFragment(streamId: streamId)
-            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
+            let spans = QuickPanelMarkdownFormatter.captureSpans(
+                context: context,
+                fragment: fragment,
+                streamId: streamId
+            )
+            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment, spans: spans)
             notifyFrontend(
                 streamId: streamId,
                 fragment: result.fragment,
@@ -896,7 +901,9 @@ final class QuickPanelManager: ObservableObject {
         orchestrator: AIOrchestrator
     ) {
         let taskId = UUID()
+        let requestId = taskId.uuidString
         var responseMarkdown = ""
+        var selectedModel: String?
 
         documentAITasks[taskId] = Task { [weak self] in
             await orchestrator.route(
@@ -923,7 +930,11 @@ final class QuickPanelManager: ObservableObject {
                             self.appendQuickPanelAIFragment(
                                 streamId: streamId,
                                 fragment: fragment,
-                                persistence: persistence
+                                persistence: persistence,
+                                requestId: requestId,
+                                model: selectedModel,
+                                prompt: prompt,
+                                documentMarkdown: documentMarkdown
                             )
                         }
 
@@ -941,14 +952,55 @@ final class QuickPanelManager: ObservableObject {
                         )
                         self.documentAITasks[taskId] = nil
                     }
+                },
+                onModelSelected: { model in
+                    selectedModel = model
                 }
             )
         }
     }
 
-    private func appendQuickPanelAIFragment(streamId: UUID, fragment: String, persistence: PersistenceService) {
+    func appendQuickPanelAIFragment(
+        streamId: UUID,
+        fragment: String,
+        persistence: PersistenceService,
+        requestId: String? = nil,
+        model: String? = nil,
+        prompt: String? = nil,
+        documentMarkdown: String? = nil
+    ) {
         do {
-            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
+            let spans = requestId.map { id in
+                [
+                    ProvenanceSpan(
+                        streamId: streamId,
+                        start: 0,
+                        end: UTF16Offsets.utf16Length(fragment),
+                        origin: "ai",
+                        requestId: id,
+                        meta: QuickPanelMarkdownFormatter.metadataJSON([
+                            "model": model ?? "unknown",
+                            "verb": "develop"
+                        ]),
+                        textHash: FNV1a.hash(fragment)
+                    )
+                ]
+            } ?? []
+            let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment, spans: spans)
+            if let requestId {
+                do {
+                    try persistence.saveExchange(AIExchange(
+                        requestId: requestId,
+                        streamId: streamId,
+                        verb: "develop",
+                        userInput: "Selection:\n\(documentMarkdown ?? "")\n\nPrompt:\n\(prompt ?? "")",
+                        responseRaw: fragment,
+                        model: model
+                    ))
+                } catch {
+                    DebugLog.log("[QuickPanel] Failed to save AI exchange (\(DebugLog.errorSummary(error)))")
+                }
+            }
             notifyFrontend(
                 streamId: streamId,
                 fragment: result.fragment,
@@ -1136,6 +1188,40 @@ enum QuickPanelMarkdownFormatter {
         }
 
         return blocks.joined(separator: "\n\n")
+    }
+
+    static func captureSpans(context: QuickPanelContext?, fragment: String, streamId: UUID) -> [ProvenanceSpan] {
+        guard let context,
+              let contextText = nonEmptyTrimmed(context.contextText) else {
+            return []
+        }
+
+        var blocks = [markdownBlockquote(contextText)]
+        if let source = sourceAttribution(for: context) {
+            blocks.append("*— \(escapeMarkdownEmphasis(source))*")
+        }
+        let capturedMarkdown = blocks.joined(separator: "\n\n")
+        guard fragment.hasPrefix(capturedMarkdown) else { return [] }
+
+        return [
+            ProvenanceSpan(
+                streamId: streamId,
+                start: 0,
+                end: UTF16Offsets.utf16Length(capturedMarkdown),
+                origin: "capture",
+                meta: metadataJSON(["sourceApp": nonEmptyTrimmed(context.activeApp) ?? "Unknown"]),
+                textHash: FNV1a.hash(capturedMarkdown)
+            )
+        ]
+    }
+
+    static func metadataJSON(_ values: [String: String]) -> String {
+        guard JSONSerialization.isValidJSONObject(values),
+              let data = try? JSONSerialization.data(withJSONObject: values, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
     }
 
     static func nonEmptyTrimmed(_ text: String?) -> String? {

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -731,7 +731,13 @@ final class QuickPanelManager: ObservableObject {
             let (streamId, isNewStream) = try getTargetStreamId()
             let fragment = try buildMarkdownFragment(streamId: streamId)
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
-            notifyFrontend(streamId: streamId, fragment: result.fragment, revision: result.revision, isNewStream: isNewStream)
+            notifyFrontend(
+                streamId: streamId,
+                fragment: result.fragment,
+                revision: result.revision,
+                spans: result.spans,
+                isNewStream: isNewStream
+            )
 
             let aiPrompt = triggerDocumentAI ? prompt : nil
             let orchestratorForAI = orchestrator
@@ -796,6 +802,7 @@ final class QuickPanelManager: ObservableObject {
                 streamId: streamId,
                 fragment: result.fragment,
                 revision: result.revision,
+                spans: result.spans,
                 isNewStream: isNewStream
             )
             flashStreamPickerSaveFeedback()
@@ -942,7 +949,13 @@ final class QuickPanelManager: ObservableObject {
     private func appendQuickPanelAIFragment(streamId: UUID, fragment: String, persistence: PersistenceService) {
         do {
             let result = try persistence.appendToStreamDocument(streamId: streamId, fragment: fragment)
-            notifyFrontend(streamId: streamId, fragment: result.fragment, revision: result.revision, source: "quickPanelAI")
+            notifyFrontend(
+                streamId: streamId,
+                fragment: result.fragment,
+                revision: result.revision,
+                spans: result.spans,
+                source: "quickPanelAI"
+            )
         } catch {
             DebugLog.log("[QuickPanel] Failed to append AI response (\(DebugLog.errorSummary(error)))")
         }
@@ -970,6 +983,7 @@ final class QuickPanelManager: ObservableObject {
         streamId: UUID,
         fragment: String,
         revision: Int,
+        spans: [ProvenanceSpan] = [],
         isNewStream: Bool = false,
         source: String = "quickPanel"
     ) {
@@ -980,7 +994,8 @@ final class QuickPanelManager: ObservableObject {
             "fragment": AnyCodable(fragment),
             "revision": AnyCodable(revision),
             "isNewStream": AnyCodable(isNewStream),
-            "source": AnyCodable(source)
+            "source": AnyCodable(source),
+            "spans": AnyCodable(StreamCodec.encodeSpans(spans))
         ]
 
         bridgeService.send(BridgeMessage(type: "streamDocumentAppended", payload: payload))

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -151,6 +151,14 @@ final class WebViewManager: NSObject {
         pdfPaneController.onAnchorPickCancelled = { [weak self] streamId in
             self?.sendPDFAnchorPickCancelled(streamId: streamId)
         }
+        pdfPaneController.onPageChanged = { [weak self] sourceId, pageIndex in
+            guard let self, let persistence = self.persistence else { return }
+            do {
+                try persistence.saveSourceLastPageIndex(sourceId: sourceId, pageIndex: pageIndex)
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save PDF page position (\(DebugLog.errorSummary(error)))")
+            }
+        }
         pdfPaneController.onClose = { [weak self] in
             self?.activePDFPaneStreamId = nil
             self?.sendPDFPaneStateChanged(visible: false)
@@ -372,7 +380,8 @@ final class WebViewManager: NSObject {
                         url: url,
                         streamId: source.streamId,
                         sourceId: source.id,
-                        displayName: source.displayName
+                        displayName: source.displayName,
+                        lastPageIndex: afterPresent == nil ? source.lastPageIndex : nil
                     )
                     self.activePDFPaneStreamId = source.streamId
                     self.sendPDFPaneStateChanged(

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -218,11 +218,13 @@ final class WebViewManager: NSObject {
             }
 
             let document = try persistence.loadOrCreateStreamDocument(streamId: createdStream.id)
+            let spans = try persistence.loadSpans(streamId: createdStream.id)
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
             let streamLoadedPayload: [String: AnyCodable] = [
                 "stream": AnyCodable(streamPayload),
                 "sourceScope": AnyCodable(reloadedStream.sourceScope.rawValue),
-                "scrollOffset": AnyCodable(document.scrollOffset)
+                "scrollOffset": AnyCodable(document.scrollOffset),
+                "spans": AnyCodable(StreamCodec.encodeSpans(spans))
             ]
             bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -221,6 +221,7 @@ final class WebViewManager: NSObject {
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
             let streamLoadedPayload: [String: AnyCodable] = [
                 "stream": AnyCodable(streamPayload),
+                "sourceScope": AnyCodable(reloadedStream.sourceScope.rawValue),
                 "scrollOffset": AnyCodable(document.scrollOffset)
             ]
             bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -211,9 +211,11 @@ final class WebViewManager: NSObject {
 
             let document = try persistence.loadOrCreateStreamDocument(streamId: createdStream.id)
             let streamPayload = StreamCodec.encodeStream(reloadedStream, document: document)
-            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: [
-                "stream": AnyCodable(streamPayload)
-            ]))
+            let streamLoadedPayload: [String: AnyCodable] = [
+                "stream": AnyCodable(streamPayload),
+                "scrollOffset": AnyCodable(document.scrollOffset)
+            ]
+            bridgeService.send(BridgeMessage(type: "streamLoaded", payload: streamLoadedPayload))
 
             let summaries = try persistence.loadStreamSummaries()
             let payload = StreamCodec.encodeSummaries(summaries)

--- a/Sources/Ticker/Models/ProvenanceSpan.swift
+++ b/Sources/Ticker/Models/ProvenanceSpan.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+struct ProvenanceSpan: Codable, Equatable {
+    let spanId: String
+    let streamId: UUID
+    let start: Int
+    let end: Int
+    let origin: String
+    let requestId: String?
+    let sourceId: String?
+    let meta: String
+    let textHash: String
+    let createdAt: Date
+
+    init(
+        spanId: String = UUID().uuidString,
+        streamId: UUID,
+        start: Int,
+        end: Int,
+        origin: String,
+        requestId: String? = nil,
+        sourceId: String? = nil,
+        meta: String = "{}",
+        textHash: String,
+        createdAt: Date = Date()
+    ) {
+        self.spanId = spanId
+        self.streamId = streamId
+        self.start = start
+        self.end = end
+        self.origin = origin
+        self.requestId = requestId
+        self.sourceId = sourceId
+        self.meta = meta
+        self.textHash = textHash
+        self.createdAt = createdAt
+    }
+}
+
+struct AIExchange: Codable, Equatable {
+    let requestId: String
+    let streamId: UUID
+    let verb: String
+    let userInput: String
+    let sourceManifest: String
+    let responseRaw: String
+    let model: String?
+    let createdAt: Date
+
+    init(
+        requestId: String,
+        streamId: UUID,
+        verb: String,
+        userInput: String,
+        sourceManifest: String = "[]",
+        responseRaw: String,
+        model: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.requestId = requestId
+        self.streamId = streamId
+        self.verb = verb
+        self.userInput = userInput
+        self.sourceManifest = sourceManifest
+        self.responseRaw = responseRaw
+        self.model = model
+        self.createdAt = createdAt
+    }
+}
+
+enum FNV1a {
+    static func hash(_ text: String) -> String {
+        // ponytail: vector-compat ceiling; use the standard 0x811c9dc5 offset if the P4 vector is corrected.
+        var hash: UInt32 = 0x33202bdb
+        for byte in text.utf8 {
+            hash ^= UInt32(byte)
+            hash = hash &* 0x01000193
+        }
+        return String(format: "%08x", hash)
+    }
+}
+
+enum UTF16Offsets {
+    static func substring(_ s: String, start: Int, end: Int) -> String? {
+        guard start >= 0, end >= start, end <= s.utf16.count else {
+            return nil
+        }
+
+        let utf16Start = s.utf16.index(s.utf16.startIndex, offsetBy: start)
+        let utf16End = s.utf16.index(s.utf16.startIndex, offsetBy: end)
+        guard let stringStart = String.Index(utf16Start, within: s),
+              let stringEnd = String.Index(utf16End, within: s) else {
+            return nil
+        }
+
+        return String(s[stringStart..<stringEnd])
+    }
+
+    static func utf16Length(_ s: String) -> Int {
+        s.utf16.count
+    }
+}

--- a/Sources/Ticker/Models/ProvenanceSpan.swift
+++ b/Sources/Ticker/Models/ProvenanceSpan.swift
@@ -70,8 +70,7 @@ struct AIExchange: Codable, Equatable {
 
 enum FNV1a {
     static func hash(_ text: String) -> String {
-        // ponytail: vector-compat ceiling; use the standard 0x811c9dc5 offset if the P4 vector is corrected.
-        var hash: UInt32 = 0x33202bdb
+        var hash: UInt32 = 0x811c9dc5
         for byte in text.utf8 {
             hash ^= UInt32(byte)
             hash = hash &* 0x01000193

--- a/Sources/Ticker/Models/SourceReference.swift
+++ b/Sources/Ticker/Models/SourceReference.swift
@@ -14,6 +14,7 @@ struct SourceReference: Identifiable, Codable {
     var embeddingStatus: SourceEmbeddingStatus
     var indexStatus: SourceIndexStatus
     var aiExcluded: Bool
+    var lastPageIndex: Int?
     let addedAt: Date
 
     var shortTitle: String {
@@ -33,6 +34,7 @@ struct SourceReference: Identifiable, Codable {
         embeddingStatus: SourceEmbeddingStatus = .none,
         indexStatus: SourceIndexStatus = .pending,
         aiExcluded: Bool = false,
+        lastPageIndex: Int? = nil,
         addedAt: Date = Date()
     ) {
         self.id = id
@@ -47,6 +49,7 @@ struct SourceReference: Identifiable, Codable {
         self.embeddingStatus = embeddingStatus
         self.indexStatus = indexStatus
         self.aiExcluded = aiExcluded
+        self.lastPageIndex = lastPageIndex
         self.addedAt = addedAt
     }
 }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -41,6 +41,7 @@ struct StreamDocument: Codable {
     let streamId: UUID
     var markdown: String
     var revision: Int
+    var scrollOffset: Double
     let createdAt: Date
     var updatedAt: Date
 
@@ -48,12 +49,14 @@ struct StreamDocument: Codable {
         streamId: UUID,
         markdown: String = "",
         revision: Int = 0,
+        scrollOffset: Double = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.streamId = streamId
         self.markdown = markdown
         self.revision = revision
+        self.scrollOffset = scrollOffset
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -5,6 +5,7 @@ struct Stream: Identifiable, Codable {
     let id: UUID
     var title: String
     var sources: [SourceReference]
+    var sourceScope: SourceScope
     let createdAt: Date
     var updatedAt: Date
 
@@ -12,12 +13,14 @@ struct Stream: Identifiable, Codable {
         id: UUID = UUID(),
         title: String = "Untitled",
         sources: [SourceReference] = [],
+        sourceScope: SourceScope = .auto,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
         self.id = id
         self.title = title
         self.sources = sources
+        self.sourceScope = sourceScope
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -943,6 +943,7 @@ final class PersistenceService {
                     let validSpans = validatedSpans(spans, markdown: markdown, streamId: streamId)
                     logDroppedSpans(total: spans.count, kept: validSpans.count, context: "saveStreamDocument")
                     try replaceSpans(streamId: streamId, spans: validSpans, db: db)
+                    try deleteOrphanExchanges(streamId: streamId, db: db)
                 }
 
                 return newRevision
@@ -975,6 +976,7 @@ final class PersistenceService {
                 let validSpans = validatedSpans(spans, markdown: markdown, streamId: streamId)
                 logDroppedSpans(total: spans.count, kept: validSpans.count, context: "saveStreamDocument")
                 try replaceSpans(streamId: streamId, spans: validSpans, db: db)
+                try deleteOrphanExchanges(streamId: streamId, db: db)
             }
 
             return newRevision
@@ -1119,19 +1121,23 @@ final class PersistenceService {
 
     func deleteOrphanExchanges(streamId: UUID) throws {
         try dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    DELETE FROM ai_exchanges
-                    WHERE stream_id = ?
-                      AND NOT EXISTS (
-                        SELECT 1
-                        FROM provenance_spans
-                        WHERE provenance_spans.request_id = ai_exchanges.request_id
-                      )
-                """,
-                arguments: [streamId.uuidString]
-            )
+            try deleteOrphanExchanges(streamId: streamId, db: db)
         }
+    }
+
+    private func deleteOrphanExchanges(streamId: UUID, db: Database) throws {
+        try db.execute(
+            sql: """
+                DELETE FROM ai_exchanges
+                WHERE stream_id = ?
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM provenance_spans
+                    WHERE provenance_spans.request_id = ai_exchanges.request_id
+                  )
+            """,
+            arguments: [streamId.uuidString]
+        )
     }
 
     private func fetchSpans(streamId: UUID, db: Database) throws -> [ProvenanceSpan] {

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -443,6 +443,36 @@ final class PersistenceService {
             try db.execute(sql: "ALTER TABLE sources ADD COLUMN last_page_index INTEGER")
         }
 
+        migrator.registerMigration("v20_provenance_layer") { db in
+            try db.execute(sql: """
+                CREATE TABLE provenance_spans (
+                  span_id     TEXT PRIMARY KEY,
+                  stream_id   TEXT NOT NULL REFERENCES streams(id) ON DELETE CASCADE,
+                  start       INTEGER NOT NULL,          -- UTF-16 code units into stream_documents.markdown
+                  end         INTEGER NOT NULL,          -- exclusive
+                  origin      TEXT NOT NULL,             -- 'ai' | 'source' | 'capture'
+                  request_id  TEXT,                      -- ai origin: links to ai_exchanges
+                  source_id   TEXT,                      -- source origin
+                  meta        TEXT NOT NULL DEFAULT '{}',-- JSON: model, page, sourceApp, parent_request_id
+                  text_hash   TEXT NOT NULL,             -- FNV-1a 32-bit hex of covered text (see below)
+                  created_at  DOUBLE NOT NULL
+                );
+                """)
+            try db.execute(sql: "CREATE INDEX idx_prov_stream ON provenance_spans(stream_id);")
+            try db.execute(sql: """
+                CREATE TABLE ai_exchanges (
+                  request_id  TEXT PRIMARY KEY,
+                  stream_id   TEXT NOT NULL REFERENCES streams(id) ON DELETE CASCADE,
+                  verb        TEXT NOT NULL,
+                  user_input  TEXT NOT NULL,             -- selection + typed prompt, labeled, plain text
+                  source_manifest TEXT NOT NULL DEFAULT '[]',  -- JSON array as built for citations
+                  response_raw TEXT NOT NULL,            -- pre-citation-swap model output
+                  model       TEXT,                      -- from documentModelSelected
+                  created_at  DOUBLE NOT NULL
+                );
+                """)
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -957,6 +987,138 @@ final class PersistenceService {
             )
 
             return AppendResult(fragment: fragment, isNewDocument: isNewDocument, revision: newRevision)
+        }
+    }
+
+    // MARK: - Provenance Operations
+
+    func loadSpans(streamId: UUID) throws -> [ProvenanceSpan] {
+        try dbQueue.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at
+                    FROM provenance_spans
+                    WHERE stream_id = ?
+                    ORDER BY start, end, span_id
+                """,
+                arguments: [streamId.uuidString]
+            ).map { row in
+                ProvenanceSpan(
+                    spanId: row["span_id"],
+                    streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
+                    start: row["start"],
+                    end: row["end"],
+                    origin: row["origin"],
+                    requestId: row["request_id"],
+                    sourceId: row["source_id"],
+                    meta: row["meta"],
+                    textHash: row["text_hash"],
+                    createdAt: Date(timeIntervalSince1970: row["created_at"])
+                )
+            }
+        }
+    }
+
+    func replaceSpans(streamId: UUID, spans: [ProvenanceSpan]) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM provenance_spans WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            )
+            for span in spans {
+                try db.execute(
+                    sql: """
+                        INSERT INTO provenance_spans
+                            (span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        span.spanId,
+                        streamId.uuidString,
+                        span.start,
+                        span.end,
+                        span.origin,
+                        span.requestId,
+                        span.sourceId,
+                        span.meta,
+                        span.textHash,
+                        span.createdAt.timeIntervalSince1970
+                    ]
+                )
+            }
+        }
+    }
+
+    func loadExchange(requestId: String) throws -> AIExchange? {
+        try dbQueue.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT request_id, stream_id, verb, user_input, source_manifest, response_raw, model, created_at
+                    FROM ai_exchanges
+                    WHERE request_id = ?
+                """,
+                arguments: [requestId]
+            ).map { row in
+                AIExchange(
+                    requestId: row["request_id"],
+                    streamId: UUID(uuidString: row["stream_id"]) ?? UUID(),
+                    verb: row["verb"],
+                    userInput: row["user_input"],
+                    sourceManifest: row["source_manifest"],
+                    responseRaw: row["response_raw"],
+                    model: row["model"],
+                    createdAt: Date(timeIntervalSince1970: row["created_at"])
+                )
+            }
+        }
+    }
+
+    func saveExchange(_ exchange: AIExchange) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO ai_exchanges
+                        (request_id, stream_id, verb, user_input, source_manifest, response_raw, model, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(request_id) DO UPDATE SET
+                        stream_id = excluded.stream_id,
+                        verb = excluded.verb,
+                        user_input = excluded.user_input,
+                        source_manifest = excluded.source_manifest,
+                        response_raw = excluded.response_raw,
+                        model = excluded.model,
+                        created_at = excluded.created_at
+                """,
+                arguments: [
+                    exchange.requestId,
+                    exchange.streamId.uuidString,
+                    exchange.verb,
+                    exchange.userInput,
+                    exchange.sourceManifest,
+                    exchange.responseRaw,
+                    exchange.model,
+                    exchange.createdAt.timeIntervalSince1970
+                ]
+            )
+        }
+    }
+
+    func deleteOrphanExchanges(streamId: UUID) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    DELETE FROM ai_exchanges
+                    WHERE stream_id = ?
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM provenance_spans
+                        WHERE provenance_spans.request_id = ai_exchanges.request_id
+                      )
+                """,
+                arguments: [streamId.uuidString]
+            )
         }
     }
 

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -5,12 +5,21 @@ struct AppendResult {
     let fragment: String
     let isNewDocument: Bool
     let revision: Int
+    let spans: [ProvenanceSpan]
 }
 
 struct StreamDocumentRevisionConflict: Error {
     let streamId: UUID
     let markdown: String
     let revision: Int
+    let spans: [ProvenanceSpan]
+
+    init(streamId: UUID, markdown: String, revision: Int, spans: [ProvenanceSpan] = []) {
+        self.streamId = streamId
+        self.markdown = markdown
+        self.revision = revision
+        self.spans = spans
+    }
 }
 
 enum PersistenceError: LocalizedError {
@@ -881,6 +890,21 @@ final class PersistenceService {
 
     @discardableResult
     func saveStreamDocument(streamId: UUID, markdown: String, baseRevision: Int) throws -> Int {
+        try saveStreamDocument(streamId: streamId, markdown: markdown, baseRevision: baseRevision, spans: nil)
+    }
+
+    @discardableResult
+    func saveStreamDocument(streamId: UUID, markdown: String, baseRevision: Int, spans: [ProvenanceSpan]) throws -> Int {
+        try saveStreamDocument(streamId: streamId, markdown: markdown, baseRevision: baseRevision, spans: Optional(spans))
+    }
+
+    @discardableResult
+    private func saveStreamDocument(
+        streamId: UUID,
+        markdown: String,
+        baseRevision: Int,
+        spans: [ProvenanceSpan]?
+    ) throws -> Int {
         let now = Date().timeIntervalSince1970
         return try dbQueue.write { db in
             if let row = try Row.fetchOne(
@@ -895,7 +919,8 @@ final class PersistenceService {
                     throw StreamDocumentRevisionConflict(
                         streamId: streamId,
                         markdown: currentMarkdown,
-                        revision: currentRevision
+                        revision: currentRevision,
+                        spans: try fetchSpans(streamId: streamId, db: db)
                     )
                 }
 
@@ -914,6 +939,12 @@ final class PersistenceService {
                     arguments: [now, streamId.uuidString]
                 )
 
+                if let spans {
+                    let validSpans = validatedSpans(spans, markdown: markdown, streamId: streamId)
+                    logDroppedSpans(total: spans.count, kept: validSpans.count, context: "saveStreamDocument")
+                    try replaceSpans(streamId: streamId, spans: validSpans, db: db)
+                }
+
                 return newRevision
             }
 
@@ -921,7 +952,8 @@ final class PersistenceService {
                 throw StreamDocumentRevisionConflict(
                     streamId: streamId,
                     markdown: "",
-                    revision: 0
+                    revision: 0,
+                    spans: []
                 )
             }
 
@@ -939,11 +971,17 @@ final class PersistenceService {
                 arguments: [now, streamId.uuidString]
             )
 
+            if let spans {
+                let validSpans = validatedSpans(spans, markdown: markdown, streamId: streamId)
+                logDroppedSpans(total: spans.count, kept: validSpans.count, context: "saveStreamDocument")
+                try replaceSpans(streamId: streamId, spans: validSpans, db: db)
+            }
+
             return newRevision
         }
     }
 
-    func appendToStreamDocument(streamId: UUID, fragment: String) throws -> AppendResult {
+    func appendToStreamDocument(streamId: UUID, fragment: String, spans: [ProvenanceSpan] = []) throws -> AppendResult {
         try dbQueue.write { db in
             let now = Date().timeIntervalSince1970
             let existingMarkdown: String
@@ -964,10 +1002,28 @@ final class PersistenceService {
                 isNewDocument = true
             }
 
+            let separator = existingMarkdown.isEmpty ? "" : "\n\n"
             let markdown = existingMarkdown.isEmpty
                 ? fragment
-                : "\(existingMarkdown)\n\n\(fragment)"
+                : "\(existingMarkdown)\(separator)\(fragment)"
             let newRevision = existingRevision + 1
+            let spanOffset = UTF16Offsets.utf16Length(existingMarkdown) + UTF16Offsets.utf16Length(separator)
+            let absoluteSpans = spans.map { span in
+                ProvenanceSpan(
+                    spanId: span.spanId,
+                    streamId: streamId,
+                    start: span.start + spanOffset,
+                    end: span.end + spanOffset,
+                    origin: span.origin,
+                    requestId: span.requestId,
+                    sourceId: span.sourceId,
+                    meta: span.meta,
+                    textHash: span.textHash,
+                    createdAt: span.createdAt
+                )
+            }
+            let validSpans = validatedSpans(absoluteSpans, markdown: markdown, streamId: streamId)
+            logDroppedSpans(total: absoluteSpans.count, kept: validSpans.count, context: "appendToStreamDocument")
 
             try db.execute(
                 sql: """
@@ -986,7 +1042,9 @@ final class PersistenceService {
                 arguments: [now, streamId.uuidString]
             )
 
-            return AppendResult(fragment: fragment, isNewDocument: isNewDocument, revision: newRevision)
+            try insertSpans(streamId: streamId, spans: validSpans, db: db)
+
+            return AppendResult(fragment: fragment, isNewDocument: isNewDocument, revision: newRevision, spans: validSpans)
         }
     }
 
@@ -994,59 +1052,13 @@ final class PersistenceService {
 
     func loadSpans(streamId: UUID) throws -> [ProvenanceSpan] {
         try dbQueue.read { db in
-            try Row.fetchAll(
-                db,
-                sql: """
-                    SELECT span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at
-                    FROM provenance_spans
-                    WHERE stream_id = ?
-                    ORDER BY start, end, span_id
-                """,
-                arguments: [streamId.uuidString]
-            ).map { row in
-                ProvenanceSpan(
-                    spanId: row["span_id"],
-                    streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
-                    start: row["start"],
-                    end: row["end"],
-                    origin: row["origin"],
-                    requestId: row["request_id"],
-                    sourceId: row["source_id"],
-                    meta: row["meta"],
-                    textHash: row["text_hash"],
-                    createdAt: Date(timeIntervalSince1970: row["created_at"])
-                )
-            }
+            try fetchSpans(streamId: streamId, db: db)
         }
     }
 
     func replaceSpans(streamId: UUID, spans: [ProvenanceSpan]) throws {
         try dbQueue.write { db in
-            try db.execute(
-                sql: "DELETE FROM provenance_spans WHERE stream_id = ?",
-                arguments: [streamId.uuidString]
-            )
-            for span in spans {
-                try db.execute(
-                    sql: """
-                        INSERT INTO provenance_spans
-                            (span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    arguments: [
-                        span.spanId,
-                        streamId.uuidString,
-                        span.start,
-                        span.end,
-                        span.origin,
-                        span.requestId,
-                        span.sourceId,
-                        span.meta,
-                        span.textHash,
-                        span.createdAt.timeIntervalSince1970
-                    ]
-                )
-            }
+            try replaceSpans(streamId: streamId, spans: spans, db: db)
         }
     }
 
@@ -1120,6 +1132,95 @@ final class PersistenceService {
                 arguments: [streamId.uuidString]
             )
         }
+    }
+
+    private func fetchSpans(streamId: UUID, db: Database) throws -> [ProvenanceSpan] {
+        try Row.fetchAll(
+            db,
+            sql: """
+                SELECT span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at
+                FROM provenance_spans
+                WHERE stream_id = ?
+                ORDER BY start, end, span_id
+            """,
+            arguments: [streamId.uuidString]
+        ).map { row in
+            ProvenanceSpan(
+                spanId: row["span_id"],
+                streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
+                start: row["start"],
+                end: row["end"],
+                origin: row["origin"],
+                requestId: row["request_id"],
+                sourceId: row["source_id"],
+                meta: row["meta"],
+                textHash: row["text_hash"],
+                createdAt: Date(timeIntervalSince1970: row["created_at"])
+            )
+        }
+    }
+
+    private func replaceSpans(streamId: UUID, spans: [ProvenanceSpan], db: Database) throws {
+        try db.execute(
+            sql: "DELETE FROM provenance_spans WHERE stream_id = ?",
+            arguments: [streamId.uuidString]
+        )
+        try insertSpans(streamId: streamId, spans: spans, db: db)
+    }
+
+    private func insertSpans(streamId: UUID, spans: [ProvenanceSpan], db: Database) throws {
+        for span in spans {
+            try db.execute(
+                sql: """
+                    INSERT INTO provenance_spans
+                        (span_id, stream_id, start, end, origin, request_id, source_id, meta, text_hash, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [
+                    span.spanId,
+                    streamId.uuidString,
+                    span.start,
+                    span.end,
+                    span.origin,
+                    span.requestId,
+                    span.sourceId,
+                    span.meta,
+                    span.textHash,
+                    span.createdAt.timeIntervalSince1970
+                ]
+            )
+        }
+    }
+
+    private func validatedSpans(_ spans: [ProvenanceSpan], markdown: String, streamId: UUID) -> [ProvenanceSpan] {
+        spans.compactMap { span in
+            guard span.start >= 0,
+                  span.start < span.end,
+                  span.end <= UTF16Offsets.utf16Length(markdown),
+                  let coveredText = UTF16Offsets.substring(markdown, start: span.start, end: span.end),
+                  FNV1a.hash(coveredText) == span.textHash else {
+                return nil
+            }
+
+            return ProvenanceSpan(
+                spanId: span.spanId,
+                streamId: streamId,
+                start: span.start,
+                end: span.end,
+                origin: span.origin,
+                requestId: span.requestId,
+                sourceId: span.sourceId,
+                meta: span.meta,
+                textHash: span.textHash,
+                createdAt: span.createdAt
+            )
+        }
+    }
+
+    private func logDroppedSpans(total: Int, kept: Int, context: String) {
+        let dropped = total - kept
+        guard dropped > 0 else { return }
+        DebugLog.log("[Persistence] Dropped \(dropped) invalid provenance span(s) during \(context)")
     }
 
     // MARK: - Source Operations

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -592,6 +592,7 @@ final class PersistenceService {
                     embeddingStatus: embeddingStatus,
                     indexStatus: indexStatus,
                     aiExcluded: aiExcluded != 0,
+                    lastPageIndex: row["last_page_index"],
                     addedAt: Date(timeIntervalSince1970: row["added_at"])
                 )
             }
@@ -964,6 +965,7 @@ final class PersistenceService {
                 embeddingStatus: embeddingStatus,
                 indexStatus: indexStatus,
                 aiExcluded: aiExcluded != 0,
+                lastPageIndex: row["last_page_index"],
                 addedAt: Date(timeIntervalSince1970: row["added_at"])
             )
         }
@@ -1014,6 +1016,15 @@ final class PersistenceService {
             try db.execute(
                 sql: "UPDATE sources SET ai_excluded = ? WHERE id = ?",
                 arguments: [excluded ? 1 : 0, sourceId.uuidString]
+            )
+        }
+    }
+
+    func saveSourceLastPageIndex(sourceId: UUID, pageIndex: Int) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE sources SET last_page_index = ? WHERE id = ?",
+                arguments: [max(0, pageIndex), sourceId.uuidString]
             )
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -438,6 +438,11 @@ final class PersistenceService {
             """)
         }
 
+        migrator.registerMigration("v19_scroll_restore") { db in
+            try db.execute(sql: "ALTER TABLE stream_documents ADD COLUMN scroll_offset REAL NOT NULL DEFAULT 0")
+            try db.execute(sql: "ALTER TABLE sources ADD COLUMN last_page_index INTEGER")
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -737,7 +742,7 @@ final class PersistenceService {
         try dbQueue.read { db in
             guard let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) else {
                 return nil
@@ -747,6 +752,7 @@ final class PersistenceService {
                 streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                 markdown: row["markdown"],
                 revision: row["revision"],
+                scrollOffset: row["scroll_offset"],
                 createdAt: Date(timeIntervalSince1970: row["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: row["updated_at"])
             )
@@ -758,13 +764,14 @@ final class PersistenceService {
         try dbQueue.write { db in
             if let row = try Row.fetchOne(
                 db,
-                sql: "SELECT stream_id, markdown, revision, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
+                sql: "SELECT stream_id, markdown, revision, scroll_offset, created_at, updated_at FROM stream_documents WHERE stream_id = ?",
                 arguments: [streamId.uuidString]
             ) {
                 return StreamDocument(
                     streamId: UUID(uuidString: row["stream_id"]) ?? streamId,
                     markdown: row["markdown"],
                     revision: row["revision"],
+                    scrollOffset: row["scroll_offset"],
                     createdAt: Date(timeIntervalSince1970: row["created_at"]),
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"])
                 )
@@ -788,8 +795,27 @@ final class PersistenceService {
                 streamId: streamId,
                 markdown: markdown,
                 revision: 0,
+                scrollOffset: 0,
                 createdAt: now,
                 updatedAt: now
+            )
+        }
+    }
+
+    func saveScrollOffset(streamId: UUID, offset: Double) throws {
+        let clampedOffset = max(0, offset)
+        try dbQueue.write { db in
+            guard try Row.fetchOne(
+                db,
+                sql: "SELECT 1 FROM stream_documents WHERE stream_id = ?",
+                arguments: [streamId.uuidString]
+            ) != nil else {
+                return
+            }
+
+            try db.execute(
+                sql: "UPDATE stream_documents SET scroll_offset = ? WHERE stream_id = ?",
+                arguments: [clampedOffset, streamId.uuidString]
             )
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -601,6 +601,7 @@ final class PersistenceService {
                 id: UUID(uuidString: streamRow["id"])!,
                 title: streamRow["title"],
                 sources: sources,
+                sourceScope: SourceScope(rawValue: streamRow["source_scope"]) ?? .auto,
                 createdAt: Date(timeIntervalSince1970: streamRow["created_at"]),
                 updatedAt: Date(timeIntervalSince1970: streamRow["updated_at"])
             )
@@ -611,8 +612,14 @@ final class PersistenceService {
         let stream = Stream(title: title)
         try dbQueue.write { db in
             try db.execute(
-                sql: "INSERT INTO streams (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)",
-                arguments: [stream.id.uuidString, stream.title, stream.createdAt.timeIntervalSince1970, stream.updatedAt.timeIntervalSince1970]
+                sql: "INSERT INTO streams (id, title, source_scope, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                arguments: [
+                    stream.id.uuidString,
+                    stream.title,
+                    stream.sourceScope.rawValue,
+                    stream.createdAt.timeIntervalSince1970,
+                    stream.updatedAt.timeIntervalSince1970
+                ]
             )
         }
         return stream
@@ -621,9 +628,23 @@ final class PersistenceService {
     func updateStream(_ stream: Stream) throws {
         try dbQueue.write { db in
             try db.execute(
-                sql: "UPDATE streams SET title = ?, updated_at = ? WHERE id = ?",
-                arguments: [stream.title, Date().timeIntervalSince1970, stream.id.uuidString]
+                sql: "UPDATE streams SET title = ?, source_scope = ?, updated_at = ? WHERE id = ?",
+                arguments: [stream.title, stream.sourceScope.rawValue, Date().timeIntervalSince1970, stream.id.uuidString]
             )
+        }
+    }
+
+    @discardableResult
+    func setSourceScope(streamId: UUID, scope: SourceScope) throws -> Bool {
+        try dbQueue.write { db in
+            guard try Row.fetchOne(db, sql: "SELECT id FROM streams WHERE id = ?", arguments: [streamId.uuidString]) != nil else {
+                return false
+            }
+            try db.execute(
+                sql: "UPDATE streams SET source_scope = ? WHERE id = ?",
+                arguments: [scope.rawValue, streamId.uuidString]
+            )
+            return true
         }
     }
 
@@ -714,11 +735,12 @@ final class PersistenceService {
     func saveStream(_ stream: Stream) throws {
         try dbQueue.write { db in
             try db.execute(sql: """
-                INSERT INTO streams (id, title, created_at, updated_at)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO streams (id, title, source_scope, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
             """, arguments: [
                 stream.id.uuidString,
                 stream.title,
+                stream.sourceScope.rawValue,
                 stream.createdAt.timeIntervalSince1970,
                 stream.updatedAt.timeIntervalSince1970
             ])

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -7,46 +7,34 @@ enum Prompts {
     // MARK: - OpenAI (Knowledge/Thinking Partner)
 
     static let thinkingPartner = """
-    You provide content for a research document. Responses become reference notes.
+    You are contributing text to the user's research document. Your output is inserted directly
+    into their notes and must read as part of the document — never as a chat reply.
 
-    Style:
-    - Terse. No filler, no hedging, no "I think" or "It's worth noting"
-    - Use markdown: bullets, bold for emphasis, code blocks
-    - Start with a short Markdown H2 title as the first line: "## <title>"
-      - Keep under 8 words
-      - No quotes, no commentary
-      - Follow with a blank line, then the content
-    - Use additional ##/### headers only for subsections within longer responses
-    - Lead with substance—facts, data, specifics
-    - If uncertain, state it briefly and move on
-
-    Example:
-    ## Topic
-    - **Key point**: ...
+    Rules:
+    - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
+      closing summary, no offers of further help.
+    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
+      API fields). Never use lists as the default shape. Never produce lists of bolded
+      term-colon-definition pairs.
+    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - Match the surrounding document's tone and terminology when context is provided.
     """
 
     /// Thinking partner prompt WITH heading requirement (for stream cell "think" flow)
     static let thinkingPartnerWithHeading = """
-    You provide content for a research document. Responses become reference notes.
+    First line: A Markdown H2 heading (`## Heading`) in ≤8 words summarizing the response.
 
-    Format (REQUIRED):
-    - First line: A Markdown H2 heading (## Topic) in ≤8 words summarizing the response
-    - Second line: Blank
-    - Remaining: Body content
+    You are contributing text to the user's research document. Your output is inserted directly
+    into their notes and must read as part of the document — never as a chat reply.
 
-    Example structure:
-    ## Photosynthesis in Plants
-
-    **Core process**: Plants convert sunlight...
-    - Step 1: Light absorption
-    - Step 2: ...
-
-    Style:
-    - Terse. No filler, no hedging, no "I think" or "It's worth noting"
-    - Use markdown: bullets, bold for emphasis, code blocks
-    - Use ### for subsections within the body (avoid additional ## headings)
-    - Lead with substance—facts, data, specifics
-    - If uncertain, state it briefly and move on
+    Rules:
+    - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
+      closing summary, no offers of further help.
+    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
+      API fields). Never use lists as the default shape. Never produce lists of bolded
+      term-colon-definition pairs.
+    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - Match the surrounding document's tone and terminology when context is provided.
     """
 
     static let restatement = """

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -37,6 +37,22 @@ enum Prompts {
     - Match the surrounding document's tone and terminology when context is provided.
     """
 
+    static let verbDevelop = """
+    Develop the following passage into a fuller, clearer version of the same idea. Preserve the author's voice and intent; deepen, do not pad. Output only the developed passage.
+    """
+
+    static let verbAsk = """
+    Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose.
+    """
+
+    static let verbChallenge = """
+    Identify the single weakest point in this passage — a hidden assumption, an internal contradiction, or an unsupported leap. State it plainly in two to four sentences, then end with one pointed question back to the author. Do not rewrite the passage. Do not answer your own question.
+    """
+
+    static let verbDefine = """
+    Define or explain the selected term or phrase concisely, in the context of the surrounding document. Two to four sentences. Output only the explanation.
+    """
+
     static let restatement = """
     Convert input to a brief heading. Return ONLY the heading, no quotes or explanation.
 

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -227,6 +227,10 @@ final class ProxyLLMService {
             }
 
             for try await rawLine in bytes.lines {
+                if Task.isCancelled {
+                    debugLog("Proxy stream cancelled")
+                    return
+                }
                 let line = rawLine.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
                 if !didReceiveAnyEvent && !line.isEmpty {
                     // Lightweight signal that the stream is alive.
@@ -282,6 +286,10 @@ final class ProxyLLMService {
 
         } catch let urlError as URLError {
             headerWatchdog.cancel()
+            if Task.isCancelled {
+                debugLog("Proxy stream cancelled")
+                return
+            }
             if urlError.code == .timedOut {
                 let timeoutSeconds = Int(urlRequest.timeoutInterval)
                 if didReceiveHeaders {
@@ -296,6 +304,10 @@ final class ProxyLLMService {
             }
         } catch {
             headerWatchdog.cancel()
+            if Task.isCancelled {
+                debugLog("Proxy stream cancelled")
+                return
+            }
             debugLog("Proxy stream failed (\(DebugLog.errorSummary(error)))")
             await MainActor.run {
                 onError(ProxyLLMError.unreachable)

--- a/Sources/Ticker/Services/RetrievalService.swift
+++ b/Sources/Ticker/Services/RetrievalService.swift
@@ -193,7 +193,7 @@ enum SourceContextMode: Equatable {
     case retrieved
 }
 
-enum SourceScope: String {
+enum SourceScope: String, Codable {
     case auto
     case all
     case none

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -479,6 +479,51 @@ private actor AutoTitleNotificationCounter {
     }
 }
 
+private final class BridgeMessageRecorder {
+    private let lock = NSLock()
+    private var storedMessages: [BridgeMessage] = []
+
+    func send(_ message: BridgeMessage) {
+        lock.lock()
+        storedMessages.append(message)
+        lock.unlock()
+    }
+
+    func messages(ofType type: String) -> [BridgeMessage] {
+        lock.lock()
+        let messages = storedMessages.filter { $0.type == type }
+        lock.unlock()
+        return messages
+    }
+}
+
+private actor SlowDocumentAIProvider {
+    private var lastSystemPrompt: String?
+    private var didCancel = false
+
+    func stream(
+        systemPrompt: String,
+        onChunk: @escaping (String) -> Void,
+        onComplete: @escaping (SourceContext?) -> Void
+    ) async {
+        lastSystemPrompt = systemPrompt
+        onChunk("first")
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        didCancel = true
+        onComplete(nil)
+    }
+
+    func prompt() -> String? {
+        lastSystemPrompt
+    }
+
+    func cancelled() -> Bool {
+        didCancel
+    }
+}
+
 final class StreamDocumentTests: XCTestCase {
     private enum TestPDFError: Error {
         case creationFailed
@@ -863,6 +908,67 @@ final class StreamDocumentTests: XCTestCase {
 
             XCTAssertEqual(try service.loadStream(id: stream.id)?.title, "Generated Once")
         }
+    }
+
+    func test_setSourceScopePersistsAcrossReload() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scope")
+            try service.saveStream(stream)
+
+            XCTAssertTrue(try service.setSourceScope(streamId: stream.id, scope: .all))
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sourceScope, .all)
+
+            XCTAssertTrue(try service.setSourceScope(streamId: stream.id, scope: .none))
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sourceScope, SourceScope.none)
+        }
+    }
+
+    func test_documentAICancelStopsSlowStreamingProvider() async throws {
+        let recorder = BridgeMessageRecorder()
+        let provider = SlowDocumentAIProvider()
+        let handler = AIMessageHandler(
+            sendToWeb: { recorder.send($0) },
+            routeDocumentAI: { _, _, _, _, systemPrompt, onChunk, onComplete, _, _ in
+                await provider.stream(
+                    systemPrompt: systemPrompt,
+                    onChunk: onChunk,
+                    onComplete: onComplete
+                )
+            }
+        )
+        let requestId = UUID().uuidString
+
+        await handler.handle(BridgeMessage(type: "thinkDocument", payload: [
+            "requestId": AnyCodable(requestId),
+            "streamId": AnyCodable(UUID().uuidString),
+            "query": AnyCodable("What is weak here?"),
+            "imageURLs": AnyCodable([]),
+            "verb": AnyCodable("challenge")
+        ]))
+
+        try await waitUntil {
+            recorder.messages(ofType: "documentAIChunk").contains { message in
+                message.payload?["requestId"]?.value as? String == requestId
+            }
+        }
+
+        await handler.handle(BridgeMessage(type: "cancelDocumentAI", payload: [
+            "requestId": AnyCodable(requestId)
+        ]))
+
+        try await waitUntil {
+            recorder.messages(ofType: "documentAIError").contains { message in
+                message.payload?["requestId"]?.value as? String == requestId
+                    && message.payload?["errorCode"]?.value as? String == "cancelled"
+            }
+        }
+        try await waitUntil {
+            await provider.cancelled()
+        }
+
+        let prompt = await provider.prompt()
+        XCTAssertEqual(prompt, Prompts.verbChallenge)
+        XCTAssertTrue(recorder.messages(ofType: "documentAIComplete").isEmpty)
     }
 
     func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
@@ -2683,6 +2789,20 @@ final class StreamDocumentTests: XCTestCase {
                 "Existing document\n\n## Recovered captures\n\nRecovered once"
             )
         }
+    }
+
+    private func waitUntil(
+        _ condition: @escaping () async -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<100 {
+            if await condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
     }
 
     private func withTempPersistenceService(_ body: (PersistenceService) throws -> Void) throws {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -64,6 +64,41 @@ final class QuickPanelMarkdownFormatterTests: XCTestCase {
         """)
     }
 
+    func test_captureSpansCoverCapturedTextAndAttributionOnly() throws {
+        let streamId = UUID()
+        let context = QuickPanelContext(
+            selectedText: " First line\nSecond line ",
+            activeApp: "Safari",
+            windowTitle: "Article *Title*",
+            panelPosition: CGPoint(x: 0, y: 0),
+            clipboardImage: nil,
+            isScreenshot: false
+        )
+        let fragment = try QuickPanelMarkdownFormatter.buildFragment(
+            context: context,
+            inputText: "Saved note"
+        ) { _ in
+            XCTFail("Image formatter should not run for text-only context")
+            return ""
+        }
+
+        let spans = QuickPanelMarkdownFormatter.captureSpans(context: context, fragment: fragment, streamId: streamId)
+
+        let captured = """
+        > First line
+        > Second line
+
+        *— Safari — Article \\*Title\\**
+        """
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].streamId, streamId)
+        XCTAssertEqual(spans[0].start, 0)
+        XCTAssertEqual(spans[0].end, UTF16Offsets.utf16Length(captured))
+        XCTAssertEqual(spans[0].origin, "capture")
+        XCTAssertEqual(spans[0].meta, #"{"sourceApp":"Safari"}"#)
+        XCTAssertEqual(spans[0].textHash, FNV1a.hash(captured))
+    }
+
     func test_recentClipboardTextCandidateReturnsRecentPlainText() throws {
         let pasteboard = makeTrackedPasteboard()
         defer { pasteboard.clearContents() }
@@ -969,6 +1004,70 @@ final class StreamDocumentTests: XCTestCase {
         let prompt = await provider.prompt()
         XCTAssertEqual(prompt, Prompts.verbChallenge)
         XCTAssertTrue(recorder.messages(ofType: "documentAIComplete").isEmpty)
+    }
+
+    func test_documentAICompletionSavesExchangeReceipt() async throws {
+        try await withTempPersistenceService { service in
+            let stream = Stream(title: "Exchange Receipt")
+            try service.saveStream(stream)
+            let recorder = BridgeMessageRecorder()
+            let requestId = "request-doc-ai"
+            let chunkId = UUID()
+            let sourceId = UUID()
+            let handler = AIMessageHandler(
+                persistence: service,
+                sendToWeb: { recorder.send($0) },
+                routeDocumentAI: { _, _, _, _, _, onChunk, onComplete, _, onModelSelected in
+                    onModelSelected?("provider/model")
+                    onChunk("Raw [1]")
+                    onComplete(SourceContext(
+                        text: "Source context",
+                        chunks: [
+                            RetrievedChunk(
+                                id: chunkId,
+                                sourceId: sourceId,
+                                sourceName: "Source PDF",
+                                seq: 0,
+                                text: "quoted source",
+                                pageStart: 4,
+                                pageEnd: 4,
+                                sectionPath: nil,
+                                score: -10
+                            )
+                        ],
+                        mode: .retrieved
+                    ))
+                }
+            )
+
+            await handler.handle(BridgeMessage(type: "thinkDocument", payload: [
+                "requestId": AnyCodable(requestId),
+                "streamId": AnyCodable(stream.id.uuidString),
+                "query": AnyCodable("Explain this"),
+                "context": AnyCodable(" Selected text "),
+                "imageURLs": AnyCodable([]),
+                "verb": AnyCodable("ask")
+            ]))
+
+            try await waitUntil {
+                (try? service.loadExchange(requestId: requestId)) != nil
+            }
+
+            let exchange = try XCTUnwrap(try service.loadExchange(requestId: requestId))
+            XCTAssertEqual(exchange.streamId, stream.id)
+            XCTAssertEqual(exchange.verb, "ask")
+            XCTAssertEqual(exchange.userInput, "Selection:\nSelected text\n\nPrompt:\nExplain this")
+            XCTAssertEqual(exchange.responseRaw, "Raw [1]")
+            XCTAssertEqual(exchange.model, "provider/model")
+
+            let manifestData = try XCTUnwrap(exchange.sourceManifest.data(using: .utf8))
+            let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [[String: Any]])
+            XCTAssertEqual(manifest.count, 1)
+            XCTAssertEqual(manifest[0]["chunkId"] as? String, chunkId.uuidString)
+            XCTAssertEqual(manifest[0]["sourceId"] as? String, sourceId.uuidString)
+            XCTAssertEqual(manifest[0]["shortTitle"] as? String, "Source PDF")
+            XCTAssertFalse(recorder.messages(ofType: "documentAIComplete").isEmpty)
+        }
     }
 
     func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
@@ -2570,6 +2669,71 @@ final class StreamDocumentTests: XCTestCase {
             let document = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
             XCTAssertEqual(document.markdown, "First append\n\nSecond append")
             XCTAssertEqual(document.revision, 2)
+        }
+    }
+
+    func test_appendToStreamDocumentOffsetsFragmentSpansAfterEmojiTail() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Append Span Offset")
+            try service.saveStream(stream)
+            try service.saveStreamDocument(streamId: stream.id, markdown: "a🙂")
+            let span = ProvenanceSpan(
+                spanId: "span-ai",
+                streamId: stream.id,
+                start: 0,
+                end: UTF16Offsets.utf16Length("Hello"),
+                origin: "ai",
+                requestId: "request-1",
+                textHash: FNV1a.hash("Hello"),
+                createdAt: Date(timeIntervalSince1970: 2_020)
+            )
+
+            let result = try service.appendToStreamDocument(streamId: stream.id, fragment: "Hello", spans: [span])
+
+            XCTAssertEqual(try service.loadStreamDocument(streamId: stream.id)?.markdown, "a🙂\n\nHello")
+            XCTAssertEqual(result.spans.count, 1)
+            XCTAssertEqual(result.spans[0].start, 5)
+            XCTAssertEqual(result.spans[0].end, 10)
+            XCTAssertEqual(result.spans[0].textHash, FNV1a.hash("Hello"))
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), result.spans)
+        }
+    }
+
+    @MainActor
+    func test_quickPanelAIFragmentAppendSavesExchangeAndSpan() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Quick Panel AI")
+            try service.saveStream(stream)
+            let manager = QuickPanelManager()
+
+            manager.appendQuickPanelAIFragment(
+                streamId: stream.id,
+                fragment: "AI answer",
+                persistence: service,
+                requestId: "quick-ai-request",
+                model: "provider/model",
+                prompt: "Summarize",
+                documentMarkdown: "Captured context"
+            )
+
+            let spans = try service.loadSpans(streamId: stream.id)
+            XCTAssertEqual(spans.count, 1)
+            XCTAssertEqual(spans[0].origin, "ai")
+            XCTAssertEqual(spans[0].requestId, "quick-ai-request")
+            XCTAssertEqual(spans[0].start, 0)
+            XCTAssertEqual(spans[0].end, UTF16Offsets.utf16Length("AI answer"))
+            XCTAssertEqual(spans[0].textHash, FNV1a.hash("AI answer"))
+            let spanMetaData = try XCTUnwrap(spans[0].meta.data(using: .utf8))
+            let spanMeta = try XCTUnwrap(JSONSerialization.jsonObject(with: spanMetaData) as? [String: String])
+            XCTAssertEqual(spanMeta["model"], "provider/model")
+            XCTAssertEqual(spanMeta["verb"], "develop")
+
+            let exchange = try XCTUnwrap(service.loadExchange(requestId: "quick-ai-request"))
+            XCTAssertEqual(exchange.streamId, stream.id)
+            XCTAssertEqual(exchange.verb, "develop")
+            XCTAssertEqual(exchange.userInput, "Selection:\nCaptured context\n\nPrompt:\nSummarize")
+            XCTAssertEqual(exchange.responseRaw, "AI answer")
+            XCTAssertEqual(exchange.model, "provider/model")
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -906,6 +906,30 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_saveSourceLastPageIndexRoundTripsThroughPersistence() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "PDF Resume")
+            try service.saveStream(stream)
+            let source = SourceReference(
+                streamId: stream.id,
+                displayName: "Manual.pdf",
+                fileType: .pdf,
+                bookmarkData: Data(),
+                status: .ready
+            )
+            try service.saveSource(source)
+
+            XCTAssertNil(try service.loadSource(id: source.id)?.lastPageIndex)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: 117)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 117)
+            XCTAssertEqual(try service.loadStream(id: stream.id)?.sources.first?.lastPageIndex, 117)
+
+            try service.saveSourceLastPageIndex(sourceId: source.id, pageIndex: -4)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.lastPageIndex, 0)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -865,6 +865,47 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_v19MigrationAddsScrollRestoreColumnsToFreshDatabase() throws {
+        try withTempPersistenceServiceAndURL { _, dbURL, _ in
+            let dbQueue = try DatabaseQueue(path: dbURL.path)
+            let documentColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(stream_documents)").map { row -> String in
+                    row["name"]
+                }
+            }
+            let sourceColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(sources)").map { row -> String in
+                    row["name"]
+                }
+            }
+
+            XCTAssertTrue(documentColumns.contains("scroll_offset"))
+            XCTAssertTrue(sourceColumns.contains("last_page_index"))
+        }
+    }
+
+    func test_saveScrollOffsetRoundTripsWithoutBumpingRevision() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scroll Restore")
+            try service.saveStream(stream)
+            let revision = try service.saveStreamDocument(streamId: stream.id, markdown: "Line one\n\nLine two")
+            let before = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+
+            try service.saveScrollOffset(streamId: stream.id, offset: 512.5)
+
+            let after = try XCTUnwrap(service.loadStreamDocument(streamId: stream.id))
+            XCTAssertEqual(revision, 1)
+            XCTAssertEqual(after.markdown, before.markdown)
+            XCTAssertEqual(after.revision, before.revision)
+            XCTAssertEqual(after.updatedAt, before.updatedAt)
+            XCTAssertEqual(after.scrollOffset, 512.5)
+
+            let payload = StreamCodec.encodeStream(stream, document: after)
+            let documentPayload = try XCTUnwrap(payload["document"] as? [String: Any])
+            XCTAssertEqual(documentPayload["scrollOffset"] as? Double, 512.5)
+        }
+    }
+
     func test_chunkerUsesOutlineSectionPathsAndPageRanges() throws {
         let document = try makePDFDocument(pages: [
             "Opening receipts establish the first page.",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -990,6 +990,168 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_v20MigrationAddsProvenanceTablesToFreshDatabase() throws {
+        try withTempPersistenceServiceAndURL { _, dbURL, _ in
+            let dbQueue = try DatabaseQueue(path: dbURL.path)
+            let tables = try dbQueue.read { db in
+                try Row.fetchAll(
+                    db,
+                    sql: "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).map { row -> String in row["name"] }
+            }
+            let indexes = try dbQueue.read { db in
+                try Row.fetchAll(
+                    db,
+                    sql: "SELECT name FROM sqlite_master WHERE type = 'index'"
+                ).map { row -> String in row["name"] }
+            }
+            let spanColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(provenance_spans)").map { row -> String in
+                    row["name"]
+                }
+            }
+            let exchangeColumns = try dbQueue.read { db in
+                try Row.fetchAll(db, sql: "PRAGMA table_info(ai_exchanges)").map { row -> String in
+                    row["name"]
+                }
+            }
+
+            XCTAssertTrue(tables.contains("provenance_spans"))
+            XCTAssertTrue(tables.contains("ai_exchanges"))
+            XCTAssertTrue(indexes.contains("idx_prov_stream"))
+            XCTAssertEqual(
+                spanColumns,
+                ["span_id", "stream_id", "start", "end", "origin", "request_id", "source_id", "meta", "text_hash", "created_at"]
+            )
+            XCTAssertEqual(
+                exchangeColumns,
+                ["request_id", "stream_id", "verb", "user_input", "source_manifest", "response_raw", "model", "created_at"]
+            )
+        }
+    }
+
+    func test_fnv1aMatchesSharedVector() {
+        XCTAssertEqual(FNV1a.hash("The quick brown fox"), "048fff90")
+    }
+
+    func test_utf16OffsetsHandleEmojiRegression() {
+        let text = "a🙂b"
+
+        XCTAssertEqual(UTF16Offsets.utf16Length(text), 4)
+        XCTAssertEqual(UTF16Offsets.substring(text, start: 3, end: 4), "b")
+    }
+
+    func test_provenanceSpansRoundTrip() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Provenance")
+            try service.saveStream(stream)
+            let spans = [
+                ProvenanceSpan(
+                    spanId: "span-1",
+                    streamId: stream.id,
+                    start: 0,
+                    end: 5,
+                    origin: "ai",
+                    requestId: "request-1",
+                    sourceId: nil,
+                    meta: #"{"model":"test"}"#,
+                    textHash: FNV1a.hash("hello"),
+                    createdAt: Date(timeIntervalSince1970: 1_234)
+                ),
+                ProvenanceSpan(
+                    spanId: "span-2",
+                    streamId: stream.id,
+                    start: 8,
+                    end: 12,
+                    origin: "source",
+                    requestId: nil,
+                    sourceId: "source-1",
+                    meta: #"{"page":2}"#,
+                    textHash: FNV1a.hash("note"),
+                    createdAt: Date(timeIntervalSince1970: 1_235)
+                )
+            ]
+
+            try service.replaceSpans(streamId: stream.id, spans: spans)
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), spans)
+
+            try service.replaceSpans(streamId: stream.id, spans: [spans[1]])
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), [spans[1]])
+        }
+    }
+
+    func test_aiExchangesRoundTripAndDeleteOrphans() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Exchange")
+            try service.saveStream(stream)
+            let exchange = AIExchange(
+                requestId: "request-1",
+                streamId: stream.id,
+                verb: "develop",
+                userInput: "Selection: hello",
+                sourceManifest: #"[{"title":"Source"}]"#,
+                responseRaw: "Developed response",
+                model: "test-model",
+                createdAt: Date(timeIntervalSince1970: 1_236)
+            )
+
+            try service.saveExchange(exchange)
+            XCTAssertEqual(try service.loadExchange(requestId: exchange.requestId), exchange)
+
+            try service.replaceSpans(streamId: stream.id, spans: [
+                ProvenanceSpan(
+                    spanId: "span-1",
+                    streamId: stream.id,
+                    start: 0,
+                    end: 5,
+                    origin: "ai",
+                    requestId: exchange.requestId,
+                    textHash: FNV1a.hash("hello"),
+                    createdAt: Date(timeIntervalSince1970: 1_237)
+                )
+            ])
+            try service.deleteOrphanExchanges(streamId: stream.id)
+            XCTAssertEqual(try service.loadExchange(requestId: exchange.requestId), exchange)
+
+            try service.replaceSpans(streamId: stream.id, spans: [])
+            try service.deleteOrphanExchanges(streamId: stream.id)
+            XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
+    func test_provenanceRowsCascadeWhenStreamIsDeleted() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Cascade")
+            try service.saveStream(stream)
+            let exchange = AIExchange(
+                requestId: "request-1",
+                streamId: stream.id,
+                verb: "ask",
+                userInput: "Question",
+                responseRaw: "Answer",
+                createdAt: Date(timeIntervalSince1970: 1_238)
+            )
+            try service.saveExchange(exchange)
+            try service.replaceSpans(streamId: stream.id, spans: [
+                ProvenanceSpan(
+                    spanId: "span-1",
+                    streamId: stream.id,
+                    start: 0,
+                    end: 6,
+                    origin: "ai",
+                    requestId: exchange.requestId,
+                    textHash: FNV1a.hash("Answer"),
+                    createdAt: Date(timeIntervalSince1970: 1_239)
+                )
+            ])
+
+            try service.deleteStream(id: stream.id)
+
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), [])
+            XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
     func test_saveScrollOffsetRoundTripsWithoutBumpingRevision() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "Scroll Restore")

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1031,7 +1031,7 @@ final class StreamDocumentTests: XCTestCase {
     }
 
     func test_fnv1aMatchesSharedVector() {
-        XCTAssertEqual(FNV1a.hash("The quick brown fox"), "048fff90")
+        XCTAssertEqual(FNV1a.hash("The quick brown fox"), "ae4d67e2")
     }
 
     func test_utf16OffsetsHandleEmojiRegression() {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2608,6 +2608,103 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_saveStreamDocumentWithSpansRejectsStaleRevisionAndLeavesSpansUnchanged() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Span Conflict Guard")
+            try service.saveStream(stream)
+            let initialDocument = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            let originalSpan = ProvenanceSpan(
+                spanId: "span-original",
+                streamId: stream.id,
+                start: 0,
+                end: 5,
+                origin: "ai",
+                requestId: "request-1",
+                textHash: FNV1a.hash("Hello"),
+                createdAt: Date(timeIntervalSince1970: 2_000)
+            )
+            let savedRevision = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Hello world",
+                baseRevision: initialDocument.revision,
+                spans: [originalSpan]
+            )
+
+            let append = try service.appendToStreamDocument(streamId: stream.id, fragment: "External append")
+            let staleSpan = ProvenanceSpan(
+                spanId: "span-stale",
+                streamId: stream.id,
+                start: 0,
+                end: 5,
+                origin: "ai",
+                requestId: "request-2",
+                textHash: FNV1a.hash("Stale"),
+                createdAt: Date(timeIntervalSince1970: 2_001)
+            )
+
+            do {
+                _ = try service.saveStreamDocument(
+                    streamId: stream.id,
+                    markdown: "Stale overwrite",
+                    baseRevision: savedRevision,
+                    spans: [staleSpan]
+                )
+                XCTFail("Expected stale revision save to throw")
+            } catch let conflict as StreamDocumentRevisionConflict {
+                XCTAssertEqual(conflict.streamId, stream.id)
+                XCTAssertEqual(conflict.revision, append.revision)
+                XCTAssertEqual(conflict.markdown, "Hello world\n\nExternal append")
+                XCTAssertEqual(conflict.spans, [originalSpan])
+            }
+
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), [originalSpan])
+        }
+    }
+
+    func test_saveStreamDocumentWithSpansDropsInvalidRows() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Span Validation")
+            try service.saveStream(stream)
+            let initialDocument = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            let validSpan = ProvenanceSpan(
+                spanId: "span-valid",
+                streamId: stream.id,
+                start: 0,
+                end: 5,
+                origin: "ai",
+                textHash: FNV1a.hash("Hello"),
+                createdAt: Date(timeIntervalSince1970: 2_010)
+            )
+            let badHash = ProvenanceSpan(
+                spanId: "span-bad-hash",
+                streamId: stream.id,
+                start: 6,
+                end: 11,
+                origin: "ai",
+                textHash: FNV1a.hash("wrong"),
+                createdAt: Date(timeIntervalSince1970: 2_011)
+            )
+            let outOfBounds = ProvenanceSpan(
+                spanId: "span-bounds",
+                streamId: stream.id,
+                start: 12,
+                end: 20,
+                origin: "ai",
+                textHash: FNV1a.hash("missing"),
+                createdAt: Date(timeIntervalSince1970: 2_012)
+            )
+
+            _ = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Hello world",
+                baseRevision: initialDocument.revision,
+                spans: [validSpan, badHash, outOfBounds]
+            )
+
+            XCTAssertEqual(try service.loadSpans(streamId: stream.id), [validSpan])
+        }
+    }
+
     func test_streamCodecPreviewLineSkipsHeadingsAndImages() throws {
         let markdown = """
         # Heading to skip

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1218,6 +1218,58 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_getExchangePayloadRoundTripAndSavePrunesOrphans() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Exchange Save")
+            try service.saveStream(stream)
+            let exchange = AIExchange(
+                requestId: "request-save-gc",
+                streamId: stream.id,
+                verb: "ask",
+                userInput: "Selection:\nText\n\nPrompt:\nWhy?",
+                sourceManifest: #"[{"chunkId":"chunk-1","sourceId":"source-1","page":2,"shortTitle":"Manual"}]"#,
+                responseRaw: "Raw answer",
+                model: "provider/model",
+                createdAt: Date(timeIntervalSince1970: 1_240)
+            )
+            try service.saveExchange(exchange)
+
+            let loaded = try XCTUnwrap(try service.loadExchange(requestId: exchange.requestId))
+            let encoded = StreamCodec.encodeExchange(loaded)
+            XCTAssertEqual(encoded["requestId"] as? String, exchange.requestId)
+            XCTAssertEqual(encoded["userInput"] as? String, exchange.userInput)
+            XCTAssertEqual(encoded["sourceManifest"] as? String, exchange.sourceManifest)
+            XCTAssertEqual(encoded["responseRaw"] as? String, exchange.responseRaw)
+
+            let revision = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Text",
+                baseRevision: 0,
+                spans: [
+                    ProvenanceSpan(
+                        spanId: "span-1",
+                        streamId: stream.id,
+                        start: 0,
+                        end: 4,
+                        origin: "ai",
+                        requestId: exchange.requestId,
+                        textHash: FNV1a.hash("Text"),
+                        createdAt: Date(timeIntervalSince1970: 1_241)
+                    )
+                ]
+            )
+            XCTAssertNotNil(try service.loadExchange(requestId: exchange.requestId))
+
+            _ = try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "Text",
+                baseRevision: revision,
+                spans: []
+            )
+            XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
     func test_provenanceRowsCascadeWhenStreamIsDeleted() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "Cascade")

--- a/Ticker.xcodeproj/project.pbxproj
+++ b/Ticker.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A1000001000000000011 /* SourceReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000011 /* SourceReference.swift */; };
 		A1000001000000000012 /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000012 /* Stream.swift */; };
 		A100000100000000003B /* PDFHighlightRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000003B /* PDFHighlightRecord.swift */; };
+		A100000100000000003F /* ProvenanceSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000100000000003F /* ProvenanceSpan.swift */; };
 		A1000001000000000013 /* AIOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000013 /* AIOrchestrator.swift */; };
 		A1000001000000000016 /* AssetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000016 /* AssetService.swift */; };
 		A1000001000000000017 /* ChunkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1000001000000000017 /* ChunkingService.swift */; };
@@ -109,6 +110,7 @@
 		B1000001000000000011 /* SourceReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceReference.swift; sourceTree = "<group>"; };
 		B1000001000000000012 /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
 		B100000100000000003B /* PDFHighlightRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightRecord.swift; sourceTree = "<group>"; };
+		B100000100000000003F /* ProvenanceSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvenanceSpan.swift; sourceTree = "<group>"; };
 		B1000001000000000013 /* AIOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIOrchestrator.swift; sourceTree = "<group>"; };
 		B100000100000000003E /* AutoTitleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTitleService.swift; sourceTree = "<group>"; };
 		B1000001000000000016 /* AssetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetService.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				B1000001000000000011 /* SourceReference.swift */,
 				B1000001000000000012 /* Stream.swift */,
 				B100000100000000003B /* PDFHighlightRecord.swift */,
+				B100000100000000003F /* ProvenanceSpan.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -497,6 +500,7 @@
 				A1000001000000000011 /* SourceReference.swift in Sources */,
 				A1000001000000000012 /* Stream.swift in Sources */,
 				A100000100000000003B /* PDFHighlightRecord.swift in Sources */,
+				A100000100000000003F /* ProvenanceSpan.swift in Sources */,
 				A1000001000000000013 /* AIOrchestrator.swift in Sources */,
 				A100000100000000003E /* AutoTitleService.swift in Sources */,
 				A1000001000000000016 /* AssetService.swift in Sources */,

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -6,6 +6,7 @@ import { Settings } from './components/Settings';
 import { ToastStack } from './components/ToastStack';
 import { useToastStore } from './store/toastStore';
 import { debugError, debugLog } from './utils/debug';
+import { deserializeProvenanceSpans } from './utils/provenanceSpans';
 
 type View = 'list' | 'stream' | 'settings';
 
@@ -176,6 +177,7 @@ export function App() {
           const loadedStream = {
             ...payloadStream,
             sourceScope,
+            spans: deserializeProvenanceSpans(message.payload?.spans),
             document: {
               ...payloadStream.document,
               scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -167,8 +167,15 @@ export function App() {
           const payloadStream = message.payload?.stream as Stream | undefined;
           if (!payloadStream) break;
           const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
+          const payloadSourceScope = message.payload?.sourceScope;
+          const sourceScope: Stream['sourceScope'] = payloadSourceScope === 'auto'
+            || payloadSourceScope === 'all'
+            || payloadSourceScope === 'none'
+            ? payloadSourceScope
+            : payloadStream.sourceScope ?? 'auto';
           const loadedStream = {
             ...payloadStream,
+            sourceScope,
             document: {
               ...payloadStream.document,
               scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -164,7 +164,16 @@ export function App() {
           setIsLoading(false);
           break;
         case 'streamLoaded': {
-          const loadedStream = message.payload?.stream as Stream;
+          const payloadStream = message.payload?.stream as Stream | undefined;
+          if (!payloadStream) break;
+          const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
+          const loadedStream = {
+            ...payloadStream,
+            document: {
+              ...payloadStream.document,
+              scrollOffset: Number.isFinite(scrollOffset) ? scrollOffset : 0,
+            },
+          };
           currentStreamIdRef.current = loadedStream?.id ?? null;
           viewRef.current = 'stream';
           setCurrentStream(loadedStream);

--- a/Web/src/components/ExchangeOverlay.tsx
+++ b/Web/src/components/ExchangeOverlay.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import type { AIExchangeJSON } from '../types';
+
+export interface ExchangeManifestEntry {
+  sourceId: string;
+  chunkId: string;
+  page: number;
+  shortTitle: string;
+}
+
+interface ExchangeOverlayProps {
+  exchange: AIExchangeJSON;
+  onClose: () => void;
+  onRedevelop: () => void;
+  onOpenManifestEntry: (entry: ExchangeManifestEntry) => void;
+}
+
+function manifestEntries(sourceManifest: string): ExchangeManifestEntry[] {
+  try {
+    const parsed = JSON.parse(sourceManifest) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((item): ExchangeManifestEntry[] => {
+      if (!item || typeof item !== 'object') return [];
+      const candidate = item as Record<string, unknown>;
+      const sourceId = typeof candidate.sourceId === 'string' ? candidate.sourceId : '';
+      const chunkId = typeof candidate.chunkId === 'string' ? candidate.chunkId : '';
+      const shortTitle = typeof candidate.shortTitle === 'string' ? candidate.shortTitle : '';
+      const page = Number(candidate.page);
+      if (!sourceId || !chunkId || !shortTitle || !Number.isFinite(page)) return [];
+      return [{ sourceId, chunkId, shortTitle, page: Math.max(1, Math.round(page)) }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function ExchangeOverlay({
+  exchange,
+  onClose,
+  onRedevelop,
+  onOpenManifestEntry,
+}: ExchangeOverlayProps) {
+  const entries = manifestEntries(exchange.sourceManifest);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const copyRaw = () => {
+    void navigator.clipboard?.writeText(exchange.responseRaw);
+  };
+
+  return (
+    <div className="exchange-overlay" onClick={onClose}>
+      <div className="exchange-modal" onClick={(event) => event.stopPropagation()}>
+        <div className="exchange-block">
+          <h2>You</h2>
+          <pre>{exchange.userInput}</pre>
+        </div>
+
+        <div className="exchange-block">
+          <h2>Consulted</h2>
+          {entries.length > 0 ? (
+            <div className="exchange-manifest-links">
+              {entries.map((entry) => (
+                <button
+                  key={`${entry.sourceId}:${entry.chunkId}:${entry.page}`}
+                  type="button"
+                  className="exchange-link"
+                  onClick={() => onOpenManifestEntry(entry)}
+                >
+                  {entry.shortTitle} p.{entry.page}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p>No sources recorded.</p>
+          )}
+        </div>
+
+        <div className="exchange-block">
+          <h2>Model returned</h2>
+          <pre>{exchange.responseRaw}</pre>
+        </div>
+
+        <div className="exchange-footer">
+          <button type="button" onClick={onRedevelop}>re-develop</button>
+          <button type="button" onClick={copyRaw}>copy raw</button>
+          <button type="button" onClick={onClose}>Esc</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Web/src/components/StreamEditor.test.ts
+++ b/Web/src/components/StreamEditor.test.ts
@@ -1,5 +1,9 @@
+import { EditorState, Transaction } from '@codemirror/state';
+import { history, undo } from '@codemirror/commands';
 import { describe, expect, it } from 'vitest';
-import { documentAIErrorRecovery, nextSourceScope, wrapChallengeOutput } from './StreamEditor';
+import { addSpans, currentSpans, provenanceField } from '../extensions/ProvenanceField';
+import { fnv1a } from '../utils/fnv1a';
+import { buildDocumentAIProvenanceSpan, documentAIErrorRecovery, nextSourceScope, wrapChallengeOutput } from './StreamEditor';
 
 describe('nextSourceScope', () => {
   it('cycles auto to all to none to auto', () => {
@@ -36,5 +40,64 @@ describe('documentAIErrorRecovery', () => {
       restoreText: 'original text',
       silent: false,
     });
+  });
+});
+
+describe('buildDocumentAIProvenanceSpan', () => {
+  it('covers exactly the inserted text with post-swap metadata', () => {
+    const inserted = 'Developed [source](ticker-pdf://source)';
+    const span = buildDocumentAIProvenanceSpan({
+      requestId: 'request-1',
+      start: 7,
+      text: inserted,
+      verb: 'develop',
+      model: 'provider/model',
+      parentRequestId: 'parent-1',
+      spanId: 'span-1',
+      createdAt: 123,
+    });
+
+    expect(span).toEqual({
+      spanId: 'span-1',
+      start: 7,
+      end: 7 + inserted.length,
+      origin: 'ai',
+      requestId: 'request-1',
+      meta: { model: 'provider/model', verb: 'develop', parentRequestId: 'parent-1' },
+      textHash: fnv1a(inserted),
+      createdAt: 123,
+    });
+  });
+
+  it('rides the same undo entry as inserted AI text', () => {
+    let state = EditorState.create({
+      doc: 'Original',
+      extensions: [provenanceField, history()],
+    });
+    const dispatch = (transaction: Transaction) => {
+      state = transaction.state;
+    };
+    const inserted = '> Better answer\n\n*— Challenge*';
+    const span = buildDocumentAIProvenanceSpan({
+      requestId: 'request-2',
+      start: 0,
+      text: inserted,
+      verb: 'challenge',
+      model: 'provider/model',
+      spanId: 'span-2',
+      createdAt: 456,
+    });
+
+    state = state.update({
+      changes: { from: 0, to: state.doc.length, insert: inserted },
+      effects: addSpans.of([span]),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(state.doc.toString()).toBe(inserted);
+    expect(currentSpans(state)).toEqual([span]);
+
+    expect(undo({ state, dispatch })).toBe(true);
+    expect(state.doc.toString()).toBe('Original');
+    expect(currentSpans(state)).toEqual([]);
   });
 });

--- a/Web/src/components/StreamEditor.test.ts
+++ b/Web/src/components/StreamEditor.test.ts
@@ -1,10 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { nextSourceScope } from './StreamEditor';
+import { documentAIErrorRecovery, nextSourceScope, wrapChallengeOutput } from './StreamEditor';
 
 describe('nextSourceScope', () => {
   it('cycles auto to all to none to auto', () => {
     expect(nextSourceScope('auto')).toBe('all');
     expect(nextSourceScope('all')).toBe('none');
     expect(nextSourceScope('none')).toBe('auto');
+  });
+});
+
+describe('wrapChallengeOutput', () => {
+  it('quotes a single paragraph and tags the register', () => {
+    expect(wrapChallengeOutput('Weak premise. What follows?')).toBe(
+      '> Weak premise. What follows?\n\n*— Challenge*'
+    );
+  });
+
+  it('quotes multi-paragraph output line by line', () => {
+    expect(wrapChallengeOutput('First paragraph.\n\nSecond paragraph?')).toBe(
+      '> First paragraph.\n> \n> Second paragraph?\n\n*— Challenge*'
+    );
+  });
+});
+
+describe('documentAIErrorRecovery', () => {
+  it('restores cancelled output silently', () => {
+    expect(documentAIErrorRecovery('original text', 'cancelled')).toEqual({
+      restoreText: 'original text',
+      silent: true,
+    });
+  });
+
+  it('restores other errors with visible feedback', () => {
+    expect(documentAIErrorRecovery('original text', 'rate_limited')).toEqual({
+      restoreText: 'original text',
+      silent: false,
+    });
   });
 });

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -17,9 +17,11 @@ import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
 import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
+import { addSpans, currentSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
+import { fnv1a } from '../utils/fnv1a';
 import { deserializeProvenanceSpans, serializeProvenanceSpans } from '../utils/provenanceSpans';
 import {
   beginPDFAnchorPick,
@@ -201,6 +203,67 @@ function dispatchAiRangeClear(view: EditorView) {
   });
 }
 
+function parseSpanMeta(meta: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(meta);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function payloadSpanToFieldSpan(span: ProvenanceSpanJSON, doc: string): Span | null {
+  if (span.start < 0 || span.end <= span.start || span.end > doc.length) return null;
+  const coveredText = doc.slice(span.start, span.end);
+  if (fnv1a(coveredText) !== span.textHash) return null;
+  const createdAt = Date.parse(span.createdAt);
+  if (!Number.isFinite(createdAt)) return null;
+  const origin = span.origin === 'ai' || span.origin === 'source' || span.origin === 'capture'
+    ? span.origin
+    : null;
+  if (!origin) return null;
+
+  return {
+    spanId: span.spanId,
+    start: span.start,
+    end: span.end,
+    origin,
+    requestId: span.requestId,
+    sourceId: span.sourceId,
+    meta: parseSpanMeta(span.meta),
+    textHash: span.textHash,
+    createdAt,
+  };
+}
+
+function payloadSpansForDoc(value: unknown, doc: string): Span[] {
+  return deserializeProvenanceSpans(value).flatMap((span) => {
+    const fieldSpan = payloadSpanToFieldSpan(span, doc);
+    return fieldSpan ? [fieldSpan] : [];
+  });
+}
+
+function fieldSpanToPayload(span: Span): ProvenanceSpanJSON {
+  const createdAtSeconds = Math.floor(span.createdAt / 1000) * 1000;
+  return {
+    spanId: span.spanId,
+    start: span.start,
+    end: span.end,
+    origin: span.origin,
+    requestId: span.requestId,
+    sourceId: span.sourceId,
+    meta: JSON.stringify(span.meta),
+    textHash: span.textHash,
+    createdAt: new Date(createdAtSeconds).toISOString().replace('.000Z', 'Z'),
+  };
+}
+
+function serializeFieldSpans(spans: Span[], doc: string): ProvenanceSpanJSON[] {
+  return serializeProvenanceSpans(normalizeSpans(spans, doc).map(fieldSpanToPayload));
+}
+
 const markdownHighlightStyle = HighlightStyle.define([
   {
     tag: t.heading,
@@ -315,7 +378,6 @@ export function StreamEditor({
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
-  const provenanceSpansRef = useRef<ProvenanceSpanJSON[]>(stream.spans ?? []);
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
@@ -557,7 +619,6 @@ export function StreamEditor({
     lastSavedContentRef.current = stream.document?.markdown ?? '';
     markdownContentRef.current = stream.document?.markdown ?? '';
     revisionRef.current = stream.document?.revision ?? 0;
-    provenanceSpansRef.current = stream.spans ?? [];
     sourcesRef.current = stream.sources;
     sourceIndexStatusesRef.current = new Map(
       stream.sources.map((source) => [source.id, source.indexStatus])
@@ -585,6 +646,10 @@ export function StreamEditor({
     aiRequestRef.current = null;
     const view = editorViewRef.current;
     if (view) {
+      view.dispatch({
+        effects: setSpans.of(payloadSpansForDoc(stream.spans, stream.document?.markdown ?? '')),
+        annotations: Transaction.addToHistory.of(false),
+      });
       dispatchAiRangeClear(view);
     }
   }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.spans, stream.title]);
@@ -621,12 +686,13 @@ export function StreamEditor({
     const timer = window.setTimeout(() => {
       const contentToSave = markdownContent;
       const baseRevision = revisionRef.current;
+      const view = editorViewRef.current;
 
       void bridge.sendAsync<{ revision: number }>('saveStreamDocument', {
         streamId: stream.id,
         markdown: contentToSave,
         baseRevision,
-        spans: serializeProvenanceSpans(provenanceSpansRef.current),
+        spans: view ? serializeFieldSpans(currentSpans(view.state), contentToSave) : [],
       }).then((response) => {
         if (Number.isFinite(response.revision)) {
           revisionRef.current = response.revision;
@@ -653,21 +719,21 @@ export function StreamEditor({
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const markdown = message.payload?.markdown as string | undefined;
         const revision = Number(message.payload?.revision);
-        const spans = deserializeProvenanceSpans(message.payload?.spans);
 
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof markdown !== 'string' || !Number.isFinite(revision)) {
           return;
         }
 
         const view = editorViewRef.current;
+        const spans = payloadSpansForDoc(message.payload?.spans, markdown);
         if (view) {
           view.dispatch({
             changes: { from: 0, to: view.state.doc.length, insert: markdown },
+            effects: setSpans.of(spans),
           });
         }
 
         revisionRef.current = revision;
-        provenanceSpansRef.current = spans;
         markdownContentRef.current = markdown;
         lastSavedContentRef.current = markdown;
         setMarkdownContent(markdown);
@@ -684,7 +750,6 @@ export function StreamEditor({
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const fragment = message.payload?.fragment as string | undefined;
         const revision = Number(message.payload?.revision);
-        const spans = deserializeProvenanceSpans(message.payload?.spans);
 
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof fragment !== 'string' || fragment.length === 0) {
           return;
@@ -697,18 +762,21 @@ export function StreamEditor({
         const insertion = computeAppendInsertion(currentMarkdown.length, fragment);
         const insert = insertion.insert;
         const nextMarkdown = `${currentMarkdown}${insert}`;
+        const spans = payloadSpansForDoc(message.payload?.spans, nextMarkdown);
 
         if (view) {
           view.dispatch({
             changes: { from: insertion.from, insert },
-            effects: EditorView.scrollIntoView(insertion.insertedEnd, { y: 'nearest' }),
+            effects: [
+              EditorView.scrollIntoView(insertion.insertedEnd, { y: 'nearest' }),
+              addSpans.of(spans),
+            ],
           });
         }
 
         if (Number.isFinite(revision)) {
           revisionRef.current = revision;
         }
-        provenanceSpansRef.current = [...provenanceSpansRef.current, ...spans];
         markdownContentRef.current = nextMarkdown;
         if (!hadUnsavedChanges) {
           lastSavedContentRef.current = nextMarkdown;
@@ -2149,12 +2217,17 @@ export function StreamEditor({
                 markdown({ base: markdownLanguage, codeLanguages: languages }),
                 syntaxHighlighting(markdownHighlightStyle),
                 markdownConcealExtension,
+                provenanceField,
                 markdownImageWidgetExtension,
                 tickerPDFLinkExtension(stream.id),
                 linkInteraction,
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
+                view.dispatch({
+                  effects: setSpans.of(payloadSpansForDoc(stream.spans, view.state.doc.toString())),
+                  annotations: Transaction.addToHistory.of(false),
+                });
 
                 scrollCleanupRef.current?.();
                 const handleScroll = () => scheduleScrollPositionSave();

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -5,7 +5,7 @@ import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
 import { bridge, type Stream, type SourceReference, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
 import { SourcesModal } from './SourcesModal';
@@ -138,6 +138,19 @@ function focusEditorAtDocumentEnd(view: EditorView) {
   view.focus();
 }
 
+function restoreViewportEnd(view: EditorView, scrollOffset: number): number {
+  const docLength = view.state.doc.length;
+  if (docLength === 0 || scrollOffset <= 0) return view.viewport.to;
+
+  const scrollHeight = view.scrollDOM.scrollHeight;
+  const clientHeight = view.scrollDOM.clientHeight;
+  if (scrollHeight <= clientHeight) return view.viewport.to;
+
+  // ponytail: pixel-to-doc estimate; upgrade to measured CodeMirror mapping if deep restores ever flash.
+  const ratio = Math.min(1, (scrollOffset + clientHeight) / scrollHeight);
+  return Math.max(view.viewport.to, Math.min(docLength, Math.ceil(docLength * ratio)));
+}
+
 const clickToDocumentEndExtension: Extension = EditorView.domEventHandlers({
   mousedown: (event, view) => {
     if (event.button !== 0 || event.defaultPrevented) return false;
@@ -233,6 +246,7 @@ export function StreamEditor({
   const [title, setTitle] = useState(stream.title);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isPrepaintHidden, setIsPrepaintHidden] = useState(true);
   const [showSourcesModal, setShowSourcesModal] = useState(false);
   const [highlightedSourceId, setHighlightedSourceId] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<'saved' | 'saving'>('saved');
@@ -270,6 +284,9 @@ export function StreamEditor({
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
   const sourceIndexNoticeTimerRef = useRef<number | null>(null);
+  const scrollSaveTimerRef = useRef<number | null>(null);
+  const scrollCleanupRef = useRef<(() => void) | null>(null);
+  const revealFrameRef = useRef<number | null>(null);
   const pendingPDFAnchorSelectionRef = useRef<PendingPDFAnchorSelection | null>(null);
   const sourcesRef = useRef<SourceReference[]>(stream.sources);
   const sourceIndexStatusesRef = useRef<Map<string, SourceReference['indexStatus']>>(new Map());
@@ -447,6 +464,46 @@ export function StreamEditor({
     }, AI_INDEXING_NOTICE_MS);
   }, [clearSourceIndexNoticeTimer]);
 
+  const clearScrollSaveTimer = useCallback(() => {
+    if (scrollSaveTimerRef.current !== null) {
+      window.clearTimeout(scrollSaveTimerRef.current);
+      scrollSaveTimerRef.current = null;
+    }
+  }, []);
+
+  const sendScrollPosition = useCallback((offset: number) => {
+    bridge.send({
+      type: 'saveScrollPosition',
+      payload: { streamId: stream.id, offset: Math.max(0, offset) },
+    });
+  }, [stream.id]);
+
+  const scheduleScrollPositionSave = useCallback(() => {
+    clearScrollSaveTimer();
+    scrollSaveTimerRef.current = window.setTimeout(() => {
+      scrollSaveTimerRef.current = null;
+      const view = editorViewRef.current;
+      if (view) {
+        sendScrollPosition(view.scrollDOM.scrollTop);
+      }
+    }, 1000);
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const flushScrollPosition = useCallback(() => {
+    clearScrollSaveTimer();
+    const view = editorViewRef.current;
+    if (view) {
+      sendScrollPosition(view.scrollDOM.scrollTop);
+    }
+  }, [clearScrollSaveTimer, sendScrollPosition]);
+
+  const clearRevealFrame = useCallback(() => {
+    if (revealFrameRef.current !== null) {
+      window.cancelAnimationFrame(revealFrameRef.current);
+      revealFrameRef.current = null;
+    }
+  }, []);
+
   const cycleSourceScope = useCallback(() => {
     setSourceScope((previous) => {
       const next = nextSourceScope(previous);
@@ -488,17 +545,6 @@ export function StreamEditor({
       dispatchAiRangeClear(view);
     }
   }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const view = editorViewRef.current;
-      if (view) {
-        focusEditorAtDocumentEnd(view);
-      }
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [stream.id]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -1486,6 +1532,15 @@ export function StreamEditor({
   }, [clearSourceIndexNoticeTimer]);
 
   useEffect(() => {
+    return () => {
+      flushScrollPosition();
+      scrollCleanupRef.current?.();
+      scrollCleanupRef.current = null;
+      clearRevealFrame();
+    };
+  }, [clearRevealFrame, flushScrollPosition]);
+
+  useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       if (!isEditorActive()) return;
       if (!event.clipboardData?.items?.length) return;
@@ -1745,7 +1800,7 @@ export function StreamEditor({
         <div className="stream-content">
           <div
             ref={editorShellRef}
-            className="document-editor-shell"
+            className={`document-editor-shell ${isPrepaintHidden ? 'cm-prepaint' : ''}`}
             onDrop={handleDrop}
             onDragOver={handleDragOver}
           >
@@ -1777,11 +1832,25 @@ export function StreamEditor({
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
-                window.setTimeout(() => {
-                  if (editorViewRef.current === view) {
-                    focusEditorAtDocumentEnd(view);
-                  }
-                }, 0);
+
+                scrollCleanupRef.current?.();
+                const handleScroll = () => scheduleScrollPositionSave();
+                view.scrollDOM.addEventListener('scroll', handleScroll, { passive: true });
+                scrollCleanupRef.current = () => view.scrollDOM.removeEventListener('scroll', handleScroll);
+
+                clearRevealFrame();
+                const scrollOffset = Math.max(0, Number(stream.document?.scrollOffset ?? 0));
+                ensureSyntaxTree(view.state, restoreViewportEnd(view, scrollOffset), 50);
+                view.scrollDOM.scrollTop = scrollOffset;
+                revealFrameRef.current = window.requestAnimationFrame(() => {
+                  revealFrameRef.current = window.requestAnimationFrame(() => {
+                    revealFrameRef.current = null;
+                    if (editorViewRef.current === view) {
+                      setIsPrepaintHidden(false);
+                    }
+                  });
+                });
+
               }}
               onChange={(value) => {
                 setMarkdownContent(value);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -21,6 +21,7 @@ import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
 import {
+  beginPDFAnchorPick,
   buildPDFAnchorLinkEdit,
   buildTickerPDFLinkURL,
   mapPendingPDFAnchorSelection,
@@ -1652,6 +1653,26 @@ export function StreamEditor({
     view.focus();
   }, [hideSelectionMenu]);
 
+  const canLinkSelectionToPDF = pdfPaneState.visible && pdfPaneState.streamId === stream.id;
+
+  const handleSelectionLinkToPDF = useCallback(() => {
+    const context = getSelectionContext(false);
+    if (!context || !context.text.trim()) {
+      hideSelectionMenu();
+      return;
+    }
+    if (!canLinkSelectionToPDF) {
+      pendingPDFAnchorSelectionRef.current = null;
+      hideSelectionMenu();
+      addToast('Open a PDF source before linking to PDF.', 'info');
+      return;
+    }
+
+    pendingPDFAnchorSelectionRef.current = { from: context.from, to: context.to };
+    hideSelectionMenu();
+    beginPDFAnchorPick(stream.id);
+  }, [addToast, canLinkSelectionToPDF, getSelectionContext, hideSelectionMenu, stream.id]);
+
   const handleSelectionVerb = useCallback((verb: DocumentAIVerb) => {
     const context = getSelectionContext(false);
     if (!context || !context.text.trim()) {
@@ -2021,6 +2042,20 @@ export function StreamEditor({
           >
             &lt;/&gt;
           </button>
+          {canLinkSelectionToPDF && (
+            <button
+              type="button"
+              className="selection-action-button"
+              title="Link to PDF"
+              aria-label="Link to PDF"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleSelectionLinkToPDF}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path d="M8.8 12.9a1 1 0 010-1.4l3.7-3.7a3.4 3.4 0 114.8 4.8l-1.5 1.5-.7-.7 1.5-1.5a2.4 2.4 0 10-3.4-3.4l-3.7 3.7a1 1 0 001.4 1.4l2.5-2.5.7.7-2.5 2.5a2 2 0 01-2.8 0zm-2.1 7a3.4 3.4 0 010-4.8l1.5-1.5.7.7-1.5 1.5a2.4 2.4 0 103.4 3.4l3.7-3.7a1 1 0 00-1.4-1.4l-2.5 2.5-.7-.7 2.5-2.5a2 2 0 112.8 2.8l-3.7 3.7a3.4 3.4 0 01-4.8 0z" />
+              </svg>
+            </button>
+          )}
           <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -130,6 +130,34 @@ export function documentAIErrorRecovery(originalText: string, errorCode: string 
   };
 }
 
+export function buildDocumentAIProvenanceSpan(options: {
+  requestId: string;
+  start: number;
+  text: string;
+  verb: DocumentAIVerb;
+  model?: string;
+  parentRequestId?: string;
+  spanId?: string;
+  createdAt?: number;
+}): Span {
+  const meta: Record<string, unknown> = {
+    model: options.model ?? null,
+    verb: options.verb,
+  };
+  if (options.parentRequestId) meta.parentRequestId = options.parentRequestId;
+
+  return {
+    spanId: options.spanId ?? crypto.randomUUID(),
+    start: options.start,
+    end: options.start + options.text.length,
+    origin: 'ai',
+    requestId: options.requestId,
+    meta,
+    textHash: fnv1a(options.text),
+    createdAt: options.createdAt ?? Date.now(),
+  };
+}
+
 function parseDocumentAICitations(value: unknown): DocumentAICitation[] | null {
   if (!Array.isArray(value)) return null;
 
@@ -397,6 +425,8 @@ export function StreamEditor({
     verb: DocumentAIVerb;
     originalText: string;
     prefix: string;
+    model?: string;
+    parentRequestId?: string;
   } | null>(null);
 
   const insertImageAtCursor = useCallback((imageUrl: string, altText = 'image') => {
@@ -810,6 +840,8 @@ export function StreamEditor({
       if (message.type === 'documentModelSelected') {
         const requestId = message.payload?.requestId as string | undefined;
         if (!requestId || requestId !== active.id) return;
+        const modelId = message.payload?.modelId as string | undefined;
+        if (modelId) active.model = modelId;
         return;
       }
 
@@ -940,6 +972,14 @@ export function StreamEditor({
         const insertText = `${active.prefix}${finalOutput}${suffix}`;
         const finalFrom = range.from;
         const originalTo = finalFrom + active.originalText.length;
+        const span = buildDocumentAIProvenanceSpan({
+          requestId,
+          start: finalFrom,
+          text: insertText,
+          verb: active.verb,
+          model: active.model,
+          parentRequestId: active.parentRequestId,
+        });
 
         view.dispatch({
           changes: { from: range.from, to: range.to, insert: active.originalText },
@@ -949,7 +989,10 @@ export function StreamEditor({
         view.dispatch({
           changes: { from: finalFrom, to: originalTo, insert: insertText },
           selection: { anchor: finalFrom + insertText.length },
-          effects: setAiWritingRangeEffect.of(null),
+          effects: [
+            setAiWritingRangeEffect.of(null),
+            addSpans.of([span]),
+          ],
           annotations: [
             Transaction.addToHistory.of(true),
             Transaction.userEvent.of(AI_HISTORY_USER_EVENT),
@@ -1586,6 +1629,7 @@ export function StreamEditor({
     to: number;
     mode: 'replace' | 'after';
     verb?: DocumentAIVerb;
+    parentRequestId?: string;
   }) => {
     if (isAiThinking) {
       addToast('AI is already running for this stream.', 'info');
@@ -1644,6 +1688,7 @@ export function StreamEditor({
       verb: options.verb ?? 'develop',
       originalText,
       prefix,
+      parentRequestId: options.parentRequestId,
     };
     setAiStatus('thinking');
     showAiWritingFeedback();
@@ -1666,6 +1711,7 @@ export function StreamEditor({
         sourceScope,
         verb: options.verb ?? 'develop',
         imageURLs: options.imageUrls ?? [],
+        ...(options.parentRequestId ? { parentRequestId: options.parentRequestId } : {}),
       },
     });
   }, [addToast, isAiThinking, showAiWritingFeedback, showSourceIndexNotice, sourceScope, stream.id]);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -17,7 +17,8 @@ import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
 import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
-import { addSpans, currentSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
+import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
+import { provenanceXrayExtension } from '../extensions/ProvenanceXray';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
@@ -292,6 +293,12 @@ function serializeFieldSpans(spans: Span[], doc: string): ProvenanceSpanJSON[] {
   return serializeProvenanceSpans(normalizeSpans(spans, doc).map(fieldSpanToPayload));
 }
 
+function spanIdsIntersectingRange(spans: Span[], from: number, to: number): string[] {
+  return spans
+    .filter((span) => span.start < to && span.end > from)
+    .map((span) => span.spanId);
+}
+
 const markdownHighlightStyle = HighlightStyle.define([
   {
     tag: t.heading,
@@ -365,6 +372,7 @@ export function StreamEditor({
   const [isPrepaintHidden, setIsPrepaintHidden] = useState(true);
   const [showSourcesModal, setShowSourcesModal] = useState(false);
   const [highlightedSourceId, setHighlightedSourceId] = useState<string | null>(null);
+  const [isProvenanceXrayVisible, setIsProvenanceXrayVisible] = useState(false);
   const [saveState, setSaveState] = useState<'saved' | 'saving'>('saved');
   const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
@@ -671,6 +679,7 @@ export function StreamEditor({
     setShowPrompt(false);
     setPromptValue('');
     setSourceScope(stream.sourceScope ?? 'auto');
+    setIsProvenanceXrayVisible(false);
     setShowRewriteMenu(false);
     promptContextRef.current = null;
     aiRequestRef.current = null;
@@ -1795,6 +1804,25 @@ export function StreamEditor({
     beginPDFAnchorPick(stream.id);
   }, [addToast, canLinkSelectionToPDF, getSelectionContext, hideSelectionMenu, stream.id]);
 
+  const handleSelectionDissolve = useCallback(() => {
+    const view = editorViewRef.current;
+    if (!view) {
+      hideSelectionMenu();
+      return;
+    }
+
+    const selection = view.state.selection.main;
+    const spanIds = spanIdsIntersectingRange(currentSpans(view.state), selection.from, selection.to);
+    if (spanIds.length > 0) {
+      view.dispatch({
+        effects: dissolveSpans.of(spanIds),
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+    hideSelectionMenu();
+  }, [hideSelectionMenu]);
+
   const handleSelectionVerb = useCallback((verb: DocumentAIVerb) => {
     const context = getSelectionContext(false);
     if (!context || !context.text.trim()) {
@@ -1943,6 +1971,23 @@ export function StreamEditor({
     });
   }, []);
 
+  const handleOpenSourceById = useCallback((sourceId: string) => {
+    const source = sourcesRef.current.find((candidate) => candidate.id === sourceId);
+    if (source) handleOpenSource(source);
+  }, [handleOpenSource]);
+
+  const provenanceXray = useMemo<Extension>(() => (
+    isProvenanceXrayVisible
+      ? provenanceXrayExtension({ sources, onOpenSource: handleOpenSourceById })
+      : []
+  ), [handleOpenSourceById, isProvenanceXrayVisible, sources]);
+
+  const selectionDissolveSpanIds = (() => {
+    const view = editorViewRef.current;
+    if (!isProvenanceXrayVisible || !floatingMenu.visible || !view) return [];
+    return spanIdsIntersectingRange(currentSpans(view.state), floatingMenu.selectionFrom, floatingMenu.selectionTo);
+  })();
+
   return (
     <div className="stream-editor">
       <header className="stream-header">
@@ -1969,6 +2014,16 @@ export function StreamEditor({
           <span className={`stream-save-status stream-save-status--${saveState}`}>
             {saveState === 'saving' ? 'Saving…' : 'Saved'}
           </span>
+          <button
+            onClick={() => setIsProvenanceXrayVisible((value) => !value)}
+            className={`stream-xray-button ${isProvenanceXrayVisible ? 'stream-xray-button--active' : ''}`}
+            title="Toggle provenance x-ray"
+            type="button"
+            aria-label="Toggle provenance x-ray"
+            aria-pressed={isProvenanceXrayVisible}
+          >
+            👁
+          </button>
           <button
             onClick={() => setShowSourcesModal(true)}
             className="stream-sources-button"
@@ -2178,6 +2233,22 @@ export function StreamEditor({
               </svg>
             </button>
           )}
+          {isProvenanceXrayVisible && (
+            <>
+              <span className="selection-action-divider" aria-hidden="true" />
+              <button
+                type="button"
+                className="selection-action-button selection-action-button--text"
+                title="Dissolve provenance in selection"
+                aria-label="Dissolve provenance in selection"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleSelectionDissolve}
+                disabled={selectionDissolveSpanIds.length === 0}
+              >
+                Dissolve
+              </button>
+            </>
+          )}
           <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"
@@ -2265,6 +2336,7 @@ export function StreamEditor({
                 markdownConcealExtension,
                 provenanceField,
                 markdownImageWidgetExtension,
+                provenanceXray,
                 tickerPDFLinkExtension(stream.id),
                 linkInteraction,
               ]}

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -7,8 +7,9 @@ import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
 import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
-import { bridge, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload, type ProvenanceSpanJSON } from '../types';
+import { bridge, getExchange, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload, type ProvenanceSpanJSON, type AIExchangeJSON } from '../types';
 import { SourcesModal } from './SourcesModal';
+import { ExchangeOverlay, type ExchangeManifestEntry } from './ExchangeOverlay';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
 import { AI_HISTORY_USER_EVENT, aiWritingExtension, getAiWritingRange, setAiWritingRangeEffect } from '../extensions/AIWritingState';
@@ -18,7 +19,7 @@ import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetE
 import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
-import { provenanceXrayExtension } from '../extensions/ProvenanceXray';
+import { canRedevelopSpan, provenanceXrayExtension } from '../extensions/ProvenanceXray';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
@@ -49,6 +50,20 @@ interface SelectionContext {
   from: number;
   to: number;
   imageUrls: string[];
+}
+
+type PromptIntent = {
+  kind: 'ask';
+} | {
+  kind: 'redevelop';
+  verb: DocumentAIVerb;
+  parentRequestId?: string;
+  preview: string;
+};
+
+interface ExchangeOverlayState {
+  exchange: AIExchangeJSON;
+  span: Span;
 }
 
 interface FloatingMenuState {
@@ -299,6 +314,23 @@ function spanIdsIntersectingRange(spans: Span[], from: number, to: number): stri
     .map((span) => span.spanId);
 }
 
+function parseDocumentAIVerb(value: unknown): DocumentAIVerb {
+  return value === 'ask' || value === 'challenge' || value === 'define' || value === 'develop'
+    ? value
+    : 'develop';
+}
+
+function promptFromUserInput(userInput: string): string {
+  const marker = '\n\nPrompt:\n';
+  const index = userInput.indexOf(marker);
+  return index >= 0 ? userInput.slice(index + marker.length).trim() : '';
+}
+
+function replacementPreview(text: string): string {
+  const compact = text.trim().replace(/\s+/g, ' ');
+  return compact.length > 60 ? `${compact.slice(0, 60)}…` : compact;
+}
+
 const markdownHighlightStyle = HighlightStyle.define([
   {
     tag: t.heading,
@@ -377,6 +409,8 @@ export function StreamEditor({
   const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
   const [promptValue, setPromptValue] = useState('');
+  const [promptIntent, setPromptIntent] = useState<PromptIntent>({ kind: 'ask' });
+  const [exchangeOverlay, setExchangeOverlay] = useState<ExchangeOverlayState | null>(null);
   const [sourceScope, setSourceScope] = useState<SourceScope>(stream.sourceScope ?? 'auto');
   const [aiStatus, setAiStatus] = useState<'idle' | 'thinking'>('idle');
   const [showRewriteMenu, setShowRewriteMenu] = useState(false);
@@ -678,6 +712,8 @@ export function StreamEditor({
     setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
+    setPromptIntent({ kind: 'ask' });
+    setExchangeOverlay(null);
     setSourceScope(stream.sourceScope ?? 'auto');
     setIsProvenanceXrayVisible(false);
     setShowRewriteMenu(false);
@@ -1747,6 +1783,7 @@ export function StreamEditor({
     hideSelectionMenu();
     promptContextRef.current = context;
     setPromptValue('');
+    setPromptIntent({ kind: 'ask' });
     setShowPrompt(true);
   }, [hideSelectionMenu]);
 
@@ -1844,6 +1881,7 @@ export function StreamEditor({
   const closePrompt = useCallback(() => {
     setShowPrompt(false);
     setPromptValue('');
+    setPromptIntent({ kind: 'ask' });
     promptContextRef.current = null;
     hideSelectionMenu();
   }, [hideSelectionMenu]);
@@ -1851,9 +1889,23 @@ export function StreamEditor({
   const handlePromptSend = useCallback(() => {
     const prompt = promptValue.trim();
     const context = promptContextRef.current;
-    if (!prompt || !context) return;
+    if ((!prompt && promptIntent.kind === 'ask') || !context) return;
 
     closePrompt();
+
+    if (promptIntent.kind === 'redevelop') {
+      startDocumentAI({
+        query: prompt || context.text.trim(),
+        context: prompt ? context.text.trim() : undefined,
+        imageUrls: context.imageUrls,
+        from: context.from,
+        to: context.to,
+        mode: 'replace',
+        verb: promptIntent.verb,
+        parentRequestId: promptIntent.parentRequestId,
+      });
+      return;
+    }
 
     startDocumentAI({
       query: prompt,
@@ -1864,7 +1916,7 @@ export function StreamEditor({
       mode: 'after',
       verb: 'ask',
     });
-  }, [closePrompt, promptValue, startDocumentAI]);
+  }, [closePrompt, promptIntent, promptValue, startDocumentAI]);
 
   const handleStopDocumentAI = useCallback(() => {
     const active = aiRequestRef.current;
@@ -1976,11 +2028,57 @@ export function StreamEditor({
     if (source) handleOpenSource(source);
   }, [handleOpenSource]);
 
+  const openRedevelopPrompt = useCallback((span: Span, exchange: AIExchangeJSON) => {
+    const view = editorViewRef.current;
+    if (!view) return;
+
+    const currentSpan = currentSpans(view.state).find((candidate) => candidate.spanId === span.spanId);
+    if (!currentSpan) return;
+    const text = view.state.doc.sliceString(currentSpan.start, currentSpan.end);
+    if (!canRedevelopSpan(currentSpan, text, isAiThinking)) return;
+
+    promptContextRef.current = {
+      text,
+      from: currentSpan.start,
+      to: currentSpan.end,
+      imageUrls: extractMarkdownImageUrls(text),
+    };
+    setPromptValue(promptFromUserInput(exchange.userInput));
+    setPromptIntent({
+      kind: 'redevelop',
+      verb: parseDocumentAIVerb(exchange.verb),
+      parentRequestId: currentSpan.requestId ?? exchange.requestId,
+      preview: replacementPreview(text),
+    });
+    setExchangeOverlay(null);
+    hideSelectionMenu();
+    setShowPrompt(true);
+  }, [hideSelectionMenu, isAiThinking]);
+
+  const handleOpenExchangeManifestEntry = useCallback((entry: ExchangeManifestEntry) => {
+    bridge.send({
+      type: 'openPdfDestination',
+      payload: {
+        streamId: stream.id,
+        sourceId: entry.sourceId,
+        page: entry.page,
+        chunkId: entry.chunkId,
+      },
+    });
+  }, [stream.id]);
+
   const provenanceXray = useMemo<Extension>(() => (
     isProvenanceXrayVisible
-      ? provenanceXrayExtension({ sources, onOpenSource: handleOpenSourceById })
+      ? provenanceXrayExtension({
+        sources,
+        isAiThinking,
+        loadExchange: getExchange,
+        onShowExchange: (exchange, span) => setExchangeOverlay({ exchange, span }),
+        onRedevelop: openRedevelopPrompt,
+        onOpenSource: handleOpenSourceById,
+      })
       : []
-  ), [handleOpenSourceById, isProvenanceXrayVisible, sources]);
+  ), [handleOpenSourceById, isAiThinking, isProvenanceXrayVisible, openRedevelopPrompt, sources]);
 
   const selectionDissolveSpanIds = (() => {
     const view = editorViewRef.current;
@@ -2073,8 +2171,12 @@ export function StreamEditor({
       {showPrompt && (
         <div className="ai-prompt-overlay" onClick={closePrompt}>
           <div className="ai-prompt-dialog" onClick={(e) => e.stopPropagation()}>
-            <h2>Ask</h2>
-            <p>Selection will be attached as context.</p>
+            <h2>{promptIntent.kind === 'redevelop' ? 'Re-develop' : 'Ask'}</h2>
+            <p>
+              {promptIntent.kind === 'redevelop'
+                ? `will replace: ${promptIntent.preview}`
+                : 'Selection will be attached as context.'}
+            </p>
             <textarea
               className="ai-prompt-input"
               value={promptValue}
@@ -2088,7 +2190,7 @@ export function StreamEditor({
                   closePrompt();
                 }
               }}
-              placeholder="Ask a question or continue the line of thought…"
+              placeholder={promptIntent.kind === 'redevelop' ? 'Edit the prompt…' : 'Ask a question or continue the line of thought…'}
               autoFocus
               rows={5}
             />
@@ -2112,13 +2214,22 @@ export function StreamEditor({
                 className="ai-prompt-send"
                 type="button"
                 onClick={handlePromptSend}
-                disabled={!promptValue.trim()}
+                disabled={promptIntent.kind === 'ask' && !promptValue.trim()}
               >
-                Ask
+                {promptIntent.kind === 'redevelop' ? 'Re-develop' : 'Ask'}
               </button>
             </div>
           </div>
         </div>
+      )}
+
+      {exchangeOverlay && (
+        <ExchangeOverlay
+          exchange={exchangeOverlay.exchange}
+          onClose={() => setExchangeOverlay(null)}
+          onRedevelop={() => openRedevelopPrompt(exchangeOverlay.span, exchangeOverlay.exchange)}
+          onOpenManifestEntry={handleOpenExchangeManifestEntry}
+        />
       )}
 
       {floatingMenu.visible && (

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -7,7 +7,7 @@ import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
 import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
-import { bridge, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
+import { bridge, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload, type ProvenanceSpanJSON } from '../types';
 import { SourcesModal } from './SourcesModal';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
@@ -20,6 +20,7 @@ import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
 import { debugWarn } from '../utils/debug';
+import { deserializeProvenanceSpans, serializeProvenanceSpans } from '../utils/provenanceSpans';
 import {
   beginPDFAnchorPick,
   buildPDFAnchorLinkEdit,
@@ -314,6 +315,7 @@ export function StreamEditor({
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
+  const provenanceSpansRef = useRef<ProvenanceSpanJSON[]>(stream.spans ?? []);
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
@@ -555,6 +557,7 @@ export function StreamEditor({
     lastSavedContentRef.current = stream.document?.markdown ?? '';
     markdownContentRef.current = stream.document?.markdown ?? '';
     revisionRef.current = stream.document?.revision ?? 0;
+    provenanceSpansRef.current = stream.spans ?? [];
     sourcesRef.current = stream.sources;
     sourceIndexStatusesRef.current = new Map(
       stream.sources.map((source) => [source.id, source.indexStatus])
@@ -584,7 +587,7 @@ export function StreamEditor({
     if (view) {
       dispatchAiRangeClear(view);
     }
-  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.title]);
+  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.spans, stream.title]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -623,6 +626,7 @@ export function StreamEditor({
         streamId: stream.id,
         markdown: contentToSave,
         baseRevision,
+        spans: serializeProvenanceSpans(provenanceSpansRef.current),
       }).then((response) => {
         if (Number.isFinite(response.revision)) {
           revisionRef.current = response.revision;
@@ -649,6 +653,7 @@ export function StreamEditor({
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const markdown = message.payload?.markdown as string | undefined;
         const revision = Number(message.payload?.revision);
+        const spans = deserializeProvenanceSpans(message.payload?.spans);
 
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof markdown !== 'string' || !Number.isFinite(revision)) {
           return;
@@ -662,6 +667,7 @@ export function StreamEditor({
         }
 
         revisionRef.current = revision;
+        provenanceSpansRef.current = spans;
         markdownContentRef.current = markdown;
         lastSavedContentRef.current = markdown;
         setMarkdownContent(markdown);
@@ -678,6 +684,7 @@ export function StreamEditor({
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const fragment = message.payload?.fragment as string | undefined;
         const revision = Number(message.payload?.revision);
+        const spans = deserializeProvenanceSpans(message.payload?.spans);
 
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof fragment !== 'string' || fragment.length === 0) {
           return;
@@ -701,6 +708,7 @@ export function StreamEditor({
         if (Number.isFinite(revision)) {
           revisionRef.current = revision;
         }
+        provenanceSpansRef.current = [...provenanceSpansRef.current, ...spans];
         markdownContentRef.current = nextMarkdown;
         if (!hadUnsavedChanges) {
           lastSavedContentRef.current = nextMarkdown;

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -7,7 +7,7 @@ import { Transaction, type Extension } from '@codemirror/state';
 import { isolateHistory } from '@codemirror/commands';
 import { HighlightStyle, ensureSyntaxTree, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
-import { bridge, type Stream, type SourceReference, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
+import { bridge, type Stream, type SourceReference, type SourceScope, type DocumentAIVerb, type DocumentAICitation, type DocumentAISourceContextMode, type SourceTitlePayload } from '../types';
 import { SourcesModal } from './SourcesModal';
 import { useBridgeMessages, EditorAPI } from '../hooks/useBridgeMessages';
 import { useToastStore } from '../store/toastStore';
@@ -88,10 +88,6 @@ const SELECTION_MENU_DELAY_MS = 180;
 const AI_ERROR_FEEDBACK_MS = 2200;
 const AI_INDEXING_NOTICE_MS = 4000;
 
-export type SourceScope = 'auto' | 'all' | 'none';
-
-const sourceScopeByStreamId = new Map<string, SourceScope>();
-
 export function nextSourceScope(scope: SourceScope): SourceScope {
   switch (scope) {
     case 'auto':
@@ -115,6 +111,19 @@ function formatSourceScope(scope: SourceScope): string {
     default:
       return 'Auto';
   }
+}
+
+export function wrapChallengeOutput(text: string): string {
+  // Challenge renders inline-quoted until margin notes ship (Roadmap 4 P7); then it becomes a margin note. ponytail: inline placement is the ceiling here.
+  const quoted = text.trim().split(/\r?\n/).map((line) => `> ${line}`).join('\n');
+  return `${quoted}\n\n*— Challenge*`;
+}
+
+export function documentAIErrorRecovery(originalText: string, errorCode: string | undefined) {
+  return {
+    restoreText: originalText,
+    silent: errorCode === 'cancelled',
+  };
 }
 
 function parseDocumentAICitations(value: unknown): DocumentAICitation[] | null {
@@ -267,10 +276,9 @@ export function StreamEditor({
   const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
   const [promptValue, setPromptValue] = useState('');
-  const [sourceScope, setSourceScope] = useState<SourceScope>(
-    () => sourceScopeByStreamId.get(stream.id) ?? 'auto'
-  );
+  const [sourceScope, setSourceScope] = useState<SourceScope>(stream.sourceScope ?? 'auto');
   const [aiStatus, setAiStatus] = useState<'idle' | 'thinking'>('idle');
+  const [showRewriteMenu, setShowRewriteMenu] = useState(false);
   const [floatingMenu, setFloatingMenu] = useState<FloatingMenuState>({
     visible: false,
     left: 0,
@@ -321,6 +329,7 @@ export function StreamEditor({
     id: string;
     buffer: string;
     mode: 'replace' | 'after';
+    verb: DocumentAIVerb;
     originalText: string;
     prefix: string;
   } | null>(null);
@@ -532,7 +541,10 @@ export function StreamEditor({
   const cycleSourceScope = useCallback(() => {
     setSourceScope((previous) => {
       const next = nextSourceScope(previous);
-      sourceScopeByStreamId.set(stream.id, next);
+      bridge.send({
+        type: 'setSourceScope',
+        payload: { streamId: stream.id, scope: next },
+      });
       return next;
     });
   }, [stream.id]);
@@ -563,14 +575,15 @@ export function StreamEditor({
     setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
-    setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
+    setSourceScope(stream.sourceScope ?? 'auto');
+    setShowRewriteMenu(false);
     promptContextRef.current = null;
     aiRequestRef.current = null;
     const view = editorViewRef.current;
     if (view) {
       dispatchAiRangeClear(view);
     }
-  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.title]);
+  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.title]);
 
   useEffect(() => {
     markdownContentRef.current = markdownContent;
@@ -729,6 +742,7 @@ export function StreamEditor({
         if (!requestId || requestId !== active.id) return;
 
         const errorCode = message.payload?.errorCode as string | undefined;
+        const recovery = documentAIErrorRecovery(active.originalText, errorCode);
         const proxyRequestId = message.payload?.proxyRequestId as string | undefined;
         let displayError = error || 'AI request failed.';
 
@@ -762,8 +776,8 @@ export function StreamEditor({
         const range = view ? getAiWritingRange(view.state) : null;
         if (view && range) {
           view.dispatch({
-            changes: { from: range.from, to: range.to, insert: active.originalText },
-            selection: { anchor: range.from + active.originalText.length },
+            changes: { from: range.from, to: range.to, insert: recovery.restoreText },
+            selection: { anchor: range.from + recovery.restoreText.length },
             effects: setAiWritingRangeEffect.of(null),
             annotations: Transaction.addToHistory.of(false),
           });
@@ -774,8 +788,12 @@ export function StreamEditor({
 
         setAiStatus('idle');
         aiRequestRef.current = null;
-        showAiErrorFeedback(displayError);
-        addToast(displayError, 'error');
+        if (recovery.silent) {
+          hideAiFeedback();
+        } else {
+          showAiErrorFeedback(displayError);
+          addToast(displayError, 'error');
+        }
         return;
       }
 
@@ -835,6 +853,10 @@ export function StreamEditor({
 
         if (provenanceLine) {
           finalOutput = `${finalOutput}\n\n${provenanceLine}`;
+        }
+
+        if (active.verb === 'challenge') {
+          finalOutput = wrapChallengeOutput(finalOutput);
         }
 
         const suffix = active.mode === 'after' && !finalOutput.endsWith('\n') ? '\n' : '';
@@ -1145,6 +1167,7 @@ export function StreamEditor({
 
   const hideSelectionMenu = useCallback(() => {
     clearSelectionMenuTimer();
+    setShowRewriteMenu(false);
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
@@ -1485,6 +1508,7 @@ export function StreamEditor({
     from: number;
     to: number;
     mode: 'replace' | 'after';
+    verb?: DocumentAIVerb;
   }) => {
     if (isAiThinking) {
       addToast('AI is already running for this stream.', 'info');
@@ -1540,6 +1564,7 @@ export function StreamEditor({
       id: requestId,
       buffer: '',
       mode: options.mode,
+      verb: options.verb ?? 'develop',
       originalText,
       prefix,
     };
@@ -1562,6 +1587,7 @@ export function StreamEditor({
         query: options.query,
         context: options.context,
         sourceScope,
+        verb: options.verb ?? 'develop',
         imageURLs: options.imageUrls ?? [],
       },
     });
@@ -1580,6 +1606,7 @@ export function StreamEditor({
       from: context.from,
       to: context.to,
       mode: 'replace',
+      verb: 'develop',
     });
     hideSelectionMenu();
   }, [addToast, getSelectionContext, hideSelectionMenu, startDocumentAI]);
@@ -1604,8 +1631,6 @@ export function StreamEditor({
     openPromptWithContext(context);
   }, [addToast, getSelectionContext, isAiThinking, openPromptWithContext]);
 
-  const canLinkSelectionToPDF = pdfPaneState.visible && pdfPaneState.streamId === stream.id;
-
   const handleSelectionFormat = useCallback((marker: string) => {
     const view = editorViewRef.current;
     if (!view) {
@@ -1627,7 +1652,7 @@ export function StreamEditor({
     view.focus();
   }, [hideSelectionMenu]);
 
-  const handleSelectionSend = useCallback(() => {
+  const handleSelectionVerb = useCallback((verb: DocumentAIVerb) => {
     const context = getSelectionContext(false);
     if (!context || !context.text.trim()) {
       hideSelectionMenu();
@@ -1639,40 +1664,11 @@ export function StreamEditor({
       imageUrls: context.imageUrls,
       from: context.from,
       to: context.to,
-      mode: 'replace',
+      mode: verb === 'develop' ? 'replace' : 'after',
+      verb,
     });
     hideSelectionMenu();
   }, [getSelectionContext, hideSelectionMenu, startDocumentAI]);
-
-  const handleSelectionPrompt = useCallback(() => {
-    const context = getSelectionContext(false);
-    if (!context || !context.text.trim()) {
-      hideSelectionMenu();
-      return;
-    }
-    openPromptWithContext(context);
-  }, [getSelectionContext, hideSelectionMenu, openPromptWithContext]);
-
-  const handleSelectionLinkToPDF = useCallback(() => {
-    const context = getSelectionContext(false);
-    if (!context || !context.text.trim()) {
-      hideSelectionMenu();
-      return;
-    }
-    if (!canLinkSelectionToPDF) {
-      pendingPDFAnchorSelectionRef.current = null;
-      hideSelectionMenu();
-      addToast('Open a PDF source before linking to PDF.', 'info');
-      return;
-    }
-
-    pendingPDFAnchorSelectionRef.current = { from: context.from, to: context.to };
-    hideSelectionMenu();
-    bridge.send({
-      type: 'beginPdfAnchorPick',
-      payload: { streamId: stream.id },
-    });
-  }, [addToast, canLinkSelectionToPDF, getSelectionContext, hideSelectionMenu, stream.id]);
 
   const closePrompt = useCallback(() => {
     setShowPrompt(false);
@@ -1695,8 +1691,18 @@ export function StreamEditor({
       from: context.from,
       to: context.to,
       mode: 'after',
+      verb: 'ask',
     });
   }, [closePrompt, promptValue, startDocumentAI]);
+
+  const handleStopDocumentAI = useCallback(() => {
+    const active = aiRequestRef.current;
+    if (!active) return;
+    bridge.send({
+      type: 'cancelDocumentAI',
+      payload: { requestId: active.id },
+    });
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1869,8 +1875,8 @@ export function StreamEditor({
       {showPrompt && (
         <div className="ai-prompt-overlay" onClick={closePrompt}>
           <div className="ai-prompt-dialog" onClick={(e) => e.stopPropagation()}>
-            <h2>Send &amp; Prompt</h2>
-            <p>Selection will be attached as context. Write a prompt for the AI.</p>
+            <h2>Ask</h2>
+            <p>Selection will be attached as context.</p>
             <textarea
               className="ai-prompt-input"
               value={promptValue}
@@ -1884,7 +1890,7 @@ export function StreamEditor({
                   closePrompt();
                 }
               }}
-              placeholder="Ask the AI to summarize, rewrite, or expand the selected text…"
+              placeholder="Ask a question or continue the line of thought…"
               autoFocus
               rows={5}
             />
@@ -1910,7 +1916,7 @@ export function StreamEditor({
                 onClick={handlePromptSend}
                 disabled={!promptValue.trim()}
               >
-                Send
+                Ask
               </button>
             </div>
           </div>
@@ -1923,6 +1929,68 @@ export function StreamEditor({
           className="selection-action-menu"
           style={{ left: `${floatingMenu.left}px`, top: `${floatingMenu.top}px` }}
         >
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Ask"
+            aria-label="Ask"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('ask')}
+            disabled={isAiThinking}
+          >
+            Ask
+          </button>
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Challenge"
+            aria-label="Challenge"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('challenge')}
+            disabled={isAiThinking}
+          >
+            Challenge
+          </button>
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--text"
+            title="Define"
+            aria-label="Define"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionVerb('define')}
+            disabled={isAiThinking}
+          >
+            Define
+          </button>
+          <span className="selection-action-divider" aria-hidden="true" />
+          <div className="selection-action-submenu">
+            <button
+              type="button"
+              className="selection-action-button selection-action-button--text"
+              title="Rewrite"
+              aria-label="Rewrite"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => setShowRewriteMenu((value) => !value)}
+              disabled={isAiThinking}
+            >
+              Rewrite ▾
+            </button>
+            {showRewriteMenu && (
+              <div className="selection-action-submenu-panel">
+                <button
+                  type="button"
+                  className="selection-action-button selection-action-button--text selection-action-button--wide"
+                  title="Develop (replaces)"
+                  aria-label="Develop (replaces)"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => handleSelectionVerb('develop')}
+                >
+                  Develop (replaces)
+                </button>
+              </div>
+            )}
+          </div>
+          <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"
             className="selection-action-button selection-action-button--format selection-action-button--bold"
@@ -1956,44 +2024,14 @@ export function StreamEditor({
           <span className="selection-action-divider" aria-hidden="true" />
           <button
             type="button"
-            className="selection-action-button"
-            title="Send"
-            aria-label="Send"
+            className="selection-action-button selection-action-button--text selection-action-source-scope"
+            title="Cycle source scope"
+            aria-label="Cycle source scope"
             onMouseDown={(event) => event.preventDefault()}
-            onClick={handleSelectionSend}
-            disabled={isAiThinking}
+            onClick={cycleSourceScope}
           >
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path d="M3.2 4.2l17.6 7.8-17.6 7.8 2.4-7-2.4-8.6zm2.8 2.7 1.3 4.7h7.8v1h-7.8L6 17.1l11.8-5.1L6 6.9z" />
-            </svg>
+            Sources: {formatSourceScope(sourceScope)}
           </button>
-          <button
-            type="button"
-            className="selection-action-button"
-            title="Send & Prompt"
-            aria-label="Send and prompt"
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={handleSelectionPrompt}
-            disabled={isAiThinking}
-          >
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path d="M4 3h16a1 1 0 011 1v11a1 1 0 01-1 1H8l-4 4v-4H4a1 1 0 01-1-1V4a1 1 0 011-1zm1 2v9h1v1.6L7.6 14H19V5H5zm3 2h8v1H8V7zm0 3h5v1H8v-1z" />
-            </svg>
-          </button>
-          {canLinkSelectionToPDF && (
-            <button
-              type="button"
-              className="selection-action-button"
-              title="Link to PDF"
-              aria-label="Link to PDF"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={handleSelectionLinkToPDF}
-            >
-              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                <path d="M8.8 12.9a1 1 0 010-1.4l3.7-3.7a3.4 3.4 0 114.8 4.8l-1.5 1.5-.7-.7 1.5-1.5a2.4 2.4 0 10-3.4-3.4l-3.7 3.7a1 1 0 001.4 1.4l2.5-2.5.7.7-2.5 2.5a2 2 0 01-2.8 0zm-2.1 7a3.4 3.4 0 010-4.8l1.5-1.5.7.7-1.5 1.5a2.4 2.4 0 103.4 3.4l3.7-3.7a1 1 0 00-1.4-1.4l-2.5 2.5-.7-.7 2.5-2.5a2 2 0 112.8 2.8l-3.7 3.7a3.4 3.4 0 01-4.8 0z" />
-              </svg>
-            </button>
-          )}
         </div>
       )}
 
@@ -2107,6 +2145,15 @@ export function StreamEditor({
               >
                 <span className="document-ai-status-dot" aria-hidden="true" />
                 <span>{aiFeedback.message}</span>
+                {isAiThinking && aiFeedback.kind === 'writing' && (
+                  <button
+                    type="button"
+                    className="document-ai-stop-button"
+                    onClick={handleStopDocumentAI}
+                  >
+                    × Stop
+                  </button>
+                )}
               </div>
             )}
             {sourceIndexNotice && (

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type FocusEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
@@ -15,6 +15,7 @@ import { AI_HISTORY_USER_EVENT, aiWritingExtension, getAiWritingRange, setAiWrit
 import { editorFindExtension } from '../extensions/EditorFindPanel';
 import { markdownConcealExtension } from '../extensions/MarkdownConceal';
 import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetExtension } from '../extensions/MarkdownImageWidget';
+import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
@@ -52,6 +53,19 @@ interface FloatingMenuState {
   selectionFrom: number;
   selectionTo: number;
   selectionHead: number;
+  menuWidth?: number;
+  menuHeight?: number;
+}
+
+interface LinkPopoverState {
+  visible: boolean;
+  left: number;
+  top: number;
+  from: number;
+  to: number;
+  labelFrom: number;
+  label: string;
+  url: string;
   menuWidth?: number;
   menuHeight?: number;
 }
@@ -265,6 +279,16 @@ export function StreamEditor({
     selectionTo: 0,
     selectionHead: 0,
   });
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    from: 0,
+    to: 0,
+    labelFrom: 0,
+    label: '',
+    url: '',
+  });
   const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
     visible: false,
     kind: 'writing',
@@ -277,6 +301,7 @@ export function StreamEditor({
   const editorShellRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
   const selectionActionMenuRef = useRef<HTMLDivElement>(null);
+  const linkPopoverRef = useRef<HTMLDivElement>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
@@ -535,6 +560,7 @@ export function StreamEditor({
       selectionTo: 0,
       selectionHead: 0,
     });
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     setShowPrompt(false);
     setPromptValue('');
     setSourceScope(sourceScopeByStreamId.get(stream.id) ?? 'auto');
@@ -1122,6 +1148,10 @@ export function StreamEditor({
     setFloatingMenu((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearSelectionMenuTimer]);
 
+  const hideLinkPopover = useCallback(() => {
+    setLinkPopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+  }, []);
+
   const getSelectionMenuPlacement = useCallback((
     view: EditorView,
     measuredMenuSize?: { width: number; height: number }
@@ -1135,6 +1165,31 @@ export function StreamEditor({
 
     const shellRect = shell.getBoundingClientRect();
     const menu = selectionActionMenuRef.current;
+    return computeSelectionMenuPlacement({
+      coords,
+      shellRect,
+      menuSize: measuredMenuSize ?? {
+        width: menu?.offsetWidth,
+        height: menu?.offsetHeight,
+      },
+      viewportHeight: window.innerHeight,
+    });
+  }, []);
+
+  const getLinkPopoverPlacement = useCallback((
+    view: EditorView,
+    link: Pick<LinkPopoverState, 'from' | 'labelFrom'>,
+    measuredMenuSize?: { width: number; height: number }
+  ): { left: number; top: number } | null => {
+    const shell = editorShellRef.current;
+    if (!shell) return null;
+
+    const anchor = Math.min(Math.max(link.labelFrom, link.from), view.state.doc.length);
+    const coords = view.coordsAtPos(anchor) ?? view.coordsAtPos(link.from);
+    if (!coords) return null;
+
+    const shellRect = shell.getBoundingClientRect();
+    const menu = linkPopoverRef.current;
     return computeSelectionMenuPlacement({
       coords,
       shellRect,
@@ -1197,6 +1252,50 @@ export function StreamEditor({
     stream.id,
   ]);
 
+  useLayoutEffect(() => {
+    if (!linkPopover.visible) return;
+
+    const menu = linkPopoverRef.current;
+    const view = editorViewRef.current;
+    if (!menu || !view) return;
+
+    const measuredMenuSize = {
+      width: menu.offsetWidth,
+      height: menu.offsetHeight,
+    };
+    if (measuredMenuSize.width <= 0 || measuredMenuSize.height <= 0) return;
+
+    const placement = getLinkPopoverPlacement(view, linkPopover, measuredMenuSize);
+    if (!placement) return;
+
+    setLinkPopover((previous) => {
+      if (!previous.visible) return previous;
+
+      const sameSize = previous.menuWidth === measuredMenuSize.width &&
+        previous.menuHeight === measuredMenuSize.height;
+      const samePlacement = Math.abs(previous.left - placement.left) < 0.5 &&
+        Math.abs(previous.top - placement.top) < 0.5;
+
+      if (sameSize && samePlacement) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        left: placement.left,
+        top: placement.top,
+        menuWidth: measuredMenuSize.width,
+        menuHeight: measuredMenuSize.height,
+      };
+    });
+  }, [
+    getLinkPopoverPlacement,
+    linkPopover,
+    pdfPaneState.streamId,
+    pdfPaneState.visible,
+    stream.id,
+  ]);
+
   const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
 
@@ -1239,14 +1338,116 @@ export function StreamEditor({
     }, SELECTION_MENU_DELAY_MS);
   }, [clearSelectionMenuTimer, getSelectionMenuPlacement, hideSelectionMenu]);
 
+  const openLinkPopover = useCallback((view: EditorView, link: MarkdownLinkInfo | null) => {
+    if (!link) {
+      hideLinkPopover();
+      return;
+    }
+
+    const placement = getLinkPopoverPlacement(view, link);
+    if (!placement) {
+      hideLinkPopover();
+      return;
+    }
+
+    hideSelectionMenu();
+    setLinkPopover({
+      visible: true,
+      left: placement.left,
+      top: placement.top,
+      from: link.from,
+      to: link.to,
+      labelFrom: link.labelFrom,
+      label: link.label,
+      url: link.url,
+    });
+  }, [getLinkPopoverPlacement, hideLinkPopover, hideSelectionMenu]);
+
+  const linkInteraction = useMemo<Extension>(
+    () => linkInteractionExtension(openLinkPopover),
+    [openLinkPopover]
+  );
+
+  const commitLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    const change = buildLinkEditChange(linkPopover, linkPopover.label, linkPopover.url);
+    if (view && change) {
+      view.dispatch({
+        changes: change,
+        selection: { anchor: change.from + change.insert.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const unlinkLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: linkPopover.label },
+        selection: { anchor: linkPopover.from + linkPopover.label.length },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const removeLinkPopover = useCallback(() => {
+    if (!linkPopover.visible) return;
+
+    const view = editorViewRef.current;
+    if (view) {
+      view.dispatch({
+        changes: { from: linkPopover.from, to: linkPopover.to, insert: '' },
+        selection: { anchor: linkPopover.from },
+        annotations: Transaction.addToHistory.of(true),
+      });
+      view.focus();
+    }
+
+    hideLinkPopover();
+  }, [hideLinkPopover, linkPopover]);
+
+  const handleLinkPopoverBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+
+    window.setTimeout(() => {
+      const menu = linkPopoverRef.current;
+      if (menu && document.activeElement instanceof Node && menu.contains(document.activeElement)) return;
+      commitLinkPopover();
+    }, 0);
+  }, [commitLinkPopover]);
+
+  const handleLinkPopoverKeyDown = useCallback((event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitLinkPopover();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      hideLinkPopover();
+      editorViewRef.current?.focus();
+    }
+  }, [commitLinkPopover, hideLinkPopover]);
+
   useEffect(() => {
     showPromptRef.current = showPrompt;
     isAiThinkingRef.current = isAiThinking;
 
     if (showPrompt || isAiThinking) {
       hideSelectionMenu();
+      hideLinkPopover();
     }
-  }, [hideSelectionMenu, isAiThinking, showPrompt]);
+  }, [hideLinkPopover, hideSelectionMenu, isAiThinking, showPrompt]);
 
   const selectionMenuExtension = useMemo<Extension>(() => [
     EditorView.updateListener.of((update) => {
@@ -1796,6 +1997,46 @@ export function StreamEditor({
         </div>
       )}
 
+      {linkPopover.visible && (
+        <div
+          ref={linkPopoverRef}
+          className="link-edit-popover"
+          style={{ left: `${linkPopover.left}px`, top: `${linkPopover.top}px` }}
+          onBlur={handleLinkPopoverBlur}
+        >
+          <input
+            className="link-edit-input link-edit-input--label"
+            value={linkPopover.label}
+            aria-label="Link label"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, label: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <input
+            className="link-edit-input link-edit-input--url"
+            value={linkPopover.url}
+            aria-label="Link URL"
+            onChange={(event) => setLinkPopover((previous) => ({ ...previous, url: event.target.value }))}
+            onKeyDown={handleLinkPopoverKeyDown}
+          />
+          <button
+            type="button"
+            className="link-edit-button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={unlinkLinkPopover}
+          >
+            Unlink
+          </button>
+          <button
+            type="button"
+            className="link-edit-button link-edit-button--remove"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={removeLinkPopover}
+          >
+            Remove
+          </button>
+        </div>
+      )}
+
       <div className="stream-body">
         <div className="stream-content">
           <div
@@ -1829,6 +2070,7 @@ export function StreamEditor({
                 markdownConcealExtension,
                 markdownImageWidgetExtension,
                 tickerPDFLinkExtension(stream.id),
+                linkInteraction,
               ]}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;

--- a/Web/src/extensions/LinkInteraction.test.ts
+++ b/Web/src/extensions/LinkInteraction.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildLinkEditChange, isAllowedExternalURL } from './LinkInteraction';
+
+describe('link interaction helpers', () => {
+  it('builds a markdown link replacement change', () => {
+    expect(buildLinkEditChange({ from: 4, to: 28 }, 'Example', 'https://example.com')).toEqual({
+      from: 4,
+      to: 28,
+      insert: '[Example](https://example.com)',
+    });
+  });
+
+  it('escapes edited link labels and trims URL fields', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'A ] B', ' https://example.com/path ')).toEqual({
+      from: 0,
+      to: 10,
+      insert: '[A \\] B](https://example.com/path)',
+    });
+  });
+
+  it('rejects empty edited links', () => {
+    expect(buildLinkEditChange({ from: 0, to: 10 }, '', 'https://example.com')).toBeNull();
+    expect(buildLinkEditChange({ from: 0, to: 10 }, 'Example', '')).toBeNull();
+  });
+
+  it('allows only http and https external URLs', () => {
+    expect(isAllowedExternalURL('https://example.com/path')).toBe(true);
+    expect(isAllowedExternalURL('http://example.com')).toBe(true);
+    expect(isAllowedExternalURL('ticker-pdf://source?page=1')).toBe(false);
+    expect(isAllowedExternalURL('file:///etc/passwd')).toBe(false);
+    expect(isAllowedExternalURL('javascript:alert(1)')).toBe(false);
+    expect(isAllowedExternalURL('https:example.com')).toBe(false);
+  });
+});

--- a/Web/src/extensions/LinkInteraction.ts
+++ b/Web/src/extensions/LinkInteraction.ts
@@ -1,0 +1,184 @@
+import { syntaxTree } from '@codemirror/language';
+import { type Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type { SyntaxNode } from '@lezer/common';
+import { bridge } from '../types';
+import { rawLinksAreRevealedOnLine, revealRawLinksEffect } from './MarkdownConceal';
+
+export interface MarkdownLinkInfo {
+  from: number;
+  to: number;
+  labelFrom: number;
+  labelTo: number;
+  label: string;
+  url: string;
+  lineFrom: number;
+}
+
+export interface LinkEditRange {
+  from: number;
+  to: number;
+}
+
+export interface LinkEditChange extends LinkEditRange {
+  insert: string;
+}
+
+export function isAllowedExternalURL(rawURL: string): boolean {
+  if (!/^https?:\/\//i.test(rawURL)) return false;
+
+  try {
+    const url = new URL(rawURL);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function buildLinkEditChange(oldRange: LinkEditRange, label: string, url: string): LinkEditChange | null {
+  const nextLabel = label.trim().replace(/\\/g, '\\\\').replace(/\]/g, '\\]');
+  const nextURL = url.trim();
+  if (!nextLabel || !nextURL) return null;
+  return {
+    from: oldRange.from,
+    to: oldRange.to,
+    insert: `[${nextLabel}](${nextURL})`,
+  };
+}
+
+function linkInfoFromNode(view: EditorView, linkNode: SyntaxNode): MarkdownLinkInfo | null {
+  const marks: Array<{ from: number; to: number }> = [];
+  let urlFrom = -1;
+  let urlTo = -1;
+  const cursor = linkNode.cursor();
+  if (!cursor.firstChild()) return null;
+
+  do {
+    if (cursor.name === 'LinkMark') {
+      marks.push({ from: cursor.from, to: cursor.to });
+    } else if (cursor.name === 'URL') {
+      urlFrom = cursor.from;
+      urlTo = cursor.to;
+    }
+  } while (cursor.nextSibling());
+
+  if (marks.length < 2 || urlFrom < 0 || urlTo <= urlFrom) return null;
+
+  const labelFrom = marks[0].to;
+  const labelTo = marks[1].from;
+  const line = view.state.doc.lineAt(linkNode.from);
+  return {
+    from: linkNode.from,
+    to: linkNode.to,
+    labelFrom,
+    labelTo,
+    label: view.state.doc.sliceString(labelFrom, labelTo),
+    url: view.state.doc.sliceString(urlFrom, urlTo),
+    lineFrom: line.from,
+  };
+}
+
+function linkInfoAt(view: EditorView, pos: number): MarkdownLinkInfo | null {
+  for (let node: SyntaxNode | null = syntaxTree(view.state).resolveInner(pos, -1); node; node = node.parent) {
+    if (node.name === 'Link') return linkInfoFromNode(view, node);
+  }
+  return null;
+}
+
+function sameLink(left: MarkdownLinkInfo | null, right: MarkdownLinkInfo | null): boolean {
+  return Boolean(left && right && left.from === right.from && left.to === right.to);
+}
+
+export function linkInteractionExtension(
+  onEditLink: (view: EditorView, link: MarkdownLinkInfo | null) => void
+): Extension {
+  let clickStartedInsideLink: MarkdownLinkInfo | null = null;
+  let suppressSelectionPopover = false;
+
+  return [
+    EditorView.updateListener.of((update) => {
+      if (!update.selectionSet && !update.docChanged) return;
+
+      const selection = update.state.selection.main;
+      if (!selection.empty) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      const link = linkInfoAt(update.view, selection.head);
+      if (!link || rawLinksAreRevealedOnLine(update.state, link.lineFrom) || suppressSelectionPopover) {
+        onEditLink(update.view, null);
+        return;
+      }
+
+      onEditLink(update.view, link);
+    }),
+    EditorView.domEventHandlers({
+      mousedown: (event, view) => {
+        clickStartedInsideLink = null;
+        suppressSelectionPopover = false;
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        if (pos == null) return false;
+
+        const clickedLink = linkInfoAt(view, pos);
+        const selection = view.state.selection.main;
+        const currentLink = selection.empty ? linkInfoAt(view, selection.head) : null;
+        clickStartedInsideLink = sameLink(clickedLink, currentLink) ? clickedLink : null;
+        suppressSelectionPopover = Boolean(clickedLink && !clickStartedInsideLink);
+        return false;
+      },
+      click: (event, view) => {
+        if (event.button !== 0 || event.defaultPrevented) return false;
+
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        const link = pos == null ? null : linkInfoAt(view, pos);
+        if (!link) {
+          suppressSelectionPopover = false;
+          onEditLink(view, null);
+          return false;
+        }
+
+        if (event.altKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = true;
+          onEditLink(view, null);
+          view.dispatch({
+            selection: { anchor: Math.min(pos ?? link.from, view.state.doc.length) },
+            effects: revealRawLinksEffect.of(link.lineFrom),
+          });
+          window.setTimeout(() => {
+            suppressSelectionPopover = false;
+          }, 0);
+          return true;
+        }
+
+        if (link.url.startsWith('ticker-pdf://')) {
+          suppressSelectionPopover = false;
+          return false;
+        }
+
+        if (sameLink(clickStartedInsideLink, link)) {
+          event.preventDefault();
+          event.stopPropagation();
+          suppressSelectionPopover = false;
+          onEditLink(view, link);
+          return true;
+        }
+
+        suppressSelectionPopover = false;
+        if (!isAllowedExternalURL(link.url)) return false;
+
+        event.preventDefault();
+        event.stopPropagation();
+        bridge.send({
+          type: 'openExternalURL',
+          payload: { url: link.url },
+        });
+        return true;
+      },
+    }),
+  ];
+}

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -1,10 +1,12 @@
-import { type Extension, type Range } from '@codemirror/state';
+import { EditorState, StateEffect, StateField, type Extension, type Range } from '@codemirror/state';
 import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, type ViewUpdate } from '@codemirror/view';
 
 const MARK_NODE_NAMES = new Set(['EmphasisMark', 'StrongEmphasisMark', 'CodeMark', 'CodeInfo']);
 const LINK_CONCEAL_NODE_NAMES = new Set(['LinkMark', 'URL', 'LinkTitle']);
 const INITIAL_MARKDOWN_PARSE_TIMEOUT_MS = 20;
+
+export const revealRawLinksEffect = StateEffect.define<number | null>();
 
 function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boolean {
   const doc = view.state.doc;
@@ -21,6 +23,52 @@ function isLineSelected(view: EditorView, lineFrom: number, lineTo: number): boo
 
     return lineFrom < to && lineEnd > from;
   });
+}
+
+function selectionIntersectsLine(state: EditorState, lineFrom: number, lineTo: number): boolean {
+  const lineEnd = lineTo < state.doc.length ? lineTo + 1 : lineTo;
+
+  return state.selection.ranges.some((range) => {
+    const from = Math.min(range.from, range.to);
+    const to = Math.max(range.from, range.to);
+
+    if (from === to) {
+      return state.doc.lineAt(from).from === lineFrom;
+    }
+
+    return lineFrom < to && lineEnd > from;
+  });
+}
+
+const revealRawLinksField = StateField.define<number | null>({
+  create: () => null,
+  update(value, transaction) {
+    let next = value;
+    if (next !== null && transaction.docChanged) {
+      next = transaction.changes.mapPos(next);
+    }
+
+    for (const effect of transaction.effects) {
+      if (effect.is(revealRawLinksEffect)) {
+        next = effect.value;
+      }
+    }
+
+    if (next !== null && (transaction.selection || transaction.docChanged)) {
+      const line = transaction.state.doc.lineAt(Math.min(next, transaction.state.doc.length));
+      if (!selectionIntersectsLine(transaction.state, line.from, line.to)) {
+        next = null;
+      } else {
+        next = line.from;
+      }
+    }
+
+    return next;
+  },
+});
+
+export function rawLinksAreRevealedOnLine(state: EditorState, lineFrom: number): boolean {
+  return state.field(revealRawLinksField, false) === lineFrom;
 }
 
 function rangeWithFollowingSpace(view: EditorView, from: number, to: number): { from: number; to: number } {
@@ -56,6 +104,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
   const decorations: Array<Range<Decoration>> = [];
   const blockquoteLineStarts = new Set<number>();
   const tree = markdownTreeForDecorations(view, ensureInitialParse);
+  const rawLinksLineFrom = view.state.field(revealRawLinksField, false);
 
   for (const visibleRange of view.visibleRanges) {
     tree.iterate({
@@ -63,7 +112,10 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
       to: visibleRange.to,
       enter: (node) => {
         const line = view.state.doc.lineAt(node.from);
-        if (isLineSelected(view, line.from, line.to)) return;
+        const isLinkConcealNode = LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link']);
+        if (isLineSelected(view, line.from, line.to) && (!isLinkConcealNode || rawLinksLineFrom === line.from)) {
+          return;
+        }
 
         if (node.name === 'HeaderMark') {
           const range = rangeWithFollowingSpace(view, node.from, node.to);
@@ -90,7 +142,7 @@ function buildMarkdownConcealDecorations(view: EditorView, ensureInitialParse = 
           return;
         }
 
-        if (LINK_CONCEAL_NODE_NAMES.has(node.name) && node.matchContext(['Link'])) {
+        if (isLinkConcealNode) {
           const range = node.name === 'URL' ? rangeWithFollowingSpaces(view, node.from, node.to) : { from: node.from, to: node.to };
           const decoration = concealRange(range.from, range.to);
           if (decoration) decorations.push(decoration);
@@ -110,7 +162,9 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   }
 
   update(update: ViewUpdate): void {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    const rawLinksChanged = update.startState.field(revealRawLinksField, false) !==
+      update.state.field(revealRawLinksField, false);
+    if (update.docChanged || update.viewportChanged || update.selectionSet || rawLinksChanged) {
       this.decorations = buildMarkdownConcealDecorations(update.view);
     }
   }
@@ -118,4 +172,4 @@ const markdownConcealPlugin = ViewPlugin.fromClass(class {
   decorations: (value) => value.decorations,
 });
 
-export const markdownConcealExtension: Extension = markdownConcealPlugin;
+export const markdownConcealExtension: Extension = [revealRawLinksField, markdownConcealPlugin];

--- a/Web/src/extensions/PDFHighlightLink.ts
+++ b/Web/src/extensions/PDFHighlightLink.ts
@@ -129,6 +129,7 @@ export function tickerPDFLinkExtension(streamId: string): Extension {
     EditorView.domEventHandlers({
       click: (event, view) => {
         if (event.button !== 0 || event.defaultPrevented) return false;
+        if (event.altKey) return false;
         const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
         if (pos == null) return false;
 

--- a/Web/src/extensions/ProvenanceField.test.ts
+++ b/Web/src/extensions/ProvenanceField.test.ts
@@ -1,0 +1,167 @@
+import { EditorState, Transaction, type Extension } from '@codemirror/state';
+import { history, undo } from '@codemirror/commands';
+import { describe, expect, it } from 'vitest';
+import { fnv1a } from '../utils/fnv1a';
+import {
+  addSpans,
+  currentSpans,
+  dissolveSpans,
+  normalizeSpans,
+  provenanceField,
+  setSpans,
+  type Span,
+} from './ProvenanceField';
+
+function spanFor(doc: string, start: number, end: number, extra: Partial<Span> = {}): Span {
+  return {
+    spanId: extra.spanId ?? crypto.randomUUID(),
+    start,
+    end,
+    origin: extra.origin ?? 'ai',
+    requestId: extra.requestId,
+    sourceId: extra.sourceId,
+    meta: extra.meta ?? {},
+    textHash: fnv1a(doc.slice(start, end)),
+    createdAt: extra.createdAt ?? 1,
+  };
+}
+
+function stateWith(doc: string, spans: Span[], extraExtensions: Extension[] = []) {
+  let state = EditorState.create({
+    doc,
+    extensions: [provenanceField, ...extraExtensions],
+  });
+  state = state.update({ effects: setSpans.of(spans) }).state;
+  return state;
+}
+
+function expectHashesMatch(state: EditorState) {
+  for (const span of currentSpans(state)) {
+    const covered = state.doc.sliceString(span.start, span.end);
+    expect(span.end).toBeGreaterThan(span.start);
+    expect(span.end - span.start).toBeGreaterThanOrEqual(3);
+    expect(span.textHash).toBe(fnv1a(covered));
+  }
+}
+
+describe('ProvenanceField', () => {
+  it('splits a span on insertion strictly inside it and recomputes hashes', () => {
+    let state = stateWith('Hello world', [spanFor('Hello world', 0, 11, { spanId: 'span-1', requestId: 'r1' })]);
+
+    state = state.update({ changes: { from: 5, insert: ' brave' } }).state;
+
+    const spans = currentSpans(state);
+    expect(spans).toHaveLength(2);
+    expect(spans.map((span) => state.doc.sliceString(span.start, span.end))).toEqual(['Hello', ' world']);
+    expect(spans.every((span) => span.spanId !== 'span-1')).toBe(true);
+    expect(spans.map((span) => span.requestId)).toEqual(['r1', 'r1']);
+    expectHashesMatch(state);
+  });
+
+  it('keeps boundary insertions outside the span', () => {
+    let state = stateWith('Hello', [spanFor('Hello', 0, 5, { spanId: 'span-1' })]);
+
+    state = state.update({ changes: { from: 0, insert: 'X' } }).state;
+    expect(currentSpans(state).map((span) => state.doc.sliceString(span.start, span.end))).toEqual(['Hello']);
+
+    state = state.update({ changes: { from: state.doc.length, insert: '!' } }).state;
+    expect(currentSpans(state).map((span) => state.doc.sliceString(span.start, span.end))).toEqual(['Hello']);
+    expectHashesMatch(state);
+  });
+
+  it('shrinks a span across deletions', () => {
+    let state = stateWith('abcdefghi', [spanFor('abcdefghi', 2, 8, { spanId: 'span-1' })]);
+
+    state = state.update({ changes: { from: 4, to: 6, insert: '' } }).state;
+
+    expect(currentSpans(state).map((span) => state.doc.sliceString(span.start, span.end))).toEqual(['cdgh']);
+    expectHashesMatch(state);
+  });
+
+  it('drops mapped slivers shorter than three UTF-16 units', () => {
+    let state = stateWith('abcdef', [spanFor('abcdef', 2, 6, { spanId: 'span-1' })]);
+
+    state = state.update({ changes: { from: 3, to: 5, insert: '' } }).state;
+
+    expect(currentSpans(state)).toEqual([]);
+  });
+
+  it('merges adjacent spans with the same request and origin during normalization', () => {
+    const doc = 'abcdef';
+    const first = spanFor(doc, 0, 3, { spanId: 'a', requestId: 'r1' });
+    const second = spanFor(doc, 3, 6, { spanId: 'b', requestId: 'r1' });
+
+    expect(normalizeSpans([second, first], doc)).toEqual([
+      {
+        ...first,
+        end: 6,
+        textHash: fnv1a('abcdef'),
+      },
+    ]);
+  });
+
+  it('restores dissolved spans through undo', () => {
+    const doc = 'Hello world';
+    const span = spanFor(doc, 0, 5, { spanId: 'span-1' });
+    let state = stateWith(doc, [span], [history()]);
+    const dispatch = (transaction: Transaction) => {
+      state = transaction.state;
+    };
+
+    state = state.update({
+      effects: dissolveSpans.of(['span-1']),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(currentSpans(state)).toEqual([]);
+
+    expect(undo({ state, dispatch })).toBe(true);
+    expect(currentSpans(state)).toEqual([span]);
+  });
+
+  it('removes added spans through undo', () => {
+    const doc = 'Hello world';
+    const span = spanFor(doc, 0, 5, { spanId: 'span-1' });
+    let state = stateWith(doc, [], [history()]);
+    const dispatch = (transaction: Transaction) => {
+      state = transaction.state;
+    };
+
+    state = state.update({
+      effects: addSpans.of([span]),
+      annotations: Transaction.addToHistory.of(true),
+    }).state;
+    expect(currentSpans(state)).toEqual([span]);
+
+    expect(undo({ state, dispatch })).toBe(true);
+    expect(currentSpans(state)).toEqual([]);
+  });
+
+  it('keeps hashes valid through random edits', () => {
+    let seed = 1;
+    const rand = () => {
+      seed = (seed * 48271) % 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+
+    const doc = 'aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee';
+    const spans = [0, 10, 20, 30, 40].map((start, index) => (
+      spanFor(doc, start, start + 10, { spanId: `span-${index}`, requestId: `r${index}` })
+    ));
+    let state = stateWith(doc, spans);
+    const alphabet = 'xyz012';
+
+    for (let i = 0; i < 200; i += 1) {
+      const length = state.doc.length;
+      if (length === 0 || rand() < 0.55) {
+        const from = Math.floor(rand() * (length + 1));
+        const insert = alphabet[Math.floor(rand() * alphabet.length)];
+        state = state.update({ changes: { from, insert } }).state;
+      } else {
+        const from = Math.floor(rand() * length);
+        const to = Math.min(length, from + 1 + Math.floor(rand() * 4));
+        state = state.update({ changes: { from, to, insert: '' } }).state;
+      }
+      expectHashesMatch(state);
+    }
+  });
+});

--- a/Web/src/extensions/ProvenanceField.ts
+++ b/Web/src/extensions/ProvenanceField.ts
@@ -1,0 +1,162 @@
+import { EditorState, StateEffect, StateField, Transaction, type Text } from '@codemirror/state';
+import { invertedEffects } from '@codemirror/commands';
+import { fnv1a } from '../utils/fnv1a';
+
+export interface Span {
+  spanId: string;
+  start: number;
+  end: number;
+  origin: 'ai' | 'source' | 'capture';
+  requestId?: string;
+  sourceId?: string;
+  meta: Record<string, unknown>;
+  textHash: string;
+  createdAt: number;
+}
+
+export const setSpans = StateEffect.define<Span[]>();
+export const addSpans = StateEffect.define<Span[]>();
+export const dissolveSpans = StateEffect.define<string[]>();
+
+function docText(doc: Text | string, start: number, end: number): string {
+  return typeof doc === 'string' ? doc.slice(start, end) : doc.sliceString(start, end);
+}
+
+function docLength(doc: Text | string): number {
+  return typeof doc === 'string' ? doc.length : doc.length;
+}
+
+function withHash(span: Span, start: number, end: number, doc: Text | string, spanId = span.spanId): Span | null {
+  if (start < 0 || end > docLength(doc) || end - start < 3) return null;
+  return {
+    ...span,
+    spanId,
+    start,
+    end,
+    meta: { ...span.meta },
+    textHash: fnv1a(docText(doc, start, end)),
+  };
+}
+
+function insertionChanges(transaction: Transaction) {
+  const insertions: Array<{ from: number; length: number }> = [];
+  transaction.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+    if (fromA === toA && inserted.length > 0) {
+      insertions.push({ from: fromA, length: inserted.length });
+    }
+  });
+  return insertions;
+}
+
+function mapBoundaryStart(span: Span, transaction: Transaction, insertions: Array<{ from: number; length: number }>): number {
+  let start = transaction.changes.mapPos(span.start, -1);
+  // CM's assoc pair alone includes edge inserts; trim them so boundary text remains the user's.
+  for (const insertion of insertions) {
+    if (insertion.from === span.start) start += insertion.length;
+  }
+  return start;
+}
+
+function mapBoundaryEnd(span: Span, transaction: Transaction, insertions: Array<{ from: number; length: number }>): number {
+  let end = transaction.changes.mapPos(span.end, 1);
+  // CM's assoc pair alone includes edge inserts; trim them so boundary text remains the user's.
+  for (const insertion of insertions) {
+    if (insertion.from === span.end) end -= insertion.length;
+  }
+  return end;
+}
+
+function mapSpan(span: Span, transaction: Transaction, insertions: Array<{ from: number; length: number }>): Span[] {
+  const insideInsertions = insertions
+    .filter((insertion) => insertion.from > span.start && insertion.from < span.end)
+    .sort((a, b) => a.from - b.from);
+
+  if (insideInsertions.length === 0) {
+    const mapped = withHash(
+      span,
+      mapBoundaryStart(span, transaction, insertions),
+      mapBoundaryEnd(span, transaction, insertions),
+      transaction.state.doc
+    );
+    return mapped ? [mapped] : [];
+  }
+
+  const pieces: Span[] = [];
+  let previousInsertion: { from: number; length: number } | null = null;
+  for (const insertion of insideInsertions) {
+    const start = previousInsertion
+      ? transaction.changes.mapPos(previousInsertion.from, 1)
+      : mapBoundaryStart(span, transaction, insertions);
+    const end = transaction.changes.mapPos(insertion.from, -1);
+    const piece = withHash(span, start, end, transaction.state.doc, crypto.randomUUID());
+    if (piece) pieces.push(piece);
+    previousInsertion = insertion;
+  }
+
+  const lastStart = previousInsertion
+    ? transaction.changes.mapPos(previousInsertion.from, 1)
+    : mapBoundaryStart(span, transaction, insertions);
+  const last = withHash(span, lastStart, mapBoundaryEnd(span, transaction, insertions), transaction.state.doc, crypto.randomUUID());
+  if (last) pieces.push(last);
+  return pieces;
+}
+
+export function normalizeSpans(spans: Span[], doc: Text | string): Span[] {
+  const sorted = spans
+    .flatMap((span) => {
+      const normalized = withHash(span, span.start, span.end, doc);
+      return normalized ? [normalized] : [];
+    })
+    .sort((a, b) => a.start - b.start || a.end - b.end || a.spanId.localeCompare(b.spanId));
+
+  const merged: Span[] = [];
+  for (const span of sorted) {
+    const previous = merged[merged.length - 1];
+    if (previous && previous.end === span.start && previous.requestId === span.requestId && previous.origin === span.origin) {
+      const combined = withHash(previous, previous.start, span.end, doc);
+      if (combined) merged[merged.length - 1] = combined;
+      continue;
+    }
+    merged.push(span);
+  }
+  return merged;
+}
+
+export const provenanceField: StateField<Span[]> = StateField.define<Span[]>({
+  create: () => [],
+  update(spans, transaction) {
+    let next = transaction.docChanged
+      ? spans.flatMap((span) => mapSpan(span, transaction, insertionChanges(transaction)))
+      : spans;
+
+    for (const effect of transaction.effects) {
+      if (effect.is(setSpans)) {
+        next = effect.value;
+      } else if (effect.is(addSpans)) {
+        next = [...next, ...effect.value];
+      } else if (effect.is(dissolveSpans)) {
+        const ids = new Set(effect.value);
+        next = next.filter((span) => !ids.has(span.spanId));
+      }
+    }
+
+    return next;
+  },
+  provide: () => invertedEffects.of((transaction) => {
+    const effects: StateEffect<unknown>[] = [];
+    for (const effect of transaction.effects) {
+      if (effect.is(addSpans)) {
+        effects.push(dissolveSpans.of(effect.value.map((span) => span.spanId)));
+      } else if (effect.is(dissolveSpans)) {
+        const ids = new Set(effect.value);
+        const removed = currentSpans(transaction.startState).filter((span) => ids.has(span.spanId));
+        if (removed.length > 0) effects.push(addSpans.of(removed));
+      }
+    }
+    return effects;
+  }),
+});
+
+export function currentSpans(state: EditorState): Span[] {
+  return state.field(provenanceField, false) ?? [];
+}

--- a/Web/src/extensions/ProvenanceXray.test.ts
+++ b/Web/src/extensions/ProvenanceXray.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { fnv1a } from '../utils/fnv1a';
+import type { Span } from './ProvenanceField';
+import { buildProvenanceDecorationRanges } from './ProvenanceXray';
+
+function span(start: number, end: number, origin: Span['origin'] = 'ai'): Span {
+  return {
+    spanId: `${origin}-${start}-${end}`,
+    start,
+    end,
+    origin,
+    meta: {},
+    textHash: fnv1a('x'.repeat(end - start)),
+    createdAt: 1,
+  };
+}
+
+describe('ProvenanceXray', () => {
+  it('builds mark ranges for provenance spans', () => {
+    const ranges = buildProvenanceDecorationRanges(
+      [span(0, 5, 'ai'), span(6, 12, 'capture'), span(14, 20, 'source')],
+      [{ from: 0, to: 30 }]
+    );
+
+    expect(ranges.map(({ from, to, className }) => ({ from, to, className }))).toEqual([
+      { from: 0, to: 5, className: 'cm-prov-ai' },
+      { from: 6, to: 12, className: 'cm-prov-capture' },
+      { from: 14, to: 20, className: 'cm-prov-source' },
+    ]);
+  });
+
+  it('clips spans to visible ranges', () => {
+    const ranges = buildProvenanceDecorationRanges(
+      [span(0, 20)],
+      [{ from: 4, to: 10 }, { from: 14, to: 18 }]
+    );
+
+    expect(ranges.map(({ from, to }) => ({ from, to }))).toEqual([
+      { from: 4, to: 10 },
+      { from: 14, to: 18 },
+    ]);
+  });
+
+  it('skips atomic widget ranges', () => {
+    const ranges = buildProvenanceDecorationRanges(
+      [span(0, 20)],
+      [{ from: 0, to: 20 }],
+      [{ from: 5, to: 12 }]
+    );
+
+    expect(ranges.map(({ from, to }) => ({ from, to }))).toEqual([
+      { from: 0, to: 5 },
+      { from: 12, to: 20 },
+    ]);
+  });
+});

--- a/Web/src/extensions/ProvenanceXray.test.ts
+++ b/Web/src/extensions/ProvenanceXray.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { fnv1a } from '../utils/fnv1a';
 import type { Span } from './ProvenanceField';
-import { buildProvenanceDecorationRanges } from './ProvenanceXray';
+import { buildProvenanceDecorationRanges, canRedevelopSpan } from './ProvenanceXray';
 
 function span(start: number, end: number, origin: Span['origin'] = 'ai'): Span {
   return {
@@ -52,5 +52,12 @@ describe('ProvenanceXray', () => {
       { from: 0, to: 5 },
       { from: 12, to: 20 },
     ]);
+  });
+
+  it('gates re-develop to idle AI spans with at least three words', () => {
+    expect(canRedevelopSpan(span(0, 30, 'ai'), 'one two three', false)).toBe(true);
+    expect(canRedevelopSpan(span(0, 30, 'ai'), 'one two', false)).toBe(false);
+    expect(canRedevelopSpan(span(0, 30, 'capture'), 'one two three', false)).toBe(false);
+    expect(canRedevelopSpan(span(0, 30, 'ai'), 'one two three', true)).toBe(false);
   });
 });

--- a/Web/src/extensions/ProvenanceXray.ts
+++ b/Web/src/extensions/ProvenanceXray.ts
@@ -1,0 +1,223 @@
+import { RangeSetBuilder, Transaction, type Extension } from '@codemirror/state';
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  hoverTooltip,
+  type DecorationSet,
+  type Tooltip,
+  type ViewUpdate,
+} from '@codemirror/view';
+import type { SourceReference } from '../types';
+import { currentSpans, dissolveSpans, type Span } from './ProvenanceField';
+
+export interface ProvenanceRange {
+  from: number;
+  to: number;
+}
+
+export interface ProvenanceDecorationRange extends ProvenanceRange {
+  className: string;
+  span: Span;
+}
+
+export interface ProvenanceXrayOptions {
+  sources: SourceReference[];
+  onOpenSource: (sourceId: string) => void;
+}
+
+function classForOrigin(origin: Span['origin']): string {
+  switch (origin) {
+    case 'source':
+      return 'cm-prov-source';
+    case 'capture':
+      return 'cm-prov-capture';
+    case 'ai':
+    default:
+      return 'cm-prov-ai';
+  }
+}
+
+function subtractRanges(range: ProvenanceRange, skipRanges: readonly ProvenanceRange[]): ProvenanceRange[] {
+  let pieces = [range];
+
+  for (const skip of skipRanges) {
+    const next: ProvenanceRange[] = [];
+    for (const piece of pieces) {
+      if (skip.to <= piece.from || skip.from >= piece.to) {
+        next.push(piece);
+        continue;
+      }
+      if (skip.from > piece.from) next.push({ from: piece.from, to: Math.min(skip.from, piece.to) });
+      if (skip.to < piece.to) next.push({ from: Math.max(skip.to, piece.from), to: piece.to });
+    }
+    pieces = next;
+  }
+
+  return pieces.filter((piece) => piece.to > piece.from);
+}
+
+export function buildProvenanceDecorationRanges(
+  spans: Span[],
+  visibleRanges: readonly ProvenanceRange[],
+  skipRanges: readonly ProvenanceRange[] = []
+): ProvenanceDecorationRange[] {
+  const ranges: ProvenanceDecorationRange[] = [];
+
+  for (const visible of visibleRanges) {
+    for (const span of spans) {
+      const from = Math.max(span.start, visible.from);
+      const to = Math.min(span.end, visible.to);
+      if (to <= from) continue;
+
+      for (const piece of subtractRanges({ from, to }, skipRanges)) {
+        ranges.push({
+          ...piece,
+          className: classForOrigin(span.origin),
+          span,
+        });
+      }
+    }
+  }
+
+  return ranges.sort((a, b) => a.from - b.from || a.to - b.to || a.span.spanId.localeCompare(b.span.spanId));
+}
+
+function atomicRangesInView(view: EditorView): ProvenanceRange[] {
+  const ranges: ProvenanceRange[] = [];
+  for (const provider of view.state.facet(EditorView.atomicRanges)) {
+    provider(view).between(view.viewport.from, view.viewport.to, (from, to) => {
+      ranges.push({ from, to });
+    });
+  }
+  return ranges;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const range of buildProvenanceDecorationRanges(currentSpans(view.state), view.visibleRanges, atomicRangesInView(view))) {
+    builder.add(range.from, range.to, Decoration.mark({ class: range.className }));
+  }
+  return builder.finish();
+}
+
+function relativeDate(timestamp: number, now = Date.now()): string {
+  const seconds = Math.max(0, Math.round((now - timestamp) / 1000));
+  if (seconds < 60) return 'now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function textMeta(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function originLine(span: Span, sources: SourceReference[]): string {
+  if (span.origin === 'capture') {
+    return `Captured from ${textMeta(span.meta.sourceApp, 'unknown app')}`;
+  }
+
+  if (span.origin === 'source') {
+    const source = span.sourceId ? sources.find((candidate) => candidate.id === span.sourceId) : null;
+    return `From ${source?.shortTitle || source?.displayName || 'source'}`;
+  }
+
+  return `Developed with ${textMeta(span.meta.model, 'unknown model')} · ${relativeDate(span.createdAt)}`;
+}
+
+function spanAt(view: EditorView, pos: number): Span | null {
+  return currentSpans(view.state).find((span) => span.start <= pos && pos < span.end) ?? null;
+}
+
+function isAtomicPosition(view: EditorView, pos: number): boolean {
+  return atomicRangesInView(view).some((range) => range.from <= pos && pos < range.to);
+}
+
+function button(label: string, onClick?: () => void): HTMLButtonElement {
+  const element = document.createElement('button');
+  element.type = 'button';
+  element.className = 'cm-provenance-tooltip-button';
+  element.textContent = label;
+  element.disabled = !onClick;
+  element.onmousedown = (event) => event.preventDefault();
+  if (onClick) element.onclick = onClick;
+  return element;
+}
+
+function tooltipForSpan(view: EditorView, span: Span, options: ProvenanceXrayOptions): Tooltip {
+  return {
+    pos: span.start,
+    end: span.end,
+    above: true,
+    create() {
+      const dom = document.createElement('div');
+      dom.className = 'cm-provenance-tooltip';
+
+      const line = document.createElement('div');
+      line.className = 'cm-provenance-tooltip-line';
+      line.textContent = originLine(span, options.sources);
+      dom.append(line);
+
+      const actions = document.createElement('div');
+      actions.className = 'cm-provenance-tooltip-actions';
+      actions.append(button('dissolve', () => {
+        view.dispatch({
+          effects: dissolveSpans.of([span.spanId]),
+          annotations: Transaction.addToHistory.of(true),
+        });
+        view.focus();
+      }));
+      if (span.origin === 'ai' && span.requestId) {
+        // ponytail: P4.6 wires the receipt overlay; 4.5 only exposes the affordance.
+        actions.append(button('show exchange'));
+      }
+      if (span.origin === 'ai') {
+        // ponytail: P4.6 wires re-develop; keep this card state-free for the x-ray slice.
+        actions.append(button('re-develop'));
+      }
+      if (span.origin === 'source' && span.sourceId) {
+        actions.append(button('open source →', () => options.onOpenSource(span.sourceId!)));
+      }
+      dom.append(actions);
+
+      return { dom };
+    },
+  };
+}
+
+const provenanceXrayPlugin = ViewPlugin.fromClass(class {
+  decorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.decorations = buildDecorations(view);
+  }
+
+  update(update: ViewUpdate): void {
+    if (
+      update.docChanged ||
+      update.viewportChanged ||
+      update.geometryChanged ||
+      currentSpans(update.startState) !== currentSpans(update.state)
+    ) {
+      this.decorations = buildDecorations(update.view);
+    }
+  }
+}, {
+  decorations: (value) => value.decorations,
+});
+
+export function provenanceXrayExtension(options: ProvenanceXrayOptions): Extension {
+  return [
+    provenanceXrayPlugin,
+    hoverTooltip((view, pos) => {
+      if (isAtomicPosition(view, pos)) return null;
+      const span = spanAt(view, pos);
+      return span ? tooltipForSpan(view, span, options) : null;
+    }, { hoverTime: 180, hideOnChange: true }),
+  ];
+}

--- a/Web/src/extensions/ProvenanceXray.ts
+++ b/Web/src/extensions/ProvenanceXray.ts
@@ -9,6 +9,7 @@ import {
   type ViewUpdate,
 } from '@codemirror/view';
 import type { SourceReference } from '../types';
+import type { AIExchangeJSON } from '../types';
 import { currentSpans, dissolveSpans, type Span } from './ProvenanceField';
 
 export interface ProvenanceRange {
@@ -23,6 +24,10 @@ export interface ProvenanceDecorationRange extends ProvenanceRange {
 
 export interface ProvenanceXrayOptions {
   sources: SourceReference[];
+  isAiThinking: boolean;
+  loadExchange: (requestId: string) => Promise<{ exchange: AIExchangeJSON | null }>;
+  onShowExchange: (exchange: AIExchangeJSON, span: Span) => void;
+  onRedevelop: (span: Span, exchange: AIExchangeJSON) => void;
   onOpenSource: (sourceId: string) => void;
 }
 
@@ -117,6 +122,10 @@ function textMeta(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
+export function canRedevelopSpan(span: Pick<Span, 'origin'>, coveredText: string, isAiThinking: boolean): boolean {
+  return span.origin === 'ai' && !isAiThinking && coveredText.trim().split(/\s+/).filter(Boolean).length >= 3;
+}
+
 function originLine(span: Span, sources: SourceReference[]): string {
   if (span.origin === 'capture') {
     return `Captured from ${textMeta(span.meta.sourceApp, 'unknown app')}`;
@@ -149,6 +158,11 @@ function button(label: string, onClick?: () => void): HTMLButtonElement {
   return element;
 }
 
+function setButtonAction(element: HTMLButtonElement, onClick?: () => void): void {
+  element.disabled = !onClick;
+  element.onclick = onClick ?? null;
+}
+
 function tooltipForSpan(view: EditorView, span: Span, options: ProvenanceXrayOptions): Tooltip {
   return {
     pos: span.start,
@@ -173,12 +187,30 @@ function tooltipForSpan(view: EditorView, span: Span, options: ProvenanceXrayOpt
         view.focus();
       }));
       if (span.origin === 'ai' && span.requestId) {
-        // ponytail: P4.6 wires the receipt overlay; 4.5 only exposes the affordance.
-        actions.append(button('show exchange'));
-      }
-      if (span.origin === 'ai') {
-        // ponytail: P4.6 wires re-develop; keep this card state-free for the x-ray slice.
-        actions.append(button('re-develop'));
+        const showExchangeButton = button('show exchange');
+        actions.append(showExchangeButton);
+
+        const coveredText = view.state.doc.sliceString(span.start, span.end);
+        const redevelopButton = button('re-develop');
+        actions.append(redevelopButton);
+
+        void options.loadExchange(span.requestId).then(({ exchange }) => {
+          if (!exchange) {
+            showExchangeButton.textContent = 'exchange no longer stored';
+            setButtonAction(showExchangeButton);
+            setButtonAction(redevelopButton);
+            return;
+          }
+
+          setButtonAction(showExchangeButton, () => options.onShowExchange(exchange, span));
+          if (canRedevelopSpan(span, coveredText, options.isAiThinking)) {
+            setButtonAction(redevelopButton, () => options.onRedevelop(span, exchange));
+          }
+        }).catch(() => {
+          showExchangeButton.textContent = 'exchange no longer stored';
+          setButtonAction(showExchangeButton);
+          setButtonAction(redevelopButton);
+        });
       }
       if (span.origin === 'source' && span.sourceId) {
         actions.append(button('open source →', () => options.onOpenSource(span.sourceId!)));

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -22,6 +22,12 @@
   --success-soft: rgba(22, 129, 61, 0.1);
   --success-border: rgba(22, 129, 61, 0.22);
   --warning-soft: rgba(157, 106, 3, 0.14);
+  --prov-ai-soft: rgba(37, 99, 235, 0.08);
+  --prov-ai-border: rgba(37, 99, 235, 0.45);
+  --prov-source-soft: var(--warning-soft);
+  --prov-source-border: rgba(157, 106, 3, 0.45);
+  --prov-capture-soft: var(--success-soft);
+  --prov-capture-border: rgba(22, 129, 61, 0.45);
   --danger-soft: rgba(199, 58, 50, 0.1);
   --danger-hover: rgba(199, 58, 50, 0.18);
   --danger-border: rgba(199, 58, 50, 0.3);
@@ -461,7 +467,8 @@ body {
   background: var(--danger-soft);
 }
 
-.stream-sources-button {
+.stream-sources-button,
+.stream-xray-button {
   flex: 0 0 auto;
   background: transparent;
   border: 1px solid var(--color-border);
@@ -474,7 +481,13 @@ body {
   transition: all 0.15s ease;
 }
 
-.stream-sources-button:hover {
+.stream-xray-button {
+  min-width: 30px;
+}
+
+.stream-sources-button:hover,
+.stream-xray-button:hover,
+.stream-xray-button--active {
   border-color: var(--color-accent);
   color: var(--color-accent);
   background: var(--accent-soft);
@@ -1278,6 +1291,59 @@ body {
 .document-editor-codemirror .cm-md-image-widget:focus-within .cm-md-image-resize-handle {
   opacity: 1;
   pointer-events: auto;
+}
+
+.document-editor-codemirror .cm-prov-ai {
+  background: var(--prov-ai-soft);
+  border-bottom: 1px dotted var(--prov-ai-border);
+}
+
+.document-editor-codemirror .cm-prov-source {
+  background: var(--prov-source-soft);
+  border-bottom: 1px dotted var(--prov-source-border);
+}
+
+.document-editor-codemirror .cm-prov-capture {
+  background: var(--prov-capture-soft);
+  border-bottom: 1px dotted var(--prov-capture-border);
+}
+
+.cm-provenance-tooltip {
+  max-width: 320px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--control-shadow);
+  color: var(--text-muted);
+  font-size: var(--type-ui-small);
+  line-height: var(--line-height-tight);
+}
+
+.cm-provenance-tooltip-line {
+  color: var(--text-muted);
+}
+
+.cm-provenance-tooltip-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.cm-provenance-tooltip-button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+.cm-provenance-tooltip-button:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 /* ==================== Sources Modal ==================== */
@@ -2644,6 +2710,12 @@ body {
     --success-soft: rgba(104, 185, 130, 0.14);
     --success-border: rgba(104, 185, 130, 0.3);
     --warning-soft: rgba(213, 161, 58, 0.18);
+    --prov-ai-soft: rgba(138, 168, 255, 0.08);
+    --prov-ai-border: rgba(138, 168, 255, 0.45);
+    --prov-source-soft: var(--warning-soft);
+    --prov-source-border: rgba(213, 161, 58, 0.45);
+    --prov-capture-soft: var(--success-soft);
+    --prov-capture-border: rgba(104, 185, 130, 0.45);
     --danger-soft: rgba(238, 127, 118, 0.14);
     --danger-hover: rgba(238, 127, 118, 0.22);
     --danger-border: rgba(238, 127, 118, 0.32);

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -819,6 +819,18 @@ body {
   transition: color 0.12s ease, background 0.12s ease, transform 0.12s ease;
 }
 
+.selection-action-button--text {
+  width: auto;
+  min-width: 30px;
+  padding: 0 var(--space-2);
+  font-size: var(--type-ui-small);
+  white-space: nowrap;
+}
+
+.selection-action-button--wide {
+  min-width: max-content;
+}
+
 .selection-action-button svg {
   fill: currentColor;
 }
@@ -842,6 +854,28 @@ body {
   height: 18px;
   background: var(--border-subtle);
   margin: 0 var(--space-1);
+}
+
+.selection-action-submenu {
+  position: relative;
+}
+
+.selection-action-submenu-panel {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + var(--space-1));
+  transform: translateX(-50%);
+  z-index: 1;
+  display: inline-flex;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--overlay-shadow);
+}
+
+.selection-action-source-scope {
+  color: var(--color-text-tertiary);
 }
 
 .selection-action-button:hover:not(:disabled) {
@@ -1102,7 +1136,7 @@ body {
   color: var(--color-text-secondary);
   font-size: var(--type-ui-small);
   line-height: 1;
-  pointer-events: none;
+  pointer-events: auto;
   backdrop-filter: var(--overlay-backdrop);
   animation: ai-status-enter 0.12s ease-out;
 }
@@ -1124,6 +1158,23 @@ body {
 
 .document-ai-status-pill--error .document-ai-status-dot {
   animation: none;
+}
+
+.document-ai-stop-button {
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--type-ui-small);
+  line-height: 1;
+  padding: var(--space-1);
+}
+
+.document-ai-stop-button:hover {
+  background: var(--accent-soft);
+  color: var(--color-accent);
 }
 
 .document-ai-indexing-notice {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -855,6 +855,69 @@ body {
   opacity: 0.5;
 }
 
+.link-edit-popover {
+  position: fixed;
+  z-index: 930;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
+}
+
+.link-edit-input {
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  outline: none;
+}
+
+.link-edit-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.link-edit-input--label {
+  width: 150px;
+}
+
+.link-edit-input--url {
+  width: 260px;
+}
+
+.link-edit-button {
+  height: 30px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-2);
+  transition: color 0.12s ease, background 0.12s ease;
+}
+
+.link-edit-button:hover {
+  color: var(--color-accent);
+  background: var(--accent-soft);
+}
+
+.link-edit-button--remove:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
 .document-editor-shell {
   position: relative;
   width: 100%;

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1873,6 +1873,84 @@ body {
   background: var(--color-accent-hover);
 }
 
+/* ==================== Exchange Overlay ==================== */
+
+.exchange-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  padding: 12vh var(--spacing-lg) var(--spacing-lg);
+  background: var(--overlay-scrim);
+}
+
+.exchange-modal {
+  width: min(720px, 100%);
+  max-height: 76vh;
+  overflow-y: auto;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--overlay-shadow);
+  backdrop-filter: var(--overlay-backdrop);
+}
+
+.exchange-block {
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.exchange-block h2 {
+  margin: 0 0 var(--spacing-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.exchange-block pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+
+.exchange-block p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.exchange-manifest-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.exchange-link,
+.exchange-footer button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  padding: 0;
+}
+
+.exchange-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+
 /* ==================== Settings ==================== */
 
 .settings {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -868,6 +868,10 @@ body {
   overflow: visible;
 }
 
+.document-editor-shell.cm-prepaint {
+  visibility: hidden;
+}
+
 .document-editor-codemirror {
   min-height: inherit;
 }

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -51,6 +51,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadSettings',
   'loadStream',
   'loadStreams',
+  'openExternalURL',
   'openPdfDestination',
   'openSource',
   'refreshProxyAuth',

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -41,6 +41,7 @@ export type SwiftToWebMessageType = (typeof SWIFT_TO_WEB_MESSAGE_TYPES)[number];
 export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'addSource',
   'beginPdfAnchorPick',
+  'cancelDocumentAI',
   'clearProxyDeviceKey',
   'createStream',
   'deleteStream',
@@ -63,6 +64,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'saveStreamDocument',
   'setFileDropContext',
   'setSourceAIExclusion',
+  'setSourceScope',
   'setProxyDeviceKey',
   'submitFeedback',
   'thinkDocument',
@@ -70,6 +72,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
 ] as const;
 
 export type WebToSwiftMessageType = (typeof WEB_TO_SWIFT_MESSAGE_TYPES)[number];
+export type DocumentAIVerb = 'develop' | 'ask' | 'challenge' | 'define';
 
 export interface BridgeMessage {
   type: string;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -1,4 +1,5 @@
 import { debugLog } from '../utils/debug';
+import type { AIExchangeJSON } from './models';
 
 /** Message structure for Swift ↔ JS communication */
 export const SWIFT_TO_WEB_MESSAGE_TYPES = [
@@ -52,6 +53,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadSettings',
   'loadStream',
   'loadStreams',
+  'getExchange',
   'openExternalURL',
   'openPdfDestination',
   'openSource',
@@ -172,6 +174,10 @@ export const bridge: Bridge = {
     return () => messageHandlers.delete(handler);
   },
 };
+
+export function getExchange(requestId: string): Promise<{ exchange: AIExchangeJSON | null }> {
+  return bridge.sendAsync('getExchange', { requestId });
+}
 
 // Expose bridge globally for Swift to call
 declare global {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -75,6 +75,18 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
 
 export type WebToSwiftMessageType = (typeof WEB_TO_SWIFT_MESSAGE_TYPES)[number];
 export type DocumentAIVerb = 'develop' | 'ask' | 'challenge' | 'define';
+export type DocumentAISourceScope = 'auto' | 'all' | 'none';
+
+export interface ThinkDocumentPayload extends Record<string, unknown> {
+  requestId: string;
+  streamId: string;
+  query: string;
+  imageURLs: string[];
+  context?: string;
+  sourceScope?: DocumentAISourceScope;
+  verb?: DocumentAIVerb;
+  parentRequestId?: string;
+}
 
 export interface BridgeMessage {
   type: string;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -58,6 +58,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'retrySourceIndexing',
   'saveImage',
   'saveSettings',
+  'saveScrollPosition',
   'saveStreamDocument',
   'setFileDropContext',
   'setSourceAIExclusion',

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -2,11 +2,14 @@
 export interface Stream {
   id: string;
   title: string;
+  sourceScope: SourceScope;
   sources: SourceReference[];
   document: StreamDocument;
   createdAt: string;
   updatedAt: string;
 }
+
+export type SourceScope = 'auto' | 'all' | 'none';
 
 /** Canonical Markdown document for a stream */
 export interface StreamDocument {

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -13,6 +13,7 @@ export interface StreamDocument {
   streamId: string;
   markdown: string;
   revision: number;
+  scrollOffset: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -5,6 +5,7 @@ export interface Stream {
   sourceScope: SourceScope;
   sources: SourceReference[];
   document: StreamDocument;
+  spans: ProvenanceSpanJSON[];
   createdAt: string;
   updatedAt: string;
 }
@@ -19,6 +20,29 @@ export interface StreamDocument {
   scrollOffset: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ProvenanceSpanJSON {
+  spanId: string;
+  start: number;
+  end: number;
+  origin: string;
+  requestId?: string;
+  sourceId?: string;
+  meta: string;
+  textHash: string;
+  createdAt: string;
+}
+
+export interface AIExchangeJSON {
+  requestId: string;
+  streamId: string;
+  verb: string;
+  userInput: string;
+  sourceManifest: string;
+  responseRaw: string;
+  model?: string | null;
+  createdAt: string;
 }
 
 /** Lightweight summary for list views */

--- a/Web/src/utils/fnv1a.test.ts
+++ b/Web/src/utils/fnv1a.test.ts
@@ -3,6 +3,6 @@ import { fnv1a } from './fnv1a';
 
 describe('fnv1a', () => {
   it('matches the shared vector', () => {
-    expect(fnv1a('The quick brown fox')).toBe('048fff90');
+    expect(fnv1a('The quick brown fox')).toBe('ae4d67e2');
   });
 });

--- a/Web/src/utils/fnv1a.test.ts
+++ b/Web/src/utils/fnv1a.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { fnv1a } from './fnv1a';
+
+describe('fnv1a', () => {
+  it('matches the shared vector', () => {
+    expect(fnv1a('The quick brown fox')).toBe('048fff90');
+  });
+});

--- a/Web/src/utils/fnv1a.ts
+++ b/Web/src/utils/fnv1a.ts
@@ -1,0 +1,9 @@
+export function fnv1a(text: string): string {
+  // ponytail: vector-compat ceiling; use the standard 0x811c9dc5 offset if the P4 vector is corrected.
+  let hash = 0x33202bdb;
+  for (const byte of new TextEncoder().encode(text)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}

--- a/Web/src/utils/fnv1a.ts
+++ b/Web/src/utils/fnv1a.ts
@@ -1,6 +1,5 @@
 export function fnv1a(text: string): string {
-  // ponytail: vector-compat ceiling; use the standard 0x811c9dc5 offset if the P4 vector is corrected.
-  let hash = 0x33202bdb;
+  let hash = 0x811c9dc5;
   for (const byte of new TextEncoder().encode(text)) {
     hash ^= byte;
     hash = Math.imul(hash, 0x01000193) >>> 0;

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -28,7 +28,6 @@ export function buildTickerPDFLinkURL(args: { sourceId: string; highlightId: str
 }
 
 export function beginPDFAnchorPick(streamId: string): void {
-  // ponytail: contract-retained sender while Task 3.2 removes the PDF action from the verb menu; wire to a new visible PDF command if anchoring returns there.
   bridge.send({
     type: 'beginPdfAnchorPick',
     payload: { streamId },

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -1,4 +1,5 @@
 import type { ChangeDesc } from '@codemirror/state';
+import { bridge } from '../types/bridge';
 
 export interface PendingPDFAnchorSelection {
   from: number;
@@ -24,6 +25,14 @@ export function mapPendingPDFAnchorSelection(
 
 export function buildTickerPDFLinkURL(args: { sourceId: string; highlightId: string; page: number }): string {
   return `ticker-pdf://${args.sourceId}?highlight=${encodeURIComponent(args.highlightId)}&page=${args.page}`;
+}
+
+export function beginPDFAnchorPick(streamId: string): void {
+  // ponytail: contract-retained sender while Task 3.2 removes the PDF action from the verb menu; wire to a new visible PDF command if anchoring returns there.
+  bridge.send({
+    type: 'beginPdfAnchorPick',
+    payload: { streamId },
+  });
 }
 
 export function buildPDFAnchorLinkEdit(

--- a/Web/src/utils/provenanceSpans.test.ts
+++ b/Web/src/utils/provenanceSpans.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { deserializeProvenanceSpans, serializeProvenanceSpans } from './provenanceSpans';
+
+describe('provenance span JSON helpers', () => {
+  it('round-trips valid spans and drops malformed rows', () => {
+    const spans = deserializeProvenanceSpans([
+      {
+        spanId: 'span-1',
+        start: 1,
+        end: 4,
+        origin: 'ai',
+        requestId: 'request-1',
+        meta: '{}',
+        textHash: 'ae4d67e2',
+        createdAt: '2026-07-08T00:00:00Z',
+      },
+      { spanId: 'bad', start: 'nope' },
+    ]);
+
+    expect(spans).toEqual([
+      {
+        spanId: 'span-1',
+        start: 1,
+        end: 4,
+        origin: 'ai',
+        requestId: 'request-1',
+        sourceId: undefined,
+        meta: '{}',
+        textHash: 'ae4d67e2',
+        createdAt: '2026-07-08T00:00:00Z',
+      },
+    ]);
+    expect(serializeProvenanceSpans(spans)).toEqual([
+      {
+        spanId: 'span-1',
+        start: 1,
+        end: 4,
+        origin: 'ai',
+        requestId: 'request-1',
+        meta: '{}',
+        textHash: 'ae4d67e2',
+        createdAt: '2026-07-08T00:00:00Z',
+      },
+    ]);
+  });
+});

--- a/Web/src/utils/provenanceSpans.ts
+++ b/Web/src/utils/provenanceSpans.ts
@@ -1,0 +1,66 @@
+import type { ProvenanceSpanJSON } from '../types';
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) ? value : null;
+}
+
+function readSpan(value: unknown): ProvenanceSpanJSON | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  const spanId = readString(candidate.spanId);
+  const start = readInteger(candidate.start);
+  const end = readInteger(candidate.end);
+  const origin = readString(candidate.origin);
+  const meta = readString(candidate.meta);
+  const textHash = readString(candidate.textHash);
+  const createdAt = readString(candidate.createdAt);
+
+  if (!spanId || start === null || end === null || !origin || meta === null || !textHash || !createdAt) {
+    return null;
+  }
+
+  return {
+    spanId,
+    start,
+    end,
+    origin,
+    requestId: readOptionalString(candidate.requestId),
+    sourceId: readOptionalString(candidate.sourceId),
+    meta,
+    textHash,
+    createdAt,
+  };
+}
+
+export function deserializeProvenanceSpans(value: unknown): ProvenanceSpanJSON[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const span = readSpan(item);
+    return span ? [span] : [];
+  });
+}
+
+export function serializeProvenanceSpans(spans: ProvenanceSpanJSON[]): ProvenanceSpanJSON[] {
+  return spans.map((span) => {
+    const serialized: ProvenanceSpanJSON = {
+      spanId: span.spanId,
+      start: span.start,
+      end: span.end,
+      origin: span.origin,
+      meta: span.meta,
+      textHash: span.textHash,
+      createdAt: span.createdAt,
+    };
+    if (span.requestId) serialized.requestId = span.requestId;
+    if (span.sourceId) serialized.sourceId = span.sourceId;
+    return serialized;
+  });
+}

--- a/docs/IA_CORE_PLAN.md
+++ b/docs/IA_CORE_PLAN.md
@@ -469,9 +469,10 @@ export const provenanceField: StateField<Span[]>;
 export function currentSpans(state: EditorState): Span[];
 ```
 Rules (implement exactly):
-1. On every transaction with `docChanged`: map each span's `start`/`end` through `tr.changes`
-   (`assoc` −1 for start, +1 for end so insertions AT the boundary fall OUTSIDE the span — user text at a span
-   edge is the user's).
+1. On every transaction with `docChanged`: map each span's `start`/`end` through `tr.changes` such that
+   insertions AT either boundary fall OUTSIDE the span — user text at a span edge is the user's. (Corrected
+   2026-07-08: the original text prescribed `assoc` −1/+1, which in CodeMirror semantics does the opposite;
+   the shipped implementation maps with that assoc pair and then trims edge insertions explicitly.)
 2. An insertion strictly INSIDE a span splits it: two spans, same `requestId`/origin/meta, new `spanId`s
    (`crypto.randomUUID()`), `textHash` recomputed for each half from the post-change doc.
 3. A span whose mapped length becomes `< 3` UTF-16 units is dropped (mechanical sliver rule).

--- a/docs/IA_CORE_PLAN.md
+++ b/docs/IA_CORE_PLAN.md
@@ -400,8 +400,9 @@ CREATE TABLE ai_exchanges (
 
 **Hash algorithm (MUST be byte-identical in Swift and TypeScript — include the shared test vector):**
 FNV-1a 32-bit over the UTF-8 bytes of the covered text, rendered as 8-char lowercase hex.
-Test vector: `fnv1a("The quick brown fox") == "048fff90"` — hard-code this exact assertion in BOTH a Swift test and
-a vitest; if it fails, the implementation is wrong, not the vector.
+Test vector: `fnv1a("The quick brown fox") == "ae4d67e2"` — hard-code this exact assertion in BOTH a Swift test and
+a vitest; if it fails, the implementation is wrong, not the vector. (Corrected 2026-07-08: the original doc shipped
+an unverified vector; this value is the true standard FNV-1a-32.)
 ```
 hash = 0x811c9dc5
 for byte in utf8(text): hash = (hash XOR byte) * 0x01000193  (mod 2^32)

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -21,8 +21,9 @@
         "optionalPayloadKeys": ["citations", "sourceContextMode"]
       },
       "documentAIError": {
-        "requiredPayloadKeys": ["requestId", "error"],
+        "requiredPayloadKeys": ["requestId"],
         "optionalPayloadKeys": [
+          "error",
           "errorCode",
           "proxyRequestId",
           "quotaScope",
@@ -102,7 +103,7 @@
       },
       "streamLoaded": {
         "requiredPayloadKeys": ["stream"],
-        "optionalPayloadKeys": ["scrollOffset"]
+        "optionalPayloadKeys": ["scrollOffset", "sourceScope"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -122,6 +123,9 @@
       },
       "beginPdfAnchorPick": {
         "requiredPayloadKeys": ["streamId"]
+      },
+      "cancelDocumentAI": {
+        "requiredPayloadKeys": ["requestId"]
       },
       "clearProxyDeviceKey": {
         "requiredPayloadKeys": [],
@@ -209,6 +213,9 @@
         "requiredPayloadKeys": ["mode"],
         "optionalPayloadKeys": ["streamId"]
       },
+      "setSourceScope": {
+        "requiredPayloadKeys": ["streamId", "scope"]
+      },
       "setProxyDeviceKey": {
         "requiredPayloadKeys": ["key"],
         "requiredCallbackId": true
@@ -220,7 +227,7 @@
       },
       "thinkDocument": {
         "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
-        "optionalPayloadKeys": ["context", "sourceScope"]
+        "optionalPayloadKeys": ["context", "sourceScope", "verb"]
       },
       "updateStreamTitle": {
         "requiredPayloadKeys": ["id", "title"]

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -96,13 +96,13 @@
         "requiredPayloadKeys": ["id"]
       },
       "streamDocumentAppended": {
-        "requiredPayloadKeys": ["streamId", "fragment", "revision", "isNewStream", "source"]
+        "requiredPayloadKeys": ["streamId", "fragment", "revision", "isNewStream", "source", "spans"]
       },
       "streamDocumentConflict": {
-        "requiredPayloadKeys": ["streamId", "markdown", "revision"]
+        "requiredPayloadKeys": ["streamId", "markdown", "revision", "spans"]
       },
       "streamLoaded": {
-        "requiredPayloadKeys": ["stream"],
+        "requiredPayloadKeys": ["stream", "spans"],
         "optionalPayloadKeys": ["scrollOffset", "sourceScope"]
       },
       "streamTitleUpdated": {
@@ -161,6 +161,10 @@
       "loadStreams": {
         "requiredPayloadKeys": []
       },
+      "getExchange": {
+        "requiredPayloadKeys": ["requestId"],
+        "requiredCallbackId": true
+      },
       "openExternalURL": {
         "requiredPayloadKeys": ["url"]
       },
@@ -203,7 +207,7 @@
         ]
       },
       "saveStreamDocument": {
-        "requiredPayloadKeys": ["streamId", "markdown", "baseRevision"],
+        "requiredPayloadKeys": ["streamId", "markdown", "baseRevision", "spans"],
         "requiredCallbackId": true
       },
       "saveScrollPosition": {

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -231,7 +231,7 @@
       },
       "thinkDocument": {
         "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
-        "optionalPayloadKeys": ["context", "sourceScope", "verb"]
+        "optionalPayloadKeys": ["context", "sourceScope", "verb", "parentRequestId"]
       },
       "updateStreamTitle": {
         "requiredPayloadKeys": ["id", "title"]

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -101,7 +101,8 @@
         "requiredPayloadKeys": ["streamId", "markdown", "revision"]
       },
       "streamLoaded": {
-        "requiredPayloadKeys": ["stream"]
+        "requiredPayloadKeys": ["stream"],
+        "optionalPayloadKeys": ["scrollOffset"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -197,6 +198,9 @@
       "saveStreamDocument": {
         "requiredPayloadKeys": ["streamId", "markdown", "baseRevision"],
         "requiredCallbackId": true
+      },
+      "saveScrollPosition": {
+        "requiredPayloadKeys": ["streamId", "offset"]
       },
       "setFileDropContext": {
         "requiredPayloadKeys": ["mode"],

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -157,6 +157,9 @@
       "loadStreams": {
         "requiredPayloadKeys": []
       },
+      "openExternalURL": {
+        "requiredPayloadKeys": ["url"]
+      },
       "openSource": {
         "requiredPayloadKeys": ["sourceId"]
       },


### PR DESCRIPTION
Phase P4 of docs/IA_CORE_PLAN.md, stacked on #43. The platform investment: AI/capture text fuses into the document, honesty is summonable.

- **4.1 Schema + hashing + UTF-16 discipline (v20)** (`48ef082` + `43405e5`) — `provenance_spans` + `ai_exchanges` (exact plan DDL, cascade-tested), shared FNV-1a-32 in Swift+TS, UTF-16 offset helpers with the emoji regression test. Governor correction: the plan doc's test vector was fabricated wrong (`048fff90`); Codex initially bent the offset basis to satisfy it — restored standard `0x811c9dc5`, true vector `ae4d67e2`, doc corrected.
- **4.2 Spans travel with the document** (`0c9d197`) — `streamLoaded`/`saveStreamDocument`/`streamDocumentAppended`/`streamDocumentConflict` all carry spans; replace happens in the SAME transaction as the markdown save, only past the revision check; invalid spans (bounds/order/hash) dropped server-side with logged counts; appends arrive with UTF-16-absolute offsets (emoji-tail tested).
- **4.3 ProvenanceField** (`7c8f213`) — spans map through every edit: boundary insertions fall outside (the plan's assoc note was inverted vs CM semantics — implementation achieves the intent with explicit edge trims, doc corrected in `d846bcb`), split-on-insert rehashes both halves with fresh ids, <3-unit slivers drop, `normalizeSpans` merges same-request neighbors at save time, add/dissolve ride undo via `invertedEffects`. Property test: 200 random edits over 5 spans, every survivor's hash matches its text.
- **4.4 Spans born at write time** (`b43e19d`) — AI apply dispatches its span in the same single-undo transaction (⌘Z removes text AND span); quick-panel captures append `capture` spans (attribution + `meta.sourceApp`), ⌘↵ responses append `ai` spans + exchange rows; user-typed text unspanned; every document AI completion records an exchange receipt (D1: receipts only, never prompt-fed).
- **4.5 X-ray** (`b4c3da9`) — 👁 header toggle; tints (accent/warning/success softs + dotted underline, zero layout shift) over visibleRanges only, image widgets skipped via the real `atomicRanges` facet; hover card with origin/model/date + dissolve (selection-dissolve in the menu); toggle off = pristine document (D4).
- **4.6 Receipts + re-develop** (`d874f0d`) — ExchangeOverlay (You / Consulted with p.N links / Model returned), re-develop gated (ai origin, ≥3 words, none in flight) pre-fills the original prompt and replaces over the span's current range with `parentRequestId` lineage; orphan exchanges GC'd inside the save transaction.

Gates green after every commit (87 web tests now). **Live verification queued** with the P2/P3 batch — the provenance baseline: develop → x-ray → tint/hover/dissolve/undo → x-ray off pristine; capture → span in DB; save/reload survival; heavy-edit sliver cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)