### PR TITLE
Editor/AI frailty fixes: drag-selection geometry, whole-stream corruption, rewrite verb, Cmd-F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- The Rewrite menu gained "With instructions…": describe how the selection should be rewritten and the AI replaces it accordingly. Re-develop with an edited prompt now actually obeys the prompt (it previously deferred to the fixed "develop" instruction and near-restated the passage).
+- In-editor AI now shows the same pulsing-dots indicator at the exact insertion point while waiting for the first chunk, matching quick-panel dispatches.
+- ⌘F opens search from the stream list (⌘K still works everywhere; in the editor ⌘F remains in-document find).
 - ⌘B and ⌘I now toggle bold and italic on the stream editor selection.
 - Quick Panel AI answers now show presence in the open editor: the AI-writing pill plus a typing indicator pinned to the exact spot where the answer will land.
 - Settings now offers a model choice — Balanced (GPT-5 mini), Fast (GPT-4o mini), or Claude — with web search available on the OpenAI options.
@@ -51,6 +54,8 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Drag selection no longer stalls or lags in streams containing links: link chips were rebuilt on every selection tick during a drag, feeding CodeMirror's pointer snapping a moving target. Failed image loads now also record their real rendered size so scroll geometry stays honest.
+- A revision-conflict reload during an in-flight AI request no longer risks replacing the entire stream with the AI passage: the request is cancelled and its writing range cleared before the document reloads.
 - Search now speaks the document model: opening a result scrolls the stream to the matched text (previously errored on a defunct cell anchor), and searching from the stream list covers all streams instead of arbitrarily treating the first list entry as "current".
 - Quick Panel typing dots now pulse while waiting for the first AI chunk instead of sitting static.
 - Bug reports no longer falsely claim the previous session crashed after an app auto-update.

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -57,6 +57,7 @@ private enum DocumentAIVerb: String {
     case ask
     case challenge
     case define
+    case rewrite
 
     var systemPrompt: String {
         switch self {
@@ -68,6 +69,8 @@ private enum DocumentAIVerb: String {
             return Prompts.verbChallenge
         case .define:
             return Prompts.verbDefine
+        case .rewrite:
+            return Prompts.verbRewrite
         }
     }
 }
@@ -185,8 +188,13 @@ final class AIMessageHandler: BridgeMessageHandler {
 
             var resolvedQuery = query
             let cleanedContext = (payload["context"]?.value as? String).flatMap(Self.cleanedDocumentContext)
-            if let context = payload["context"]?.value as? String, !context.isEmpty {
-                if let cleanContext = Self.cleanedDocumentContext(context) {
+            if let cleanContext = cleanedContext {
+                if verb == .rewrite {
+                    // Instruction-primary framing: the passage is material, the
+                    // user's prompt is the task. The Ask-style "Regarding this
+                    // context" wrapper demotes the instruction to a footnote.
+                    resolvedQuery = "Passage:\n\"\"\"\n\(cleanContext)\n\"\"\"\n\nInstruction: \(resolvedQuery)"
+                } else {
                     resolvedQuery = "Regarding this context:\n\"\"\"\n\(cleanContext)\n\"\"\"\n\n\(resolvedQuery)"
                 }
             }

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -53,6 +53,10 @@ enum Prompts {
     Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose.
     """
 
+    static let verbRewrite = """
+    Rewrite the provided passage following the instruction exactly — including any required length, tone, or structure. Preserve the passage's meaning unless the instruction says otherwise. Output only the rewritten passage.
+    """
+
     static let verbChallenge = """
     Identify the single weakest point in this passage — a hidden assumption, an internal contradiction, or an unsupported leap. State it plainly in two to four sentences, then end with one pointed question back to the author. Do not rewrite the passage. Do not answer your own question.
     """

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -111,7 +111,10 @@ export function App() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'k') return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      const key = event.key.toLowerCase();
+      // ⌘K everywhere; ⌘F only outside the editor (inside, it's in-document find).
+      if (key !== 'k' && !(key === 'f' && viewRef.current === 'list')) return;
       const canSearch = viewRef.current === 'list' || (viewRef.current === 'stream' && currentStreamIdRef.current);
       if (isAuthGated || !canSearch) return;
       event.preventDefault();

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -69,6 +69,9 @@ interface SelectionContext {
 type PromptIntent = {
   kind: 'ask';
 } | {
+  kind: 'rewrite';
+  preview: string;
+} | {
   kind: 'redevelop';
   verb: DocumentAIVerb;
   parentRequestId?: string;
@@ -359,7 +362,7 @@ function spanIdsIntersectingRange(spans: Span[], from: number, to: number): stri
 }
 
 function parseDocumentAIVerb(value: unknown): DocumentAIVerb {
-  return value === 'ask' || value === 'challenge' || value === 'define' || value === 'develop'
+  return value === 'ask' || value === 'challenge' || value === 'define' || value === 'develop' || value === 'rewrite'
     ? value
     : 'develop';
 }
@@ -724,6 +727,21 @@ export function StreamEditor({
     if (!aiRequestRef.current) hideAiFeedback();
   }, [hideAiFeedback]);
 
+  // A full-document reload while document AI is streaming is fatal if the
+  // writing range survives it: mapping the range through a doc-wide replace
+  // collapses it to {0, docLength}, so the completion handler would then
+  // overwrite the ENTIRE stream with the AI passage. Abort before reloading.
+  const abortInFlightDocumentAI = useCallback(() => {
+    const active = aiRequestRef.current;
+    if (!active) return;
+    bridge.send({ type: 'cancelDocumentAI', payload: { requestId: active.id } });
+    aiRequestRef.current = null;
+    const view = editorViewRef.current;
+    if (view) dispatchAiRangeClear(view);
+    setAiStatus('idle');
+    hideAiFeedback();
+  }, [hideAiFeedback]);
+
   const showAiErrorFeedback = useCallback((message: string) => {
     clearAiFeedbackTimer();
     setAiFeedback({
@@ -1035,6 +1053,8 @@ export function StreamEditor({
           return;
         }
 
+        abortInFlightDocumentAI();
+
         const view = editorViewRef.current;
         const spans = payloadSpansForDoc(message.payload?.spans, markdown);
         if (view) {
@@ -1080,6 +1100,7 @@ export function StreamEditor({
             localRevision: revisionRef.current,
             appendRevision: revision,
           });
+          abortInFlightDocumentAI();
           bridge.send({ type: 'loadStream', payload: { id: stream.id } });
           return;
         }
@@ -1328,7 +1349,7 @@ export function StreamEditor({
     });
 
     return () => unsubscribe();
-  }, [addToast, clearQuickPanelPending, hideAiFeedback, showAiErrorFeedback, showAiWritingFeedback, stream.id]);
+  }, [abortInFlightDocumentAI, addToast, clearQuickPanelPending, hideAiFeedback, showAiErrorFeedback, showAiWritingFeedback, stream.id]);
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
@@ -2108,6 +2129,23 @@ export function StreamEditor({
     openPromptWithContext(context);
   }, [addToast, getSelectionContext, isAiThinking, openPromptWithContext]);
 
+  const openRewritePrompt = useCallback(() => {
+    if (isAiThinking) {
+      addToast('AI is already running for this stream.', 'info');
+      return;
+    }
+    const context = getSelectionContext(true);
+    if (!context || !context.text.trim()) {
+      addToast('Select text to rewrite.', 'info');
+      return;
+    }
+    hideSelectionMenu();
+    promptContextRef.current = context;
+    setPromptValue('');
+    setPromptIntent({ kind: 'rewrite', preview: replacementPreview(context.text) });
+    setShowPrompt(true);
+  }, [addToast, getSelectionContext, hideSelectionMenu, isAiThinking]);
+
   const handleSelectionFormat = useCallback((marker: string) => {
     const view = editorViewRef.current;
     if (!view) {
@@ -2217,9 +2255,22 @@ export function StreamEditor({
   const handlePromptSend = useCallback(() => {
     const prompt = promptValue.trim();
     const context = promptContextRef.current;
-    if ((!prompt && promptIntent.kind === 'ask') || !context) return;
+    if ((!prompt && promptIntent.kind !== 'redevelop') || !context) return;
 
     closePrompt();
+
+    if (promptIntent.kind === 'rewrite') {
+      startDocumentAI({
+        query: prompt,
+        context: context.text.trim(),
+        imageUrls: context.imageUrls,
+        from: context.from,
+        to: context.to,
+        mode: 'replace',
+        verb: 'rewrite',
+      });
+      return;
+    }
 
     if (promptIntent.kind === 'redevelop') {
       startDocumentAI({
@@ -2229,7 +2280,10 @@ export function StreamEditor({
         from: context.from,
         to: context.to,
         mode: 'replace',
-        verb: promptIntent.verb,
+        // With an edited prompt the instruction must win: rewrite's system
+        // prompt follows it, while the original verb's (e.g. develop's
+        // "deepen, do not pad") overrides it.
+        verb: prompt ? 'rewrite' : promptIntent.verb,
         parentRequestId: promptIntent.parentRequestId,
       });
       return;
@@ -2508,11 +2562,13 @@ export function StreamEditor({
       {showPrompt && (
         <div className="ai-prompt-overlay" onClick={closePrompt}>
           <div className="ai-prompt-dialog" onClick={(e) => e.stopPropagation()}>
-            <h2>{promptIntent.kind === 'redevelop' ? 'Re-develop' : 'Ask'}</h2>
+            <h2>
+              {promptIntent.kind === 'redevelop' ? 'Re-develop' : promptIntent.kind === 'rewrite' ? 'Rewrite' : 'Ask'}
+            </h2>
             <p>
-              {promptIntent.kind === 'redevelop'
-                ? `will replace: ${promptIntent.preview}`
-                : 'Selection will be attached as context.'}
+              {promptIntent.kind === 'ask'
+                ? 'Selection will be attached as context.'
+                : `will replace: ${promptIntent.preview}`}
             </p>
             <textarea
               className="ai-prompt-input"
@@ -2527,7 +2583,13 @@ export function StreamEditor({
                   closePrompt();
                 }
               }}
-              placeholder={promptIntent.kind === 'redevelop' ? 'Edit the prompt…' : 'Ask a question or continue the line of thought…'}
+              placeholder={
+                promptIntent.kind === 'redevelop'
+                  ? 'Edit the prompt…'
+                  : promptIntent.kind === 'rewrite'
+                    ? 'How should this be rewritten? (e.g. "condense to one sentence")'
+                    : 'Ask a question or continue the line of thought…'
+              }
               autoFocus
               rows={5}
             />
@@ -2551,9 +2613,9 @@ export function StreamEditor({
                 className="ai-prompt-send"
                 type="button"
                 onClick={handlePromptSend}
-                disabled={promptIntent.kind === 'ask' && !promptValue.trim()}
+                disabled={promptIntent.kind !== 'redevelop' && !promptValue.trim()}
               >
-                {promptIntent.kind === 'redevelop' ? 'Re-develop' : 'Ask'}
+                {promptIntent.kind === 'redevelop' ? 'Re-develop' : promptIntent.kind === 'rewrite' ? 'Rewrite' : 'Ask'}
               </button>
             </div>
           </div>
@@ -2741,6 +2803,16 @@ export function StreamEditor({
                   onClick={() => handleSelectionVerb('develop')}
                 >
                   Develop (replaces)
+                </button>
+                <button
+                  type="button"
+                  className="selection-action-button selection-action-button--text selection-action-button--wide selection-action-button--ai"
+                  title="Rewrite with instructions (replaces)"
+                  aria-label="Rewrite with instructions (replaces)"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={openRewritePrompt}
+                >
+                  With instructions…
                 </button>
               </div>
             )}

--- a/Web/src/extensions/AIWritingState.test.ts
+++ b/Web/src/extensions/AIWritingState.test.ts
@@ -1,5 +1,6 @@
 import { EditorState, Transaction } from '@codemirror/state';
 import { history, isolateHistory, undo } from '@codemirror/commands';
+import { EditorView, type DecorationSet } from '@codemirror/view';
 import { describe, expect, it } from 'vitest';
 import {
   AI_HISTORY_USER_EVENT,
@@ -7,6 +8,17 @@ import {
   getAiWritingRange,
   setAiWritingRangeEffect,
 } from './AIWritingState';
+
+function collectDecorations(state: EditorState): Array<{ from: number; to: number; spec: Record<string, unknown> }> {
+  const found: Array<{ from: number; to: number; spec: Record<string, unknown> }> = [];
+  for (const value of state.facet(EditorView.decorations)) {
+    if (typeof value === 'function') continue;
+    (value as DecorationSet).between(0, state.doc.length, (from, to, deco) => {
+      found.push({ from, to, spec: deco.spec as Record<string, unknown> });
+    });
+  }
+  return found;
+}
 
 describe('aiWritingExtension', () => {
   it('maps the active AI writing range through document edits', () => {
@@ -46,6 +58,26 @@ describe('aiWritingExtension', () => {
     }).state;
 
     expect(getAiWritingRange(state)).toBeNull();
+  });
+
+  it('shows a pending widget at the insertion point while the range is empty', () => {
+    let state = EditorState.create({ doc: 'hello world', extensions: [aiWritingExtension] });
+    state = state.update({ effects: setAiWritingRangeEffect.of({ from: 5, to: 5 }) }).state;
+
+    const decorations = collectDecorations(state);
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(5);
+    expect(decorations[0].spec.widget).toBeDefined();
+  });
+
+  it('switches to the writing-range highlight once content streams in', () => {
+    let state = EditorState.create({ doc: 'hello world', extensions: [aiWritingExtension] });
+    state = state.update({ effects: setAiWritingRangeEffect.of({ from: 5, to: 11 }) }).state;
+
+    const decorations = collectDecorations(state);
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].spec.class).toBe('cm-ai-writing-range');
+    expect(decorations[0].spec.widget).toBeUndefined();
   });
 
   it('keeps streamed partials out of history and records final AI text as one undo step', () => {

--- a/Web/src/extensions/AIWritingState.ts
+++ b/Web/src/extensions/AIWritingState.ts
@@ -1,5 +1,5 @@
 import { EditorState, StateEffect, StateField, type Extension } from '@codemirror/state';
-import { Decoration, EditorView } from '@codemirror/view';
+import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 
 export interface AiWritingRange {
   from: number;
@@ -31,12 +31,37 @@ export const aiWritingRangeField = StateField.define<AiWritingRange | null>({
     return nextRange;
   },
   provide: (field) => EditorView.decorations.from(field, (range) => {
-    if (!range || range.to <= range.from) return Decoration.none;
+    if (!range) return Decoration.none;
+    if (range.to <= range.from) {
+      // Waiting for the first chunk: pulsing dots at the exact insertion point.
+      return Decoration.set([
+        Decoration.widget({ widget: new AiPendingWidget(), side: 1 }).range(range.from),
+      ]);
+    }
     return Decoration.set([
       Decoration.mark({ class: 'cm-ai-writing-range' }).range(range.from, range.to),
     ]);
   }),
 });
+
+/** Inline three-dot typing indicator shown before the first streamed chunk lands. */
+class AiPendingWidget extends WidgetType {
+  toDOM(): HTMLElement {
+    const wrap = document.createElement('span');
+    wrap.className = 'cm-ai-pending';
+    wrap.setAttribute('aria-label', 'AI is writing');
+    for (let i = 0; i < 3; i += 1) {
+      const dot = document.createElement('span');
+      dot.className = 'cm-pending-append-dot';
+      wrap.appendChild(dot);
+    }
+    return wrap;
+  }
+
+  override eq(): boolean {
+    return true;
+  }
+}
 
 export const aiWritingExtension: Extension = aiWritingRangeField;
 

--- a/Web/src/extensions/LinkInteraction.ts
+++ b/Web/src/extensions/LinkInteraction.ts
@@ -3,7 +3,7 @@ import { RangeSetBuilder, type Extension } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, WidgetType, type ViewUpdate } from '@codemirror/view';
 import type { SyntaxNode } from '@lezer/common';
 import { bridge } from '../types';
-import { isChipEligibleLink, rawFormattingIsShown, rawLinksAreRevealedOnLine, revealRawLinksEffect } from './MarkdownConceal';
+import { isChipEligibleLink, rawFormattingIsShown, rawLinkRevealLine, rawLinksAreRevealedOnLine, revealRawLinksEffect } from './MarkdownConceal';
 
 export interface MarkdownLinkInfo {
   from: number;
@@ -218,7 +218,12 @@ export function linkInteractionExtension(
 
     update(update: ViewUpdate): void {
       const rawFormattingChanged = rawFormattingIsShown(update.startState) !== rawFormattingIsShown(update.state);
-      if (update.docChanged || update.viewportChanged || update.selectionSet || rawFormattingChanged) {
+      const revealLineChanged = rawLinkRevealLine(update.startState) !== rawLinkRevealLine(update.state);
+      // Never rebuild on selectionSet: these replace decorations feed atomicRanges,
+      // which CM re-queries on every pointer-drag tick — a selection-keyed rebuild
+      // creates a geometry feedback loop that breaks drag selection (invariant:
+      // conceal depends only on document + viewport + explicit reveal).
+      if (update.docChanged || update.viewportChanged || revealLineChanged || rawFormattingChanged) {
         this.decorations = safeChipBuild(update.view, this.decorations.map(update.changes));
       }
     }

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -108,6 +108,11 @@ export function rawLinksAreRevealedOnLine(state: EditorState, lineFrom: number):
   return state.field(revealRawLinksField, false) === lineFrom;
 }
 
+/** Current ⌥-click reveal line, for extensions that need to diff reveal state across updates. */
+export function rawLinkRevealLine(state: EditorState): number | null {
+  return state.field(revealRawLinksField, false) ?? null;
+}
+
 function rangeWithFollowingSpace(view: EditorView, from: number, to: number): { from: number; to: number } {
   if (to >= view.state.doc.length) return { from, to };
   const nextCharacter = view.state.doc.sliceString(to, to + 1);

--- a/Web/src/extensions/MarkdownImageWidget.ts
+++ b/Web/src/extensions/MarkdownImageWidget.ts
@@ -191,6 +191,10 @@ class MarkdownImageBlockWidget extends WidgetType {
     }
 
     image.onload = () => this.scheduleRenderedSizeMeasure(view, wrapper, image);
+    // Failed loads must also record their rendered (collapsed) size, or the
+    // height estimate for this URL stays a guess forever and drifts CM's
+    // heightmap against the real layout.
+    image.onerror = () => this.scheduleRenderedSizeMeasure(view, wrapper, image);
     if (image.complete && image.naturalWidth > 0) {
       this.scheduleRenderedSizeMeasure(view, wrapper, image);
     }

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1545,6 +1545,15 @@ body {
   padding: var(--space-2) 0;
 }
 
+/* Inline variant: in-editor AI insertion point (same dots, in text flow). */
+.cm-ai-pending {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-1);
+  vertical-align: baseline;
+}
+
 .cm-pending-append-dot {
   width: 6px;
   height: 6px;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -77,7 +77,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
 ] as const;
 
 export type WebToSwiftMessageType = (typeof WEB_TO_SWIFT_MESSAGE_TYPES)[number];
-export type DocumentAIVerb = 'develop' | 'ask' | 'challenge' | 'define';
+export type DocumentAIVerb = 'develop' | 'ask' | 'challenge' | 'define' | 'rewrite';
 export type DocumentAISourceScope = 'auto' | 'all' | 'none';
 
 export interface ThinkDocumentPayload extends Record<string, unknown> {


### PR DESCRIPTION
## Summary
- **Drag-selection geometry**: link chips were rebuilt on every selection tick during a drag while also feeding `atomicRanges`, creating a geometry feedback loop that broke selection in link-heavy (AI-cited) streams. Chips now rebuild only on document/viewport/reveal changes. Failed image loads also record their rendered size to stop height-estimate drift.
- **Whole-stream corruption**: a revision-conflict (or append-gap) reload during an in-flight document-AI request collapsed the tracked writing range to the entire document via `mapPos`, so the completion overwrote the whole stream. Reload paths now cancel the request and clear the range first.
- **Rewrite verb**: new instruction-primary `rewrite` verb (Passage/Instruction framing). Re-develop with an edited prompt routes through it — the old path buried the instruction under develop's "deepen, do not pad" system prompt. Selection menu gains Rewrite → "With instructions…".
- **Presence consistency**: in-editor AI shows the same pulsing dots at the exact insertion point until the first chunk arrives.
- **⌘F** opens global search from the stream list (⌘K unchanged; editor keeps in-document find).

All six gates green; live-verified by Niko (including the mid-stream capture race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)