### PR TITLE
AI polish: Claude coming soon, animated quick-panel dots, standalone answers, Cmd-B/Cmd-I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- ⌘B and ⌘I now toggle bold and italic on the stream editor selection.
 - Quick Panel AI answers now show presence in the open editor: the AI-writing pill plus a typing indicator pinned to the exact spot where the answer will land.
 - Settings now offers a model choice — Balanced (GPT-5 mini), Fast (GPT-4o mini), or Claude — with web search available on the OpenAI options.
 - Search-vs-knowledge routing now uses Apple's on-device foundation model when available (macOS 26 + Apple Intelligence), with the keyword gate as fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- AI answers now fold the question's substance into their opening sentence so saved passages read complete on their own.
 - The Claude model option is now marked "Coming soon"; AI requests route to the OpenAI models until it ships.
 - Document AI now biases toward the only attached large source when a question has weak but present lexical overlap.
 - Document AI now uses local source retrieval for large source sets instead of concatenating every source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- The Claude model option is now marked "Coming soon"; AI requests route to the OpenAI models until it ships.
 - Document AI now biases toward the only attached large source when a question has weak but present lexical overlap.
 - Document AI now uses local source retrieval for large source sets instead of concatenating every source.
 - Main window chrome is now transparent, with content inset around the floating traffic-light controls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Quick Panel typing dots now pulse while waiting for the first AI chunk instead of sitting static.
 - Bug reports no longer falsely claim the previous session crashed after an app auto-update.
 - Quick Panel now avoids copying an editor cursor line when Accessibility reports that no text is selected.
 - Debug builds now use a distinct bundle id and display name so they do not share the release app's macOS permission identity.

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -530,14 +530,8 @@ struct QuickPanelView: View {
 
             if manager.ephemeralConversation.currentResponse.isEmpty {
                 // Typing indicator when waiting for first chunk
-                HStack(spacing: QuickPanelStyle.typingDotSize) {
-                    ForEach(0..<3, id: \.self) { _ in
-                        Circle()
-                            .fill(QuickPanelStyle.textSubtle)
-                            .frame(width: QuickPanelStyle.typingDotSize, height: QuickPanelStyle.typingDotSize)
-                    }
-                }
-                .padding(.vertical, Spacing.xs)
+                TypingDotsView()
+                    .padding(.vertical, Spacing.xs)
             } else {
                 HStack(alignment: .bottom, spacing: 0) {
                     Text(verbatim: manager.ephemeralConversation.currentResponse)
@@ -1000,6 +994,31 @@ class QuickPanelTextView: NSTextView {
         }
 
         super.keyDown(with: event)
+    }
+}
+
+// MARK: - Typing Indicator
+
+/// Three dots pulsing in a staggered wave while waiting for the first AI chunk.
+private struct TypingDotsView: View {
+    @State private var pulsing = false
+
+    var body: some View {
+        HStack(spacing: QuickPanelStyle.typingDotSize) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(QuickPanelStyle.textSubtle)
+                    .frame(width: QuickPanelStyle.typingDotSize, height: QuickPanelStyle.typingDotSize)
+                    .opacity(pulsing ? 1 : 0.25)
+                    .animation(
+                        .easeInOut(duration: 0.5)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(index) * 0.15),
+                        value: pulsing
+                    )
+            }
+        }
+        .onAppear { pulsing = true }
     }
 }
 

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -16,7 +16,11 @@ enum Prompts {
     - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
       API fields). Never use lists as the default shape. Never produce lists of bolded
       term-colon-definition pairs.
-    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - When responding to a question, fold its substance into your opening sentence so the
+      passage reads as complete on its own — like an interviewee restating the reporter's
+      question ("What causes tides?" → "Tides are caused by…"). Never quote the question
+      verbatim, and never open with a bare "Yes/No" that needs the question to make sense.
+    - Be concrete and specific. No filler, no hedging.
     - Match the surrounding document's tone and terminology when context is provided.
     """
 
@@ -33,7 +37,11 @@ enum Prompts {
     - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
       API fields). Never use lists as the default shape. Never produce lists of bolded
       term-colon-definition pairs.
-    - Be concrete and specific. No filler, no hedging, no restating the question.
+    - When responding to a question, fold its substance into your opening sentence so the
+      passage reads as complete on its own — like an interviewee restating the reporter's
+      question ("What causes tides?" → "Tides are caused by…"). Never quote the question
+      verbatim, and never open with a bare "Yes/No" that needs the question to make sense.
+    - Be concrete and specific. No filler, no hedging.
     - Match the surrounding document's tone and terminology when context is provided.
     """
 

--- a/Sources/Ticker/Services/SettingsService.swift
+++ b/Sources/Ticker/Services/SettingsService.swift
@@ -199,7 +199,8 @@ final class SettingsService {
                   let value = DefaultModel(rawValue: raw) else {
                 return .openai  // Default to OpenAI
             }
-            return value
+            // Claude is "coming soon" in Settings; coerce any stored pick to the default.
+            return value == .anthropic ? .openai : value
         }
         set { defaults.set(newValue.rawValue, forKey: Keys.defaultModel) }
     }

--- a/Web/src/components/Settings.tsx
+++ b/Web/src/components/Settings.tsx
@@ -557,14 +557,9 @@ export function Settings({ onClose }: SettingsProps) {
                 <span className="settings-model-name">Fast</span>
                 <span className="settings-model-detail">GPT-4o mini · searches the web</span>
               </button>
-              <button
-                className={`settings-model-btn ${settings.defaultModel === 'anthropic' ? 'settings-model-btn--active' : ''}`}
-                onClick={() => {
-                  applySettingsPatch({ defaultModel: 'anthropic' });
-                }}
-              >
+              <button className="settings-model-btn" disabled>
                 <span className="settings-model-name">Claude</span>
-                <span className="settings-model-detail">Sonnet · no live web access</span>
+                <span className="settings-model-detail">Coming soon</span>
               </button>
             </div>
             <p className="settings-hint">

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -122,6 +122,22 @@ const SELECTION_MENU_DELAY_MS = 180;
 const AI_ERROR_FEEDBACK_MS = 2200;
 const AI_INDEXING_NOTICE_MS = 4000;
 
+/** Keymap command for ⌘B/⌘I: toggle an inline markdown marker on the selection. */
+function toggleInlineMarkCommand(marker: string) {
+  return (view: EditorView): boolean => {
+    const edit = toggleInlineMark(view.state, view.state.selection.main, marker);
+    if (edit) {
+      view.dispatch({
+        changes: edit.changes,
+        selection: edit.newSelection,
+        annotations: Transaction.userEvent.of('input.format'),
+      });
+    }
+    // Always consume so WebKit's contenteditable bold/italic never fires.
+    return true;
+  };
+}
+
 export function nextSourceScope(scope: SourceScope): SourceScope {
   switch (scope) {
     case 'auto':
@@ -2810,7 +2826,12 @@ export function StreamEditor({
                 // Bullet lines get our always-tight continuation; everything
                 // else falls through to markdownKeymap (quote continuation,
                 // Backspace marker deletion).
-                Prec.high(keymap.of([{ key: 'Enter', run: continueBulletListOnEnter }, ...markdownKeymap])),
+                Prec.high(keymap.of([
+                  { key: 'Enter', run: continueBulletListOnEnter },
+                  { key: 'Mod-b', run: toggleInlineMarkCommand('**') },
+                  { key: 'Mod-i', run: toggleInlineMarkCommand('*') },
+                  ...markdownKeymap,
+                ])),
                 syntaxHighlighting(markdownHighlightStyle),
                 markdownConcealExtension,
                 arrivalField,


### PR DESCRIPTION
## Summary
- Settings: Claude model option disabled and marked "Coming soon"; stored anthropic picks coerce back to the OpenAI default.
- Quick Panel: typing-indicator dots now pulse in a staggered wave while waiting for the first AI chunk.
- Prompts: document-AI answers fold the question's substance into their opening sentence so saved passages read complete on their own (the old prompt forbade restating the question).
- Editor: ⌘B/⌘I toggle bold/italic on the selection via the existing inline-mark toggles.

All six gates green; live-verified by Niko.

🤖 Generated with [Claude Code](https://claude.com/claude-code)