### PR TITLE
Search speaks the document model: navigate to matches, list-wide search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Search now speaks the document model: opening a result scrolls the stream to the matched text (previously errored on a defunct cell anchor), and searching from the stream list covers all streams instead of arbitrarily treating the first list entry as "current".
 - Quick Panel typing dots now pulse while waiting for the first AI chunk instead of sitting static.
 - Bug reports no longer falsely claim the previous session crashed after an app auto-update.
 - Quick Panel now avoids copying an editor cursor line when Accessibility reports that no text is selected.

--- a/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
@@ -18,14 +18,15 @@ final class SearchMessageHandler: BridgeMessageHandler {
         case "hybridSearch":
             guard let payload = message.payload,
                   let query = payload["query"]?.value as? String,
-                  let currentStreamIdStr = payload["currentStreamId"]?.value as? String,
-                  let currentStreamId = UUID(uuidString: currentStreamIdStr),
                   let callbackId = message.callbackId else {
                 DebugLog.log("[WebViewManager] Invalid hybridSearch payload")
                 await bridgeService.sendBridgeError(type: message.type, reason: "Invalid hybridSearch payload")
                 return
             }
 
+            // Absent when searching from the stream list.
+            let currentStreamId = (payload["currentStreamId"]?.value as? String)
+                .flatMap(UUID.init(uuidString:))
             let limit = payload["limit"]?.intValue ?? 20
 
             guard let searchService = searchService else {

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -1855,9 +1855,10 @@ final class PersistenceService {
 
     /// Search stream documents by text, returning results split by current vs other streams.
     /// Each stream category gets its own limit to ensure cross-stream coverage.
+    /// With no current stream (e.g. searching from the stream list) every match lands in `otherStreams`.
     func textSearchStreamDocuments(
         query: String,
-        currentStreamId: UUID,
+        currentStreamId: UUID?,
         limitPerCategory: Int = 15
     ) throws -> (currentStream: [StreamDocumentSearchResult], otherStreams: [StreamDocumentSearchResult]) {
         // Escape SQL LIKE special characters to prevent injection
@@ -1877,7 +1878,7 @@ final class PersistenceService {
                   AND d.markdown LIKE ? ESCAPE '\\' COLLATE NOCASE
                 ORDER BY d.updated_at DESC
                 LIMIT ?
-            """, arguments: [currentStreamId.uuidString, pattern, limitPerCategory])
+            """, arguments: [currentStreamId?.uuidString ?? "", pattern, limitPerCategory])
             .map { row in
                 StreamDocumentSearchResult(
                     streamId: UUID(uuidString: row["stream_id"])!,
@@ -1896,7 +1897,7 @@ final class PersistenceService {
                   AND d.markdown LIKE ? ESCAPE '\\' COLLATE NOCASE
                 ORDER BY d.updated_at DESC
                 LIMIT ?
-            """, arguments: [currentStreamId.uuidString, pattern, limitPerCategory])
+            """, arguments: [currentStreamId?.uuidString ?? "", pattern, limitPerCategory])
             .map { row in
                 StreamDocumentSearchResult(
                     streamId: UUID(uuidString: row["stream_id"])!,

--- a/Sources/Ticker/Services/SearchService.swift
+++ b/Sources/Ticker/Services/SearchService.swift
@@ -15,10 +15,12 @@ final class SearchService {
 
     // MARK: - Public Interface
 
-    /// Perform hybrid search combining text and semantic results
+    /// Perform hybrid search combining text and semantic results.
+    /// With no current stream (searching from the stream list) all matches land in
+    /// `otherStreamResults` and source chunks are skipped.
     func hybridSearch(
         query: String,
-        currentStreamId: UUID,
+        currentStreamId: UUID?,
         limit: Int = 20
     ) async throws -> HybridSearchResults {
         // 1. Text search with separate limits per stream category (ensures cross-stream coverage)
@@ -28,85 +30,37 @@ final class SearchService {
             limitPerCategory: limit
         )
 
-        // 2. Get current stream title for chunk results
-        let currentStreamTitle = try persistence.getStreamTitle(id: currentStreamId) ?? "Untitled"
+        // 2. Convert to unified SearchResult format, keeping results separated by stream
+        var currentStreamResults = currentTextResults.map { documentResult($0, query: query) }
+        var otherStreamResults = otherTextResults.map { documentResult($0, query: query) }
 
-        // 3. Source chunk search in current stream.
-        let chunkResults = try retrieval.retrieve(
-            query: query,
-            streamId: currentStreamId,
-            excludeAIPrivateSources: false
-        )
+        // 3. Source chunk search, current stream only.
+        if let currentStreamId {
+            let currentStreamTitle = try persistence.getStreamTitle(id: currentStreamId) ?? "Untitled"
+            let chunkResults = try retrieval.retrieve(
+                query: query,
+                streamId: currentStreamId,
+                excludeAIPrivateSources: false
+            )
 
-        // 4. Convert to unified SearchResult format, keeping results separated by stream
-        var currentStreamResults: [SearchResult] = []
-        var otherStreamResults: [SearchResult] = []
+            for chunkResult in chunkResults {
+                let snippet = truncate(chunkResult.text, maxLength: 150)
+                let shortTitle = SourceShortTitle.derive(displayName: chunkResult.sourceName)
 
-        // Add text results for current stream
-        for textResult in currentTextResults {
-            let title = extractFirstHeading(from: textResult.markdown)
-                ?? textResult.streamTitle
-
-            let snippet = extractSnippet(from: textResult.markdown, query: query)
-
-            currentStreamResults.append(SearchResult(
-                id: textResult.streamId.uuidString,
-                streamId: textResult.streamId.uuidString,
-                streamTitle: textResult.streamTitle,
-                sourceType: .cell,
-                title: title,
-                shortTitle: nil,
-                snippet: snippet,
-                cellType: "text",
-                sourceId: nil,
-                sourceName: nil,
-                similarity: nil,
-                matchType: .text
-            ))
-        }
-
-        // Add text results for other streams
-        for textResult in otherTextResults {
-            let title = extractFirstHeading(from: textResult.markdown)
-                ?? textResult.streamTitle
-
-            let snippet = extractSnippet(from: textResult.markdown, query: query)
-
-            otherStreamResults.append(SearchResult(
-                id: textResult.streamId.uuidString,
-                streamId: textResult.streamId.uuidString,
-                streamTitle: textResult.streamTitle,
-                sourceType: .cell,
-                title: title,
-                shortTitle: nil,
-                snippet: snippet,
-                cellType: "text",
-                sourceId: nil,
-                sourceName: nil,
-                similarity: nil,
-                matchType: .text
-            ))
-        }
-
-        // Add source chunk results (only for current stream)
-        for chunkResult in chunkResults {
-            let snippet = truncate(chunkResult.text, maxLength: 150)
-            let shortTitle = SourceShortTitle.derive(displayName: chunkResult.sourceName)
-
-            currentStreamResults.append(SearchResult(
-                id: chunkResult.id.uuidString,
-                streamId: currentStreamId.uuidString,
-                streamTitle: currentStreamTitle,
-                sourceType: .chunk,
-                title: shortTitle,
-                shortTitle: shortTitle,
-                snippet: snippet,
-                cellType: nil,
-                sourceId: chunkResult.sourceId.uuidString,
-                sourceName: chunkResult.sourceName,
-                similarity: nil,
-                matchType: .text
-            ))
+                currentStreamResults.append(SearchResult(
+                    id: chunkResult.id.uuidString,
+                    streamId: currentStreamId.uuidString,
+                    streamTitle: currentStreamTitle,
+                    sourceType: .chunk,
+                    title: shortTitle,
+                    shortTitle: shortTitle,
+                    snippet: snippet,
+                    sourceId: chunkResult.sourceId.uuidString,
+                    sourceName: chunkResult.sourceName,
+                    similarity: nil,
+                    matchType: .text
+                ))
+            }
         }
 
         // 5. Deduplicate within each category
@@ -124,6 +78,22 @@ final class SearchService {
     }
 
     // MARK: - Private Helpers
+
+    private func documentResult(_ textResult: StreamDocumentSearchResult, query: String) -> SearchResult {
+        SearchResult(
+            id: textResult.streamId.uuidString,
+            streamId: textResult.streamId.uuidString,
+            streamTitle: textResult.streamTitle,
+            sourceType: .document,
+            title: extractFirstHeading(from: textResult.markdown) ?? textResult.streamTitle,
+            shortTitle: nil,
+            snippet: extractSnippet(from: textResult.markdown, query: query),
+            sourceId: nil,
+            sourceName: nil,
+            similarity: nil,
+            matchType: .text
+        )
+    }
 
     private func sortResults(_ results: [SearchResult]) -> [SearchResult] {
         // Preserve input indices for stable tie-breaking (SQL returns by updated_at DESC)
@@ -222,7 +192,6 @@ struct SearchResult: Encodable {
     let title: String
     let shortTitle: String?
     let snippet: String
-    let cellType: String?
     let sourceId: String?
     let sourceName: String?
     let similarity: Float?
@@ -230,7 +199,7 @@ struct SearchResult: Encodable {
 }
 
 enum SearchResultSourceType: String, Encodable {
-    case cell
+    case document
     case chunk
 }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -3318,11 +3318,35 @@ final class StreamDocumentTests: XCTestCase {
             let result = try XCTUnwrap(results.currentStreamResults.first)
             XCTAssertEqual(result.streamId, stream.id.uuidString)
             XCTAssertEqual(result.streamTitle, "Searchable Stream")
-            XCTAssertEqual(result.sourceType.rawValue, "cell")
-            XCTAssertEqual(result.cellType, "text")
+            XCTAssertEqual(result.sourceType.rawValue, "document")
             XCTAssertEqual(result.title, "Research Notes")
             XCTAssertTrue(result.snippet.contains("retargeted search phrase"))
             XCTAssertTrue(results.otherStreamResults.isEmpty)
+        }
+    }
+
+    func test_hybridSearchWithoutCurrentStreamReturnsAllMatchesAsOtherStreams() async throws {
+        try await withTempPersistenceService { service in
+            let stream = Stream(title: "Listed Stream")
+            try service.saveStream(stream)
+            try service.saveStreamDocument(
+                streamId: stream.id,
+                markdown: "A globally findable phrase."
+            )
+
+            let searchService = SearchService(
+                persistence: service,
+                retrieval: RetrievalService(persistence: service)
+            )
+
+            let results = try await searchService.hybridSearch(
+                query: "globally findable",
+                currentStreamId: nil,
+                limit: 5
+            )
+
+            XCTAssertTrue(results.currentStreamResults.isEmpty)
+            XCTAssertEqual(results.otherStreamResults.first?.streamId, stream.id.uuidString)
         }
     }
 

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -258,16 +258,16 @@ export function App() {
     }
   };
 
-  // Navigate to a different stream and scroll to a specific cell or source
-  const [pendingCellId, setPendingCellId] = useState<string | null>(null);
+  // Navigate to a different stream and scroll to a text match or a source
+  const [pendingMatchText, setPendingMatchText] = useState<string | null>(null);
   const [pendingSourceId, setPendingSourceId] = useState<string | null>(null);
 
-  const handleNavigateToStream = (streamId: string, targetId: string, targetType: 'cell' | 'source' = 'cell') => {
+  const handleNavigateToStream = (streamId: string, targetId: string, targetType: 'match' | 'source' = 'match') => {
     if (targetType === 'source') {
       setPendingSourceId(targetId);
-      setPendingCellId(null);
+      setPendingMatchText(null);
     } else {
-      setPendingCellId(targetId);
+      setPendingMatchText(targetId);
       setPendingSourceId(null);
     }
 
@@ -280,14 +280,14 @@ export function App() {
     bridge.send({ type: 'loadStream', payload: { id: streamId } });
   };
 
-  const handleNavigateToCell = (cellId: string) => {
-    setPendingCellId(cellId);
+  const handleNavigateToMatch = (matchText: string) => {
+    setPendingMatchText(matchText);
     setPendingSourceId(null);
   };
 
   const handleNavigateToSource = (sourceId: string) => {
     setPendingSourceId(sourceId);
-    setPendingCellId(null);
+    setPendingMatchText(null);
   };
 
   const handleOpenSettings = () => {
@@ -320,9 +320,9 @@ export function App() {
         stream={currentStream}
         onBack={handleBackToList}
         onDelete={handleDeleteStream}
-        pendingCellId={pendingCellId}
+        pendingMatchText={pendingMatchText}
         pendingSourceId={pendingSourceId}
-        onClearPendingCell={() => setPendingCellId(null)}
+        onClearPendingMatch={() => setPendingMatchText(null)}
         onClearPendingSource={() => setPendingSourceId(null)}
       />
     );
@@ -345,9 +345,9 @@ export function App() {
       <SearchModal
         isOpen={showSearch}
         onClose={() => setShowSearch(false)}
-        currentStreamId={currentStream?.id ?? streams[0]?.id ?? null}
+        currentStreamId={view === 'stream' ? currentStream?.id ?? null : null}
         isStreamOpen={view === 'stream' && currentStream !== null}
-        onNavigateToCell={handleNavigateToCell}
+        onNavigateToMatch={handleNavigateToMatch}
         onNavigateToStream={handleNavigateToStream}
         onNavigateToSource={handleNavigateToSource}
       />

--- a/Web/src/components/SearchModal.tsx
+++ b/Web/src/components/SearchModal.tsx
@@ -8,9 +8,10 @@ interface SearchModalProps {
   onClose: () => void;
   currentStreamId: string | null;
   isStreamOpen: boolean;
-  onNavigateToCell: (cellId: string) => void;
-  /** Navigate to another stream, optionally to a specific cell or source */
-  onNavigateToStream: (streamId: string, targetId: string, targetType?: 'cell' | 'source') => void;
+  /** Scroll the open editor to the first occurrence of the matched text */
+  onNavigateToMatch: (matchText: string) => void;
+  /** Navigate to another stream, to a text match or a source */
+  onNavigateToStream: (streamId: string, targetId: string, targetType?: 'match' | 'source') => void;
   /** Navigate to a source in the source panel (for chunk results) */
   onNavigateToSource: (sourceId: string) => void;
 }
@@ -20,7 +21,7 @@ export function SearchModal({
   onClose,
   currentStreamId,
   isStreamOpen,
-  onNavigateToCell,
+  onNavigateToMatch,
   onNavigateToStream,
   onNavigateToSource,
 }: SearchModalProps) {
@@ -71,17 +72,12 @@ export function SearchModal({
     // Increment sequence for this request
     const currentSequence = ++requestSequenceRef.current;
 
-    if (!currentStreamId) {
-      setResults({ currentStreamResults: [], otherStreamResults: [] });
-      setLoading(false);
-      return;
-    }
-
     debounceRef.current = window.setTimeout(async () => {
       try {
         const response = await bridge.sendAsync<HybridSearchResults>('hybridSearch', {
           query: query.trim(),
-          currentStreamId,
+          // Absent when searching from the stream list
+          ...(currentStreamId ? { currentStreamId } : {}),
           limit: 20,
         });
         // Only update state if this is still the most recent request
@@ -118,13 +114,14 @@ export function SearchModal({
 
   // Handle clicking on a search result
   const navigateToResult = useCallback((result: SearchResult) => {
-    const targetId = result.sourceType === 'chunk' && result.sourceId
-      ? result.sourceId
-      : result.id;
-    const targetType = result.sourceType === 'chunk' ? 'source' : 'cell';
     onClose();
-    onNavigateToStream(result.streamId, targetId, targetType);
-  }, [onClose, onNavigateToStream]);
+    if (result.sourceType === 'chunk' && result.sourceId) {
+      onNavigateToStream(result.streamId, result.sourceId, 'source');
+    } else {
+      // Document result: scroll the target stream to the matched text
+      onNavigateToStream(result.streamId, query.trim(), 'match');
+    }
+  }, [onClose, onNavigateToStream, query]);
 
   const handleResultClick = useCallback((result: SearchResult) => {
     if (isStreamOpen && result.streamId === currentStreamId) {
@@ -134,8 +131,8 @@ export function SearchModal({
         // Chunk result: navigate to source in source panel
         onNavigateToSource(result.sourceId);
       } else {
-        // Cell result: scroll to cell
-        onNavigateToCell(result.id);
+        // Document result: scroll to the matched text
+        onNavigateToMatch(query.trim());
       }
     } else if (!isStreamOpen) {
       navigateToResult(result);
@@ -143,7 +140,7 @@ export function SearchModal({
       // Other stream: show expanded preview
       setExpandedResult(result);
     }
-  }, [currentStreamId, isStreamOpen, navigateToResult, onClose, onNavigateToCell, onNavigateToSource]);
+  }, [currentStreamId, isStreamOpen, navigateToResult, onClose, onNavigateToMatch, onNavigateToSource, query]);
 
   // Keyboard navigation
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -186,7 +183,7 @@ export function SearchModal({
             ref={inputRef}
             type="text"
             className="search-modal-input"
-            placeholder="Search cells..."
+            placeholder="Search…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -236,7 +233,7 @@ export function SearchModal({
             {results.otherStreamResults.length > 0 && (
               <>
                 <div className="search-modal-section-header search-modal-section-divider">
-                  Other Streams
+                  {isStreamOpen ? 'Other Streams' : 'Streams'}
                 </div>
                 {results.otherStreamResults.map((result, index) => (
                   <SearchResultItem
@@ -257,7 +254,7 @@ export function SearchModal({
 
         {!results && !loading && query.trim() === '' && (
           <div className="search-modal-hint">
-            Type to search across cells and sources
+            Type to search streams and sources
           </div>
         )}
       </div>
@@ -290,7 +287,7 @@ function SearchResultItem({ result, isSelected, onClick }: SearchResultItemProps
       <span className="search-result-icon">{icon}</span>
       <div className="search-result-content">
         <div className="search-result-title">
-          {result.streamTitle !== '' && result.sourceType === 'cell' && (
+          {result.streamTitle !== '' && result.sourceType === 'document' && (
             <span className="search-result-stream">[{result.streamTitle}]</span>
           )}
           {title}
@@ -306,16 +303,7 @@ function getResultIcon(result: SearchResult): ReactNode {
   if (result.sourceType === 'chunk') {
     return <DocumentIcon size={14} />;
   }
-  switch (result.cellType) {
-    case 'text':
-      return 'T';
-    case 'aiResponse':
-      return <SparkleIcon size={14} />;
-    case 'quote':
-      return '"';
-    default:
-      return '•';
-  }
+  return 'T';
 }
 
 function getMatchBadge(matchType: string): ReactNode | null {

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -53,9 +53,9 @@ interface StreamEditorProps {
   stream: Stream;
   onBack: () => void;
   onDelete: () => void;
-  pendingCellId?: string | null;
+  pendingMatchText?: string | null;
   pendingSourceId?: string | null;
-  onClearPendingCell?: () => void;
+  onClearPendingMatch?: () => void;
   onClearPendingSource?: () => void;
 }
 
@@ -490,9 +490,9 @@ export function StreamEditor({
   stream,
   onBack,
   onDelete,
-  pendingCellId,
+  pendingMatchText,
   pendingSourceId,
-  onClearPendingCell,
+  onClearPendingMatch,
   onClearPendingSource,
 }: StreamEditorProps) {
   const addToast = useToastStore((state) => state.addToast);
@@ -937,12 +937,37 @@ export function StreamEditor({
     }
   }, [onClearPendingSource, pendingSourceId, sources]);
 
+  // Scroll to the first occurrence of a search match once the editor view exists.
   useEffect(() => {
-    if (pendingCellId) {
-      addToast('Cell anchors are not available in document editor mode yet.', 'info');
-      onClearPendingCell?.();
-    }
-  }, [pendingCellId, addToast, onClearPendingCell]);
+    if (!pendingMatchText) return;
+    let cancelled = false;
+
+    const tryScroll = (attempt: number) => {
+      if (cancelled) return;
+      const view = editorViewRef.current;
+      if (!view) {
+        // Editor may not be mounted yet when arriving from another stream.
+        if (attempt < 10) requestAnimationFrame(() => tryScroll(attempt + 1));
+        else onClearPendingMatch?.();
+        return;
+      }
+      const doc = view.state.doc.toString();
+      const index = doc.toLowerCase().indexOf(pendingMatchText.toLowerCase());
+      if (index >= 0) {
+        view.dispatch({
+          selection: { anchor: index, head: index + pendingMatchText.length },
+          effects: EditorView.scrollIntoView(index, { y: 'center' }),
+        });
+        view.focus();
+      }
+      onClearPendingMatch?.();
+    };
+
+    tryScroll(0);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingMatchText, onClearPendingMatch]);
 
   useEffect(() => {
     if (markdownContent === lastSavedContentRef.current) return;

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -111,11 +111,10 @@ export interface SearchResult {
   id: string;
   streamId: string;
   streamTitle: string;
-  sourceType: 'cell' | 'chunk';
+  sourceType: 'document' | 'chunk';
   title: string;
   shortTitle?: string;
   snippet: string;
-  cellType?: 'text' | 'aiResponse' | 'quote';
   /** Source ID for chunk results (to navigate to source panel) */
   sourceId?: string;
   sourceName?: string;

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -151,7 +151,8 @@
         "requiredCallbackId": true
       },
       "hybridSearch": {
-        "requiredPayloadKeys": ["query", "currentStreamId", "limit"],
+        "requiredPayloadKeys": ["query", "limit"],
+        "optionalPayloadKeys": ["currentStreamId"],
         "requiredCallbackId": true
       },
       "loadProxyAuth": {


### PR DESCRIPTION
## Summary
- Opening a search result scrolls the stream to the first occurrence of the query (selected + centered) instead of erroring on a defunct cell anchor.
- `hybridSearch`'s `currentStreamId` is now optional: searching from the stream list covers all streams flat rather than treating the first list entry as "current".
- Cell vocabulary retired from the search surface: `sourceType` 'cell' → 'document', dead `cellType` field removed, copy updated.
- Contract updated (`currentStreamId` moved to optional keys); new Swift test covers the no-current-stream path.

All six gates green; live-verified by Niko.

🤖 Generated with [Claude Code](https://claude.com/claude-code)