### PR TITLE
Audit P1: editor durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Rapid stream navigation can no longer be overwritten by an older, slower stream load.
 - Leaving a stream now flushes pending edits, stops in-flight document AI, and visibly reports save failures instead of remaining stuck on “Saving…”.
 - Drag selection no longer stalls or lags in streams containing links: link chips were rebuilt on every selection tick during a drag, feeding CodeMirror's pointer snapping a moving target. Failed image loads now also record their real rendered size so scroll geometry stays honest.
 - A revision-conflict reload during an in-flight AI request no longer risks replacing the entire stream with the AI passage: the request is cancelled and its writing range cleared before the document reloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Database upgrades now stop before migration when the required safety backup cannot be created.
 - Rapid stream navigation can no longer be overwritten by an older, slower stream load.
 - Leaving a stream now flushes pending edits, stops in-flight document AI, and visibly reports save failures instead of remaining stuck on “Saving…”.
 - Drag selection no longer stalls or lags in streams containing links: link chips were rebuilt on every selection tick during a drag, feeding CodeMirror's pointer snapping a moving target. Failed image loads now also record their real rendered size so scroll geometry stays honest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Leaving a stream now flushes pending edits, stops in-flight document AI, and visibly reports save failures instead of remaining stuck on “Saving…”.
 - Drag selection no longer stalls or lags in streams containing links: link chips were rebuilt on every selection tick during a drag, feeding CodeMirror's pointer snapping a moving target. Failed image loads now also record their real rendered size so scroll geometry stays honest.
 - A revision-conflict reload during an in-flight AI request no longer risks replacing the entire stream with the AI passage: the request is cancelled and its writing range cleared before the document reloads.
 - Search now speaks the document model: opening a result scrolls the stream to the matched text (previously errored on a defunct cell anchor), and searching from the stream list covers all streams instead of arbitrarily treating the first list entry as "current".

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -100,7 +100,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 return
             }
             do {
-                try await sendStreamLoaded(id: id)
+                try await sendStreamLoaded(id: id, requestId: payload["requestId"]?.intValue)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to load stream (\(DebugLog.errorSummary(error)))")
             }
@@ -364,7 +364,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         }
     }
 
-    func sendStreamLoaded(id: UUID) async throws {
+    func sendStreamLoaded(id: UUID, requestId: Int? = nil) async throws {
         guard let stream = try persistence.loadStream(id: id) else { return }
         delegate?.setCurrentStreamIdForFileDrops(id)
         await delegate?.closePDFPaneIfShowingDifferentStream(id)
@@ -372,13 +372,16 @@ final class StreamMessageHandler: BridgeMessageHandler {
         let spans = try persistence.loadSpans(streamId: id)
         let marginNotes = try persistence.loadMarginNotes(streamId: id)
         let streamPayload = StreamCodec.encodeStream(stream, document: document)
-        let payload: [String: AnyCodable] = [
+        var payload: [String: AnyCodable] = [
             "stream": AnyCodable(streamPayload),
             "sourceScope": AnyCodable(stream.sourceScope.rawValue),
             "scrollOffset": AnyCodable(document.scrollOffset),
             "spans": AnyCodable(StreamCodec.encodeSpans(spans)),
             "marginNotes": AnyCodable(StreamCodec.encodeMarginNotes(marginNotes))
         ]
+        if let requestId {
+            payload["requestId"] = AnyCodable(requestId)
+        }
         bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
         ingestService?.enqueuePendingSources(for: id)
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -508,11 +508,7 @@ final class PersistenceService {
                 try !migrator.hasCompletedMigrations(db)
             }
             if hasPendingMigrations {
-                do {
-                    try backupDatabaseBeforeMigration(retainingLast: Self.databaseBackupRetentionCount)
-                } catch {
-                    Self.debugLog("PersistenceService: Failed to create pre-migration DB backup (continuing): \(error)")
-                }
+                try backupDatabaseBeforeMigration(retainingLast: Self.databaseBackupRetentionCount)
             }
         }
 
@@ -533,7 +529,11 @@ final class PersistenceService {
         let backupQueue = try DatabaseQueue(path: backupURL.path)
         try dbQueue.backup(to: backupQueue)
 
-        try rotateBackups(in: backupsDirectory, retainingLast: retentionCount)
+        do {
+            try rotateBackups(in: backupsDirectory, retainingLast: retentionCount)
+        } catch {
+            Self.debugLog("PersistenceService: Failed to rotate old DB backups: \(error)")
+        }
     }
 
     private func rotateBackups(in directory: URL, retainingLast retentionCount: Int) throws {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -3417,6 +3417,27 @@ final class StreamDocumentTests: XCTestCase {
         )
     }
 
+    func test_migrationBackupFailurePreventsMigration() throws {
+        try withSeededV10Database { _ in
+            // v10 is intentionally behind the service's registered migrations.
+        } body: { dbURL, fileManager in
+            let backupsDirectory = dbURL.deletingLastPathComponent().appendingPathComponent("backups", isDirectory: true)
+            try fileManager.createDirectory(at: backupsDirectory, withIntermediateDirectories: true)
+            try fileManager.setAttributes([.posixPermissions: 0o444], ofItemAtPath: backupsDirectory.path)
+            defer {
+                try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: backupsDirectory.path)
+            }
+
+            XCTAssertThrowsError(try PersistenceService(databaseURL: dbURL, fileManager: fileManager))
+
+            let dbQueue = try DatabaseQueue(path: dbURL.path)
+            let migrationCount = try dbQueue.read { db in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM grdb_migrations")
+            }
+            XCTAssertEqual(migrationCount, 10)
+        }
+    }
+
     func test_v11MigrationRecoversPostDocumentQuickPanelCellsInOrder() throws {
         let streamId = UUID()
         let documentCreatedAt = 1_000.0

--- a/Web/src/App.test.ts
+++ b/Web/src/App.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { shouldAcceptStreamLoaded } from './App';
+
+describe('shouldAcceptStreamLoaded', () => {
+  it('accepts only the pending correlated response', () => {
+    expect(shouldAcceptStreamLoaded(2, 2)).toBe(true);
+    expect(shouldAcceptStreamLoaded(1, 2)).toBe(false);
+    expect(shouldAcceptStreamLoaded(2, null)).toBe(false);
+  });
+
+  it('accepts an uncorrelated native response only with no web load pending', () => {
+    expect(shouldAcceptStreamLoaded(undefined, null)).toBe(true);
+    expect(shouldAcceptStreamLoaded(undefined, 2)).toBe(false);
+  });
+});

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -35,6 +35,11 @@ const DEFAULT_EDITOR_TYPOGRAPHY: EditorTypographySettings = {
   editorLineSpacing: 1.55,
 };
 
+export function shouldAcceptStreamLoaded(requestId: unknown, pendingRequestId: number | null): boolean {
+  if (requestId === undefined) return pendingRequestId === null;
+  return typeof requestId === 'number' && Number.isInteger(requestId) && requestId === pendingRequestId;
+}
+
 function editorFontStack(font: EditorFont): string {
   switch (font) {
     case 'humanistSans':
@@ -82,6 +87,14 @@ export function App() {
   const addToast = useToastStore((state) => state.addToast);
   const viewRef = useRef(view);
   const currentStreamIdRef = useRef<string | null>(currentStream?.id ?? null);
+  const streamLoadSequenceRef = useRef(0);
+  const pendingStreamLoadRequestIdRef = useRef<number | null>(null);
+
+  const requestStreamLoad = (id: string) => {
+    const requestId = ++streamLoadSequenceRef.current;
+    pendingStreamLoadRequestIdRef.current = requestId;
+    bridge.send({ type: 'loadStream', payload: { id, requestId } });
+  };
 
   // Proxy auth state - gates main UI until key is validated
   const [proxyAuthState, setProxyAuthState] = useState<ProxyAuthState>('validating');
@@ -169,6 +182,9 @@ export function App() {
           setIsLoading(false);
           break;
         case 'streamLoaded': {
+          const requestId = message.payload?.requestId;
+          if (!shouldAcceptStreamLoaded(requestId, pendingStreamLoadRequestIdRef.current)) break;
+          pendingStreamLoadRequestIdRef.current = null;
           const payloadStream = message.payload?.stream as Stream | undefined;
           if (!payloadStream) break;
           const scrollOffset = Number(message.payload?.scrollOffset ?? payloadStream?.document?.scrollOffset ?? 0);
@@ -219,7 +235,7 @@ export function App() {
 
             debugLog('[App] Quick Panel created new stream document', { streamId });
 
-            bridge.send({ type: 'loadStream', payload: { id: streamId } });
+            requestStreamLoad(streamId);
           }
           break;
         case 'streamsChanged':
@@ -239,15 +255,17 @@ export function App() {
   }, [addToast]);
 
   const handleCreateStream = () => {
+    pendingStreamLoadRequestIdRef.current = null;
     bridge.send({ type: 'createStream' });
   };
 
   const handleSelectStream = (id: string) => {
     setIsLoadingStream(true);
-    bridge.send({ type: 'loadStream', payload: { id } });
+    requestStreamLoad(id);
   };
 
   const handleBackToList = () => {
+    pendingStreamLoadRequestIdRef.current = null;
     setCurrentStream(null);
     setView('list');
     bridge.send({ type: 'loadStreams' });
@@ -255,6 +273,7 @@ export function App() {
 
   const handleDeleteStream = () => {
     if (currentStream) {
+      pendingStreamLoadRequestIdRef.current = null;
       bridge.send({ type: 'deleteStream', payload: { id: currentStream.id } });
       setCurrentStream(null);
       setView('list');
@@ -280,7 +299,7 @@ export function App() {
     }
 
     setIsLoadingStream(true);
-    bridge.send({ type: 'loadStream', payload: { id: streamId } });
+    requestStreamLoad(streamId);
   };
 
   const handleNavigateToMatch = (matchText: string) => {

--- a/Web/src/components/StreamEditor.test.ts
+++ b/Web/src/components/StreamEditor.test.ts
@@ -3,7 +3,14 @@ import { history, undo } from '@codemirror/commands';
 import { describe, expect, it } from 'vitest';
 import { addSpans, currentSpans, provenanceField } from '../extensions/ProvenanceField';
 import { fnv1a } from '../utils/fnv1a';
-import { buildDocumentAIProvenanceSpan, documentAIErrorRecovery, nextSourceScope } from './StreamEditor';
+import { buildDocumentAIProvenanceSpan, documentAIErrorRecovery, isStreamDocumentDirty, nextSourceScope } from './StreamEditor';
+
+describe('isStreamDocumentDirty', () => {
+  it('only reports content that differs from the last successful save', () => {
+    expect(isStreamDocumentDirty('edited', 'saved')).toBe(true);
+    expect(isStreamDocumentDirty('saved', 'saved')).toBe(false);
+  });
+});
 
 describe('nextSourceScope', () => {
   it('cycles auto to all to none to auto', () => {

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -173,6 +173,10 @@ export function documentAIErrorRecovery(originalText: string, errorCode: string 
   };
 }
 
+export function isStreamDocumentDirty(content: string, lastSavedContent: string): boolean {
+  return content !== lastSavedContent;
+}
+
 export function buildDocumentAIProvenanceSpan(options: {
   requestId: string;
   start: number;
@@ -508,7 +512,7 @@ export function StreamEditor({
   const [highlightedSourceId, setHighlightedSourceId] = useState<string | null>(null);
   const [isProvenanceXrayVisible, setIsProvenanceXrayVisible] = useState(false);
   const [showRawFormatting, setShowRawFormatting] = useState(false);
-  const [saveState, setSaveState] = useState<'saved' | 'saving'>('saved');
+  const [saveState, setSaveState] = useState<'saved' | 'saving' | 'error'>('saved');
   const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
   const [promptValue, setPromptValue] = useState('');
@@ -551,6 +555,8 @@ export function StreamEditor({
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
+  const queuedSaveContentRef = useRef<string | null>(null);
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
@@ -941,6 +947,53 @@ export function StreamEditor({
     markdownContentRef.current = markdownContent;
   }, [markdownContent]);
 
+  const saveNow = useCallback(() => {
+    const contentToSave = markdownContentRef.current;
+    if (!isStreamDocumentDirty(contentToSave, lastSavedContentRef.current)) return saveQueueRef.current;
+    if (queuedSaveContentRef.current === contentToSave) return saveQueueRef.current;
+
+    const view = editorViewRef.current;
+    const spans = view ? serializeFieldSpans(currentSpans(view.state), contentToSave) : [];
+    queuedSaveContentRef.current = contentToSave;
+    setSaveState('saving');
+
+    const save = async () => {
+      const baseRevision = revisionRef.current;
+      try {
+        const response = await bridge.sendAsync<{ revision: number }>('saveStreamDocument', {
+          streamId: stream.id,
+          markdown: contentToSave,
+          baseRevision,
+          spans,
+        });
+        if (Number.isFinite(response.revision)) {
+          revisionRef.current = response.revision;
+        }
+        lastSavedContentRef.current = contentToSave;
+        if (markdownContentRef.current === contentToSave) {
+          setSaveState('saved');
+        }
+      } catch (error) {
+        if (markdownContentRef.current === contentToSave) {
+          setSaveState('error');
+        }
+        addToast('Changes could not be saved. Your edits are still in the editor.', 'error');
+        debugWarn('[StreamEditor] Failed to save stream document', {
+          streamId: stream.id,
+          baseRevision,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        if (queuedSaveContentRef.current === contentToSave) {
+          queuedSaveContentRef.current = null;
+        }
+      }
+    };
+
+    saveQueueRef.current = saveQueueRef.current.then(save, save);
+    return saveQueueRef.current;
+  }, [addToast, stream.id]);
+
   useEffect(() => {
     if (!pendingSourceId) return;
     if (sources.some((source) => source.id === pendingSourceId)) {
@@ -988,38 +1041,15 @@ export function StreamEditor({
   }, [pendingMatchText, onClearPendingMatch]);
 
   useEffect(() => {
-    if (markdownContent === lastSavedContentRef.current) return;
+    if (!isStreamDocumentDirty(markdownContent, lastSavedContentRef.current)) return;
     setSaveState('saving');
 
     const timer = window.setTimeout(() => {
-      const contentToSave = markdownContent;
-      const baseRevision = revisionRef.current;
-      const view = editorViewRef.current;
-
-      void bridge.sendAsync<{ revision: number }>('saveStreamDocument', {
-        streamId: stream.id,
-        markdown: contentToSave,
-        baseRevision,
-        spans: view ? serializeFieldSpans(currentSpans(view.state), contentToSave) : [],
-      }).then((response) => {
-        if (Number.isFinite(response.revision)) {
-          revisionRef.current = response.revision;
-        }
-        lastSavedContentRef.current = contentToSave;
-        if (markdownContentRef.current === contentToSave) {
-          setSaveState('saved');
-        }
-      }).catch((error) => {
-        debugWarn('[StreamEditor] Failed to save stream document', {
-          streamId: stream.id,
-          baseRevision,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
+      void saveNow();
     }, 350);
 
     return () => window.clearTimeout(timer);
-  }, [markdownContent, stream.id]);
+  }, [markdownContent, saveNow]);
 
   useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
@@ -2345,6 +2375,13 @@ export function StreamEditor({
 
   useEffect(() => {
     return () => {
+      void saveNow();
+      abortInFlightDocumentAI();
+    };
+  }, [abortInFlightDocumentAI, saveNow]);
+
+  useEffect(() => {
+    return () => {
       flushScrollPosition();
       scrollCleanupRef.current?.();
       scrollCleanupRef.current = null;
@@ -2501,7 +2538,7 @@ export function StreamEditor({
         )}
         <div className="stream-header-actions">
           <span className={`stream-save-status stream-save-status--${saveState}`}>
-            {saveState === 'saving' ? 'Saving…' : 'Saved'}
+            {saveState === 'saving' ? 'Saving…' : saveState === 'error' ? 'Save failed' : 'Saved'}
           </span>
           <button
             onClick={() => setIsProvenanceXrayVisible((value) => !value)}
@@ -2983,6 +3020,7 @@ export function StreamEditor({
 
               }}
               onChange={(value) => {
+                markdownContentRef.current = value;
                 setMarkdownContent(value);
               }}
               className="document-editor-codemirror"

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -878,6 +878,10 @@ body {
   color: var(--color-text-secondary);
 }
 
+.stream-save-status--error {
+  color: var(--color-error);
+}
+
 .selection-action-menu {
   position: fixed;
   z-index: 920;

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -109,7 +109,7 @@
       },
       "streamLoaded": {
         "requiredPayloadKeys": ["stream", "spans", "marginNotes"],
-        "optionalPayloadKeys": ["scrollOffset", "sourceScope"]
+        "optionalPayloadKeys": ["scrollOffset", "sourceScope", "requestId"]
       },
       "streamTitleUpdated": {
         "requiredPayloadKeys": ["id", "title"]
@@ -163,7 +163,8 @@
         "requiredPayloadKeys": []
       },
       "loadStream": {
-        "requiredPayloadKeys": ["id"]
+        "requiredPayloadKeys": ["id"],
+        "optionalPayloadKeys": ["requestId"]
       },
       "loadStreams": {
         "requiredPayloadKeys": []


### PR DESCRIPTION
Audit findings #1, #10, #6 (docs/audits/AUDIT_2026-07-10.md): flush-on-teardown saves with visible error state + in-flight AI abort, requestId-correlated streamLoaded, backup-before-migrate hard gate. All gates green; implemented by Codex Sol high, reviewed by governor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)