### PR TITLE
Quick-panel AI presence indicator + settings model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Quick Panel AI answers now show presence in the open editor: the AI-writing pill plus a typing indicator pinned to the exact spot where the answer will land.
+- Settings now offers a model choice — Balanced (GPT-5 mini), Fast (GPT-4o mini), or Claude — with web search available on the OpenAI options.
 - Search-vs-knowledge routing now uses Apple's on-device foundation model when available (macOS 26 + Apple Intelligence), with the keyword gate as fallback.
 - Provenance x-ray now tints each AI exchange with its own color variant so neighboring exchanges read as distinct, and the exchange overlay gained a proper title bar with a close button.
 - Selection menu now offers heading (H1/H2/H3), quote, and bullet-list toggles, and a new stream-editor footer has a "Show formatting" switch that reveals the raw markdown document-wide.

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -989,6 +989,13 @@ final class QuickPanelManager: ObservableObject {
         var responseMarkdown = ""
         var selectedModel: String?
 
+        // Tell the editor work is in flight so it can show presence at the
+        // append point. Every terminal path below appends (answer or error
+        // fragment), so streamDocumentAppended doubles as the "done" signal.
+        bridgeService?.send(BridgeMessage(type: "quickPanelAIStarted", payload: [
+            "streamId": AnyCodable(streamId.uuidString)
+        ]))
+
         documentAITasks[taskId] = Task { [weak self] in
             await orchestrator.route(
                 query: prompt,

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -83,7 +83,7 @@ final class ProxyLLMService {
         let messages = buildProxyMessages(from: request)
         let provider = determineProvider(for: request)
         let requestBody: [String: Any] = [
-            "model": "default",  // Let proxy resolve model based on provider + vision
+            "model": SettingsService.shared.defaultModel.proxyModel,
             "messages": messages,
             "provider": provider,
             "stream": true
@@ -334,7 +334,7 @@ final class ProxyLLMService {
             ["role": "user", "content": input]
         ]
         let requestBody: [String: Any] = [
-            "model": "default",
+            "model": SettingsService.shared.defaultModel.proxyModel,
             "messages": messages,
             "provider": provider,
             "stream": false
@@ -483,12 +483,7 @@ final class ProxyLLMService {
 
     /// Determine which provider to use based on user settings (preference hint for proxy)
     private func determineProvider(for request: LLMRequest) -> String {
-        switch SettingsService.shared.defaultModel {
-        case .openai:
-            return "openai"
-        case .anthropic:
-            return "anthropic"
-        }
+        SettingsService.shared.defaultModel.provider
     }
 
     // MARK: - SSE Event Handling

--- a/Sources/Ticker/Services/SettingsService.swift
+++ b/Sources/Ticker/Services/SettingsService.swift
@@ -46,7 +46,24 @@ final class SettingsService {
 
     enum DefaultModel: String {
         case openai = "openai"
+        case openaiFast = "openaiFast"
         case anthropic = "anthropic"
+
+        /// Proxy provider name for this choice.
+        var provider: String {
+            switch self {
+            case .openai, .openaiFast: return "openai"
+            case .anthropic: return "anthropic"
+            }
+        }
+
+        /// Explicit model to request, or "default" to use the proxy's default.
+        var proxyModel: String {
+            switch self {
+            case .openai, .anthropic: return "default"
+            case .openaiFast: return "gpt-4o-mini"
+            }
+        }
     }
 
     enum EditorFont: String {

--- a/Web/src/components/Settings.tsx
+++ b/Web/src/components/Settings.tsx
@@ -5,7 +5,7 @@ import { useToastStore } from '../store/toastStore';
 import { debugError } from '../utils/debug';
 
 type Appearance = 'light' | 'dark' | 'system';
-type DefaultModel = 'openai' | 'anthropic';
+type DefaultModel = 'openai' | 'openaiFast' | 'anthropic';
 type EditorFont = 'systemSans' | 'humanistSans' | 'monoSans';
 
 interface SettingsData {
@@ -545,8 +545,17 @@ export function Settings({ onClose }: SettingsProps) {
                   applySettingsPatch({ defaultModel: 'openai' });
                 }}
               >
-                <span className="settings-model-name">OpenAI</span>
-                <span className="settings-model-detail">GPT-4o</span>
+                <span className="settings-model-name">Balanced</span>
+                <span className="settings-model-detail">GPT-5 mini · searches the web</span>
+              </button>
+              <button
+                className={`settings-model-btn ${settings.defaultModel === 'openaiFast' ? 'settings-model-btn--active' : ''}`}
+                onClick={() => {
+                  applySettingsPatch({ defaultModel: 'openaiFast' });
+                }}
+              >
+                <span className="settings-model-name">Fast</span>
+                <span className="settings-model-detail">GPT-4o mini · searches the web</span>
               </button>
               <button
                 className={`settings-model-btn ${settings.defaultModel === 'anthropic' ? 'settings-model-btn--active' : ''}`}
@@ -554,12 +563,13 @@ export function Settings({ onClose }: SettingsProps) {
                   applySettingsPatch({ defaultModel: 'anthropic' });
                 }}
               >
-                <span className="settings-model-name">Anthropic</span>
-                <span className="settings-model-detail">Claude Sonnet</span>
+                <span className="settings-model-name">Claude</span>
+                <span className="settings-model-detail">Sonnet · no live web access</span>
               </button>
             </div>
             <p className="settings-hint">
-              Select the default AI provider for responses (requests are routed through Ticker Proxy).
+              Which model answers AI requests (routed through Ticker Proxy). OpenAI models can
+              search the web when a question needs current information.
             </p>
           </div>
         </section>

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -21,6 +21,7 @@ import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } 
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
 import { canRedevelopSpan, provenanceXrayExtension } from '../extensions/ProvenanceXray';
+import { pendingAppendField, setPendingAppend } from '../extensions/PendingAppend';
 import {
   buildPromoteMarginNoteEdit,
   currentMarginNotes,
@@ -543,6 +544,8 @@ export function StreamEditor({
   const sourceIndexStatusesRef = useRef<Map<string, SourceReference['indexStatus']>>(new Map());
   const showPromptRef = useRef(showPrompt);
   const isAiThinkingRef = useRef(false);
+  const quickPanelPendingRef = useRef(false);
+  const quickPanelPendingTimerRef = useRef<number | null>(null);
   const aiRequestRef = useRef<{
     id: string;
     buffer: string;
@@ -690,6 +693,21 @@ export function StreamEditor({
     setAiFeedback((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [clearAiFeedbackTimer]);
 
+  const clearQuickPanelPending = useCallback(() => {
+    if (quickPanelPendingTimerRef.current !== null) {
+      window.clearTimeout(quickPanelPendingTimerRef.current);
+      quickPanelPendingTimerRef.current = null;
+    }
+    if (!quickPanelPendingRef.current) return;
+    quickPanelPendingRef.current = false;
+    editorViewRef.current?.dispatch({
+      effects: setPendingAppend.of(false),
+      annotations: Transaction.addToHistory.of(false),
+    });
+    // Don't stomp the pill if an in-editor AI request is also running.
+    if (!aiRequestRef.current) hideAiFeedback();
+  }, [hideAiFeedback]);
+
   const showAiErrorFeedback = useCallback((message: string) => {
     clearAiFeedbackTimer();
     setAiFeedback({
@@ -834,6 +852,7 @@ export function StreamEditor({
     setSaveState('saved');
     setAiStatus('idle');
     hideAiFeedback();
+    clearQuickPanelPending();
     clearSourceIndexNoticeTimer();
     setSourceIndexNotice(null);
     setFloatingMenu({
@@ -878,7 +897,7 @@ export function StreamEditor({
       persistNewUnanchoredMarginNotes(stream.marginNotes, notes);
       dispatchAiRangeClear(view);
     }
-  }, [clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.spans, stream.title]);
+  }, [clearQuickPanelPending, clearSourceIndexNoticeTimer, hideAiFeedback, stream.id, stream.document?.markdown, stream.document?.revision, stream.sourceScope, stream.spans, stream.title]);
 
   useEffect(() => {
     applyMarginNotesToEditor(stream.marginNotes);
@@ -945,6 +964,27 @@ export function StreamEditor({
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
+      if (message.type === 'quickPanelAIStarted') {
+        if (message.payload?.streamId !== stream.id) return;
+        const view = editorViewRef.current;
+        if (!view) return;
+        quickPanelPendingRef.current = true;
+        view.dispatch({
+          effects: [
+            setPendingAppend.of(true),
+            EditorView.scrollIntoView(view.state.doc.length, { y: 'nearest' }),
+          ],
+          annotations: Transaction.addToHistory.of(false),
+        });
+        showAiWritingFeedback();
+        if (quickPanelPendingTimerRef.current !== null) {
+          window.clearTimeout(quickPanelPendingTimerRef.current);
+        }
+        // Fallback: proxy idle timeout is 120s; never leave the indicator stranded.
+        quickPanelPendingTimerRef.current = window.setTimeout(clearQuickPanelPending, 130_000);
+        return;
+      }
+
       if (message.type === 'streamDocumentConflict') {
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const markdown = message.payload?.markdown as string | undefined;
@@ -984,6 +1024,10 @@ export function StreamEditor({
         if (!payloadStreamId || payloadStreamId !== stream.id || typeof fragment !== 'string' || fragment.length === 0) {
           return;
         }
+
+        // An append landing (answer or error fragment) ends any pending
+        // quick-panel AI presence.
+        clearQuickPanelPending();
 
         // Revision gap = this editor missed an earlier append (it wasn't
         // listening when it broadcast). Patching the fragment in and adopting
@@ -1243,7 +1287,7 @@ export function StreamEditor({
     });
 
     return () => unsubscribe();
-  }, [addToast, hideAiFeedback, showAiErrorFeedback, stream.id]);
+  }, [addToast, clearQuickPanelPending, hideAiFeedback, showAiErrorFeedback, showAiWritingFeedback, stream.id]);
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
@@ -2772,6 +2816,7 @@ export function StreamEditor({
                 arrivalField,
                 provenanceField,
                 marginNotesField,
+                pendingAppendField,
                 markdownImageWidgetExtension,
                 provenanceXray,
                 marginNotesExtensionValue,

--- a/Web/src/extensions/PendingAppend.test.ts
+++ b/Web/src/extensions/PendingAppend.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { pendingAppendField, pendingAppendIsShown, setPendingAppend } from './PendingAppend';
+
+function stateWithDoc(doc: string): EditorState {
+  return EditorState.create({ doc, extensions: [pendingAppendField] });
+}
+
+describe('PendingAppend', () => {
+  it('shows the indicator at doc end and clears it', () => {
+    let state = stateWithDoc('hello');
+    expect(pendingAppendIsShown(state)).toBe(false);
+
+    state = state.update({ effects: setPendingAppend.of(true) }).state;
+    expect(pendingAppendIsShown(state)).toBe(true);
+
+    let position = -1;
+    state.field(pendingAppendField).between(0, state.doc.length, (from) => {
+      position = from;
+    });
+    expect(position).toBe(state.doc.length);
+
+    state = state.update({ effects: setPendingAppend.of(false) }).state;
+    expect(pendingAppendIsShown(state)).toBe(false);
+  });
+
+  it('re-pins the indicator to the doc end when the document changes', () => {
+    let state = stateWithDoc('hello');
+    state = state.update({ effects: setPendingAppend.of(true) }).state;
+    state = state.update({ changes: { from: state.doc.length, insert: ' world' } }).state;
+
+    let position = -1;
+    state.field(pendingAppendField).between(0, state.doc.length, (from) => {
+      position = from;
+    });
+    expect(position).toBe(state.doc.length);
+  });
+});

--- a/Web/src/extensions/PendingAppend.ts
+++ b/Web/src/extensions/PendingAppend.ts
@@ -1,0 +1,54 @@
+import { StateEffect, StateField } from '@codemirror/state';
+import { Decoration, EditorView, WidgetType, type DecorationSet } from '@codemirror/view';
+
+/**
+ * Typing-indicator ghost line at the end of the document: shown while a
+ * quick-panel AI answer is in flight, at the exact spot where it will land.
+ * Communicates *where* text will arrive, not just that the app is busy.
+ */
+export const setPendingAppend = StateEffect.define<boolean>();
+
+class TypingIndicatorWidget extends WidgetType {
+  toDOM(): HTMLElement {
+    const line = document.createElement('div');
+    line.className = 'cm-pending-append';
+    line.setAttribute('aria-label', 'AI is writing');
+    for (let i = 0; i < 3; i += 1) {
+      const dot = document.createElement('span');
+      dot.className = 'cm-pending-append-dot';
+      line.appendChild(dot);
+    }
+    return line;
+  }
+
+  override eq(): boolean {
+    return true;
+  }
+}
+
+function indicatorAt(pos: number): DecorationSet {
+  return Decoration.set([
+    Decoration.widget({ widget: new TypingIndicatorWidget(), side: 1, block: true }).range(pos),
+  ]);
+}
+
+export const pendingAppendField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(decorations, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setPendingAppend)) {
+        return effect.value ? indicatorAt(tr.newDoc.length) : Decoration.none;
+      }
+    }
+    // The indicator marks the append point; keep it pinned to the doc end.
+    if (tr.docChanged && decorations.size > 0) {
+      return indicatorAt(tr.newDoc.length);
+    }
+    return decorations;
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+export function pendingAppendIsShown(state: { field(f: typeof pendingAppendField): DecorationSet }): boolean {
+  return state.field(pendingAppendField).size > 0;
+}

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1537,6 +1537,42 @@ body {
   border-top: 1px solid var(--border-subtle);
 }
 
+/* Typing indicator at the append point while quick-panel AI is in flight */
+.cm-pending-append {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) 0;
+}
+
+.cm-pending-append-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  opacity: 0.3;
+  animation: pending-append-pulse 1.2s ease-in-out infinite;
+}
+
+.cm-pending-append-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.cm-pending-append-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes pending-append-pulse {
+  0%, 100% {
+    opacity: 0.25;
+    transform: none;
+  }
+  50% {
+    opacity: 0.9;
+    transform: translateY(-1px);
+  }
+}
+
 .cm-margin-notes-layer {
   position: absolute;
   inset: 0;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -20,6 +20,7 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
   'imageSaved',
   'marginNotesChanged',
   'proxyAuthState',
+  'quickPanelAIStarted',
   'pdfAnchorPickCancelled',
   'pdfAnchorPlaced',
   'pdfHighlightLinked',

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -79,6 +79,9 @@
       "proxyAuthState": {
         "requiredPayloadKeys": ["state"]
       },
+      "quickPanelAIStarted": {
+        "requiredPayloadKeys": ["streamId"]
+      },
       "settingsLoaded": {
         "requiredPayloadKeys": ["settings"]
       },


### PR DESCRIPTION
## Summary
- Quick Panel ⌘↵ now announces itself to the open editor: `quickPanelAIStarted {streamId}` bridge message triggers the AI-writing pill plus a pulsing typing indicator pinned to the doc end where the answer will land. Cleared by the append (answer or error), stream switch, or a 130s fallback.
- Settings model picker: Balanced (GPT-5 mini via proxy default), Fast (explicit gpt-4o-mini), Claude (anthropic provider). `DefaultModel` gained `provider`/`proxyModel` computed properties consumed by ProxyLLMService.

## Testing
- All six gates green (build-dev, swift-test, typecheck, vitest, web build, contract checker).
- Live-verified by Niko: pill + dots appear during quick-panel AI, model switching reflected in proxy logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)