### PR TITLE
Audit P2: editor performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- Selection dragging in large documents now avoids repeated text extraction and dormant margin-note/find rescans.
 - Large documents now avoid full-document React updates and editor reconfiguration on every keystroke, making typing more responsive.
 - AI answers now fold the question's substance into their opening sentence so saved passages read complete on their own.
 - The Claude model option is now marked "Coming soon"; AI requests route to the OpenAI models until it ships.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- Provenance spans now avoid unnecessary rehashing during edits and preserve distinct adjacent source attribution.
 - Selection dragging in large documents now avoids repeated text extraction and dormant margin-note/find rescans.
 - Large documents now avoid full-document React updates and editor reconfiguration on every keystroke, making typing more responsive.
 - AI answers now fold the question's substance into their opening sentence so saved passages read complete on their own.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- Large documents now avoid full-document React updates and editor reconfiguration on every keystroke, making typing more responsive.
 - AI answers now fold the question's substance into their opening sentence so saved passages read complete on their own.
 - The Claude model option is now marked "Coming soon"; AI requests route to the OpenAI models until it ships.
 - Document AI now biases toward the only attached large source when a question has weak but present lexical overlap.

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -493,6 +493,13 @@ const markdownHighlightStyle = HighlightStyle.define([
   },
 ]);
 
+const editorBasicSetup = {
+  lineNumbers: false,
+  foldGutter: false,
+  highlightActiveLine: false,
+  highlightActiveLineGutter: false,
+};
+
 export function StreamEditor({
   stream,
   onBack,
@@ -513,7 +520,7 @@ export function StreamEditor({
   const [isProvenanceXrayVisible, setIsProvenanceXrayVisible] = useState(false);
   const [showRawFormatting, setShowRawFormatting] = useState(false);
   const [saveState, setSaveState] = useState<'saved' | 'saving' | 'error'>('saved');
-  const [markdownContent, setMarkdownContent] = useState(stream.document?.markdown ?? '');
+  const initialMarkdownRef = useRef(stream.document?.markdown ?? '');
   const [showPrompt, setShowPrompt] = useState(false);
   const [promptValue, setPromptValue] = useState('');
   const [promptIntent, setPromptIntent] = useState<PromptIntent>({ kind: 'ask' });
@@ -557,6 +564,7 @@ export function StreamEditor({
   const revisionRef = useRef(stream.document?.revision ?? 0);
   const queuedSaveContentRef = useRef<string | null>(null);
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const autosaveTimerRef = useRef<number | null>(null);
   const promptContextRef = useRef<SelectionContext | null>(null);
   const selectionMenuTimerRef = useRef<number | null>(null);
   const aiFeedbackTimerRef = useRef<number | null>(null);
@@ -588,7 +596,7 @@ export function StreamEditor({
     const view = editorViewRef.current;
 
     if (!view) {
-      setMarkdownContent((prev) => `${prev}${snippet}`);
+      markdownContentRef.current += snippet;
       return;
     }
 
@@ -608,7 +616,7 @@ export function StreamEditor({
     const view = editorViewRef.current;
 
     if (!view) {
-      setMarkdownContent((prev) => `${prev}${snippet}`);
+      markdownContentRef.current += snippet;
       return;
     }
 
@@ -880,7 +888,10 @@ export function StreamEditor({
   }, [persistMarginNoteStatus]);
 
   useEffect(() => {
-    setMarkdownContent(stream.document?.markdown ?? '');
+    if (autosaveTimerRef.current !== null) {
+      window.clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
     lastSavedContentRef.current = stream.document?.markdown ?? '';
     markdownContentRef.current = stream.document?.markdown ?? '';
     revisionRef.current = stream.document?.revision ?? 0;
@@ -943,13 +954,13 @@ export function StreamEditor({
     applyMarginNotesToEditor(stream.marginNotes);
   }, [applyMarginNotesToEditor, stream.id, stream.marginNotes]);
 
-  useEffect(() => {
-    markdownContentRef.current = markdownContent;
-  }, [markdownContent]);
-
   const saveNow = useCallback(() => {
-    const contentToSave = markdownContentRef.current;
-    if (!isStreamDocumentDirty(contentToSave, lastSavedContentRef.current)) return saveQueueRef.current;
+    const contentToSave = editorViewRef.current?.state.doc.toString() ?? markdownContentRef.current;
+    markdownContentRef.current = contentToSave;
+    if (!isStreamDocumentDirty(contentToSave, lastSavedContentRef.current)) {
+      setSaveState('saved');
+      return saveQueueRef.current;
+    }
     if (queuedSaveContentRef.current === contentToSave) return saveQueueRef.current;
 
     const view = editorViewRef.current;
@@ -993,6 +1004,15 @@ export function StreamEditor({
     saveQueueRef.current = saveQueueRef.current.then(save, save);
     return saveQueueRef.current;
   }, [addToast, stream.id]);
+
+  const scheduleAutosave = useCallback((view: EditorView) => {
+    if (autosaveTimerRef.current !== null) window.clearTimeout(autosaveTimerRef.current);
+    setSaveState('saving');
+    autosaveTimerRef.current = window.setTimeout(() => {
+      autosaveTimerRef.current = null;
+      if (editorViewRef.current === view) void saveNow();
+    }, 350);
+  }, [saveNow]);
 
   useEffect(() => {
     if (!pendingSourceId) return;
@@ -1041,17 +1061,6 @@ export function StreamEditor({
   }, [pendingMatchText, onClearPendingMatch]);
 
   useEffect(() => {
-    if (!isStreamDocumentDirty(markdownContent, lastSavedContentRef.current)) return;
-    setSaveState('saving');
-
-    const timer = window.setTimeout(() => {
-      void saveNow();
-    }, 350);
-
-    return () => window.clearTimeout(timer);
-  }, [markdownContent, saveNow]);
-
-  useEffect(() => {
     const unsubscribe = bridge.onMessage((message) => {
       if (message.type === 'quickPanelAIStarted') {
         if (message.payload?.streamId !== stream.id) return;
@@ -1097,7 +1106,6 @@ export function StreamEditor({
         revisionRef.current = revision;
         markdownContentRef.current = markdown;
         lastSavedContentRef.current = markdown;
-        setMarkdownContent(markdown);
         setSaveState('saved');
 
         debugWarn('[StreamEditor] Reloaded document after revision conflict', {
@@ -1172,7 +1180,6 @@ export function StreamEditor({
           lastSavedContentRef.current = nextMarkdown;
           setSaveState('saved');
         }
-        setMarkdownContent(nextMarkdown);
         return;
       }
 
@@ -1997,6 +2004,8 @@ export function StreamEditor({
 
   const selectionMenuExtension = useMemo<Extension>(() => [
     EditorView.updateListener.of((update) => {
+      if (update.docChanged) scheduleAutosave(update.view);
+
       if (update.docChanged && pendingPDFAnchorSelectionRef.current) {
         pendingPDFAnchorSelectionRef.current = mapPendingPDFAnchorSelection(
           pendingPDFAnchorSelectionRef.current,
@@ -2022,7 +2031,7 @@ export function StreamEditor({
         hideSelectionMenu();
       },
     }),
-  ], [hideSelectionMenu, scheduleSelectionMenu]);
+  ], [hideSelectionMenu, scheduleAutosave, scheduleSelectionMenu]);
 
   const startDocumentAI = useCallback((options: {
     query: string;
@@ -2375,6 +2384,10 @@ export function StreamEditor({
 
   useEffect(() => {
     return () => {
+      if (autosaveTimerRef.current !== null) {
+        window.clearTimeout(autosaveTimerRef.current);
+        autosaveTimerRef.current = null;
+      }
       void saveNow();
       abortInFlightDocumentAI();
     };
@@ -2507,6 +2520,42 @@ export function StreamEditor({
     onDismiss: handleDismissMarginNote,
     onUnanchor: (note) => persistMarginNoteStatus(note, 'unanchored'),
   }), [handleDismissMarginNote, handlePromoteMarginNote, persistMarginNoteStatus]);
+
+  const editorExtensions = useMemo<Extension[]>(() => [
+    EditorView.lineWrapping,
+    EditorView.contentAttributes.of({
+      spellcheck: 'true',
+      autocapitalize: 'sentences',
+      autocomplete: 'on',
+      autocorrect: 'on',
+    }),
+    selectionMenuExtension,
+    clickToDocumentEndExtension,
+    aiWritingExtension,
+    editorFindExtension,
+    markdown({ base: markdownLanguage, codeLanguages: languages }),
+    // basicSetup's default Enter shadows the markdown bindings.
+    // Bullet lines get our always-tight continuation; everything
+    // else falls through to markdownKeymap (quote continuation,
+    // Backspace marker deletion).
+    Prec.high(keymap.of([
+      { key: 'Enter', run: continueBulletListOnEnter },
+      { key: 'Mod-b', run: toggleInlineMarkCommand('**') },
+      { key: 'Mod-i', run: toggleInlineMarkCommand('*') },
+      ...markdownKeymap,
+    ])),
+    syntaxHighlighting(markdownHighlightStyle),
+    markdownConcealExtension,
+    arrivalField,
+    provenanceField,
+    marginNotesField,
+    pendingAppendField,
+    markdownImageWidgetExtension,
+    provenanceXray,
+    marginNotesExtensionValue,
+    tickerPDFLinkExtension(stream.id),
+    linkInteraction,
+  ], [linkInteraction, marginNotesExtensionValue, provenanceXray, selectionMenuExtension, stream.id]);
 
   const selectionDissolveSpanIds = (() => {
     const view = editorViewRef.current;
@@ -2936,50 +2985,17 @@ export function StreamEditor({
             onDragOver={handleDragOver}
           >
             <CodeMirror
-              value={markdownContent}
-              basicSetup={{
-                lineNumbers: false,
-                foldGutter: false,
-                highlightActiveLine: false,
-                highlightActiveLineGutter: false,
-              }}
-              extensions={[
-                EditorView.lineWrapping,
-                EditorView.contentAttributes.of({
-                  spellcheck: 'true',
-                  autocapitalize: 'sentences',
-                  autocomplete: 'on',
-                  autocorrect: 'on',
-                }),
-                selectionMenuExtension,
-                clickToDocumentEndExtension,
-                aiWritingExtension,
-                editorFindExtension,
-                markdown({ base: markdownLanguage, codeLanguages: languages }),
-                // basicSetup's default Enter shadows the markdown bindings.
-                // Bullet lines get our always-tight continuation; everything
-                // else falls through to markdownKeymap (quote continuation,
-                // Backspace marker deletion).
-                Prec.high(keymap.of([
-                  { key: 'Enter', run: continueBulletListOnEnter },
-                  { key: 'Mod-b', run: toggleInlineMarkCommand('**') },
-                  { key: 'Mod-i', run: toggleInlineMarkCommand('*') },
-                  ...markdownKeymap,
-                ])),
-                syntaxHighlighting(markdownHighlightStyle),
-                markdownConcealExtension,
-                arrivalField,
-                provenanceField,
-                marginNotesField,
-                pendingAppendField,
-                markdownImageWidgetExtension,
-                provenanceXray,
-                marginNotesExtensionValue,
-                tickerPDFLinkExtension(stream.id),
-                linkInteraction,
-              ]}
+              value={initialMarkdownRef.current}
+              basicSetup={editorBasicSetup}
+              extensions={editorExtensions}
               onCreateEditor={(view) => {
                 editorViewRef.current = view;
+                if (markdownContentRef.current !== view.state.doc.toString()) {
+                  view.dispatch({
+                    changes: { from: 0, to: view.state.doc.length, insert: markdownContentRef.current },
+                    annotations: Transaction.addToHistory.of(false),
+                  });
+                }
                 view.dispatch({
                   effects: [
                     setSpans.of(payloadSpansForDoc(stream.spans, view.state.doc.toString())),
@@ -3017,11 +3033,6 @@ export function StreamEditor({
                     }
                   });
                 });
-
-              }}
-              onChange={(value) => {
-                markdownContentRef.current = value;
-                setMarkdownContent(value);
               }}
               className="document-editor-codemirror"
             />

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -342,7 +342,7 @@ function fieldSpanToPayload(span: Span): ProvenanceSpanJSON {
 }
 
 function serializeFieldSpans(spans: Span[], doc: string): ProvenanceSpanJSON[] {
-  return serializeProvenanceSpans(normalizeSpans(spans, doc).map(fieldSpanToPayload));
+  return serializeProvenanceSpans(normalizeSpans(spans, doc, true).map(fieldSpanToPayload));
 }
 
 function persistNewUnanchoredMarginNotes(rawNotes: Stream['marginNotes'], notes: MarginNote[]): void {

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -23,15 +23,10 @@ import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField,
 import { canRedevelopSpan, provenanceXrayExtension } from '../extensions/ProvenanceXray';
 import { pendingAppendField, setPendingAppend } from '../extensions/PendingAppend';
 import {
-  buildPromoteMarginNoteEdit,
-  currentMarginNotes,
-  marginNotesExtension,
   marginNotesField,
   payloadMarginNotesForDoc,
   setMarginNotes,
-  updateMarginNoteStatusEffect,
   type MarginNote,
-  type MarginNoteStatus,
 } from '../extensions/MarginNotes';
 import { computeAppendInsertion } from '../utils/appendInsertion';
 import { buildProvenanceLine, swapCitationMarkersWithMetadata } from '../utils/citationMarkers';
@@ -846,46 +841,6 @@ export function StreamEditor({
     });
     persistNewUnanchoredMarginNotes(rawNotes, notes);
   }, []);
-
-  const persistMarginNoteStatus = useCallback((note: Pick<MarginNote, 'noteId'>, status: MarginNoteStatus) => {
-    updateMarginNote({ noteId: note.noteId, status });
-  }, []);
-
-  const handleDismissMarginNote = useCallback((note: MarginNote) => {
-    const view = editorViewRef.current;
-    if (view) {
-      view.dispatch({
-        effects: updateMarginNoteStatusEffect.of({ noteId: note.noteId, status: 'dismissed' }),
-        annotations: Transaction.addToHistory.of(false),
-      });
-      view.focus();
-    }
-    persistMarginNoteStatus(note, 'dismissed');
-  }, [persistMarginNoteStatus]);
-
-  const handlePromoteMarginNote = useCallback((note: MarginNote) => {
-    const view = editorViewRef.current;
-    if (!view) return;
-    const currentNote = currentMarginNotes(view.state).find((candidate) => candidate.noteId === note.noteId) ?? note;
-    const edit = buildPromoteMarginNoteEdit(currentNote, view.state.doc.toString());
-    if (!edit) return;
-
-    view.dispatch({
-      changes: { from: edit.from, insert: edit.insert },
-      selection: { anchor: edit.from + edit.insert.length },
-      effects: [
-        addSpans.of([edit.span]),
-        updateMarginNoteStatusEffect.of({ noteId: note.noteId, status: 'promoted' }),
-      ],
-      annotations: [
-        Transaction.addToHistory.of(true),
-        Transaction.userEvent.of('input'),
-        isolateHistory.of('full'),
-      ],
-    });
-    view.focus();
-    persistMarginNoteStatus(note, 'promoted');
-  }, [persistMarginNoteStatus]);
 
   useEffect(() => {
     if (autosaveTimerRef.current !== null) {
@@ -1836,8 +1791,8 @@ export function StreamEditor({
       return;
     }
 
-    const selection = view.state.selection.main;
-    if (selection.empty || !view.state.sliceDoc(selection.from, selection.to).trim()) {
+    const { from, to } = view.state.selection.main;
+    if (from === to) {
       hideSelectionMenu();
       return;
     }
@@ -1852,9 +1807,9 @@ export function StreamEditor({
       }
 
       const currentSelection = currentView.state.selection.main;
-      const selectedText = currentView.state.sliceDoc(currentSelection.from, currentSelection.to);
+      const selectedText = currentView.state.sliceDoc(from, to);
       const placement = getSelectionMenuPlacement(currentView);
-      if (currentSelection.empty || !selectedText.trim() || !placement) {
+      if (currentSelection.from !== from || currentSelection.to !== to || !selectedText.trim() || !placement) {
         hideSelectionMenu();
         return;
       }
@@ -2512,15 +2467,6 @@ export function StreamEditor({
       : []
   ), [handleOpenSourceById, isAiThinking, isProvenanceXrayVisible, openRedevelopPrompt, sources]);
 
-  const marginNotesExtensionValue = useMemo<Extension>(() => marginNotesExtension({
-    // Margin rendering is retired from the UI; the field stays wired so
-    // existing notes keep mapping/persisting their anchors dormant.
-    visible: false,
-    onPromote: handlePromoteMarginNote,
-    onDismiss: handleDismissMarginNote,
-    onUnanchor: (note) => persistMarginNoteStatus(note, 'unanchored'),
-  }), [handleDismissMarginNote, handlePromoteMarginNote, persistMarginNoteStatus]);
-
   const editorExtensions = useMemo<Extension[]>(() => [
     EditorView.lineWrapping,
     EditorView.contentAttributes.of({
@@ -2552,10 +2498,9 @@ export function StreamEditor({
     pendingAppendField,
     markdownImageWidgetExtension,
     provenanceXray,
-    marginNotesExtensionValue,
     tickerPDFLinkExtension(stream.id),
     linkInteraction,
-  ], [linkInteraction, marginNotesExtensionValue, provenanceXray, selectionMenuExtension, stream.id]);
+  ], [linkInteraction, provenanceXray, selectionMenuExtension, stream.id]);
 
   const selectionDissolveSpanIds = (() => {
     const view = editorViewRef.current;

--- a/Web/src/extensions/EditorFindPanel.ts
+++ b/Web/src/extensions/EditorFindPanel.ts
@@ -126,6 +126,8 @@ class EditorFindPanel implements Panel {
   readonly top = true;
 
   private query: SearchQuery;
+  private matches: EditorFindMatch[] = [];
+  private capped = false;
   private readonly input: HTMLInputElement;
   private readonly count: HTMLSpanElement;
 
@@ -154,6 +156,7 @@ class EditorFindPanel implements Panel {
 
     this.input.addEventListener('input', this.handleInput);
     this.dom.addEventListener('keydown', this.handleKeyDown);
+    this.refreshMatches();
     this.refreshCount();
   }
 
@@ -173,6 +176,9 @@ class EditorFindPanel implements Panel {
       }
     }
 
+    if (queryChanged || update.docChanged) {
+      this.refreshMatches();
+    }
     if (queryChanged || update.docChanged || update.selectionSet) {
       this.refreshCount();
     }
@@ -202,10 +208,8 @@ class EditorFindPanel implements Panel {
   private handleInput = (): void => {
     const anchor = this.view.state.selection.main.from;
     const query = createLiteralQuery(this.input.value);
-    this.query = query;
     this.view.dispatch({ effects: setSearchQuery.of(query) });
     selectNearestMatch(this.view, query, anchor);
-    this.refreshCount();
   };
 
   private handleKeyDown = (event: KeyboardEvent): void => {
@@ -220,12 +224,16 @@ class EditorFindPanel implements Panel {
     }
   };
 
+  private refreshMatches(): void {
+    const result = collectMatches(this.view, this.query);
+    this.matches = result.matches;
+    this.capped = result.capped;
+  }
+
   private refreshCount(): void {
-    const query = getSearchQuery(this.view.state);
-    const { matches, capped } = collectMatches(this.view, query);
     const selection = this.view.state.selection.main;
     this.count.textContent = formatEditorFindCount(
-      deriveEditorFindCount(matches, { from: selection.from, to: selection.to }, capped),
+      deriveEditorFindCount(this.matches, { from: selection.from, to: selection.to }, this.capped),
     );
   }
 }

--- a/Web/src/extensions/MarginNotes.test.ts
+++ b/Web/src/extensions/MarginNotes.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
 import { fnv1a } from '../utils/fnv1a';
 import {
   buildPromoteMarginNoteEdit,
+  currentMarginNotes,
+  marginNotesField,
   normalizeMarginNoteAnchors,
+  setMarginNotes,
   stackMarginCards,
   type MarginNote,
 } from './MarginNotes';
@@ -40,6 +44,16 @@ describe('MarginNotes', () => {
   it('marks anchor hash mismatches as unanchored', () => {
     expect(normalizeMarginNoteAnchors([note()], 'Hello world')[0].status).toBe('open');
     expect(normalizeMarginNoteAnchors([note()], 'Hullo world')[0].status).toBe('unanchored');
+  });
+
+  it('preserves field identity for selection-only transactions', () => {
+    let state = EditorState.create({ doc: 'Hello world', extensions: [marginNotesField] });
+    state = state.update({ effects: setMarginNotes.of([note()]) }).state;
+    const notes = currentMarginNotes(state);
+
+    state = state.update({ selection: { anchor: 5 } }).state;
+
+    expect(currentMarginNotes(state)).toBe(notes);
   });
 
   it('builds promote insertion at paragraph end with an ai span', () => {

--- a/Web/src/extensions/MarginNotes.ts
+++ b/Web/src/extensions/MarginNotes.ts
@@ -156,18 +156,21 @@ export const marginNotesField: StateField<MarginNote[]> = StateField.define<Marg
     let next = transaction.docChanged
       ? notes.map((note) => mapNote(note, transaction, insertionChanges(transaction)))
       : notes;
+    let affected = transaction.docChanged;
 
     for (const effect of transaction.effects) {
       if (effect.is(setMarginNotes)) {
         next = effect.value;
+        affected = true;
       } else if (effect.is(updateMarginNoteStatusEffect)) {
         next = next.map((note) => (
           note.noteId === effect.value.noteId ? { ...note, status: effect.value.status } : note
         ));
+        affected = true;
       }
     }
 
-    return normalizeMarginNoteAnchors(next, transaction.state.doc);
+    return affected ? normalizeMarginNoteAnchors(next, transaction.state.doc) : notes;
   },
 });
 

--- a/Web/src/extensions/ProvenanceField.test.ts
+++ b/Web/src/extensions/ProvenanceField.test.ts
@@ -69,6 +69,15 @@ describe('ProvenanceField', () => {
     expectHashesMatch(state);
   });
 
+  it('keeps the existing hash when edits do not touch covered text', () => {
+    const original = spanFor('beforeHello', 6, 11, { spanId: 'span-1' });
+    let state = stateWith('beforeHello', [{ ...original, textHash: 'already-verified' }]);
+
+    state = state.update({ changes: { from: 0, insert: 'X' } }).state;
+
+    expect(currentSpans(state)[0].textHash).toBe('already-verified');
+  });
+
   it('shrinks a span across deletions', () => {
     let state = stateWith('abcdefghi', [spanFor('abcdefghi', 2, 8, { spanId: 'span-1' })]);
 
@@ -98,6 +107,15 @@ describe('ProvenanceField', () => {
         textHash: fnv1a('abcdef'),
       },
     ]);
+  });
+
+  it('does not merge adjacent spans with different source attribution or metadata', () => {
+    const doc = 'abcdefghi';
+    const first = spanFor(doc, 0, 3, { spanId: 'a', requestId: 'r1', sourceId: 'source-1', meta: { page: 1 } });
+    const differentSource = spanFor(doc, 3, 6, { spanId: 'b', requestId: 'r1', sourceId: 'source-2', meta: { page: 1 } });
+    const differentMeta = spanFor(doc, 6, 9, { spanId: 'c', requestId: 'r1', sourceId: 'source-2', meta: { page: 2 } });
+
+    expect(normalizeSpans([first, differentSource, differentMeta], doc)).toHaveLength(3);
   });
 
   it('restores dissolved spans through undo', () => {

--- a/Web/src/extensions/ProvenanceField.ts
+++ b/Web/src/extensions/ProvenanceField.ts
@@ -26,7 +26,14 @@ function docLength(doc: Text | string): number {
   return typeof doc === 'string' ? doc.length : doc.length;
 }
 
-function withHash(span: Span, start: number, end: number, doc: Text | string, spanId = span.spanId): Span | null {
+function withHash(
+  span: Span,
+  start: number,
+  end: number,
+  doc: Text | string,
+  spanId = span.spanId,
+  keepHash = false,
+): Span | null {
   if (start < 0 || end > docLength(doc) || end - start < 3) return null;
   return {
     ...span,
@@ -34,8 +41,20 @@ function withHash(span: Span, start: number, end: number, doc: Text | string, sp
     start,
     end,
     meta: { ...span.meta },
-    textHash: fnv1a(docText(doc, start, end)),
+    textHash: keepHash ? span.textHash : fnv1a(docText(doc, start, end)),
   };
+}
+
+function spanTextChanged(span: Span, transaction: Transaction): boolean {
+  let changed = false;
+  transaction.changes.iterChanges((fromA, toA) => {
+    if (fromA === toA) {
+      if (fromA > span.start && fromA < span.end) changed = true;
+    } else if (fromA < span.end && toA > span.start) {
+      changed = true;
+    }
+  });
+  return changed;
 }
 
 function insertionChanges(transaction: Transaction) {
@@ -76,7 +95,9 @@ function mapSpan(span: Span, transaction: Transaction, insertions: Array<{ from:
       span,
       mapBoundaryStart(span, transaction, insertions),
       mapBoundaryEnd(span, transaction, insertions),
-      transaction.state.doc
+      transaction.state.doc,
+      span.spanId,
+      !spanTextChanged(span, transaction),
     );
     return mapped ? [mapped] : [];
   }
@@ -101,10 +122,10 @@ function mapSpan(span: Span, transaction: Transaction, insertions: Array<{ from:
   return pieces;
 }
 
-export function normalizeSpans(spans: Span[], doc: Text | string): Span[] {
+export function normalizeSpans(spans: Span[], doc: Text | string, keepHashes = false): Span[] {
   const sorted = spans
     .flatMap((span) => {
-      const normalized = withHash(span, span.start, span.end, doc);
+      const normalized = withHash(span, span.start, span.end, doc, span.spanId, keepHashes);
       return normalized ? [normalized] : [];
     })
     .sort((a, b) => a.start - b.start || a.end - b.end || a.spanId.localeCompare(b.spanId));
@@ -112,7 +133,15 @@ export function normalizeSpans(spans: Span[], doc: Text | string): Span[] {
   const merged: Span[] = [];
   for (const span of sorted) {
     const previous = merged[merged.length - 1];
-    if (previous && previous.end === span.start && previous.requestId === span.requestId && previous.origin === span.origin) {
+    if (
+      previous
+      && previous.end === span.start
+      && previous.origin === span.origin
+      && previous.requestId === span.requestId
+      && previous.sourceId === span.sourceId
+      && previous.createdAt === span.createdAt
+      && JSON.stringify(previous.meta) === JSON.stringify(span.meta)
+    ) {
       const combined = withHash(previous, previous.start, span.end, doc);
       if (combined) merged[merged.length - 1] = combined;
       continue;
@@ -125,9 +154,8 @@ export function normalizeSpans(spans: Span[], doc: Text | string): Span[] {
 export const provenanceField: StateField<Span[]> = StateField.define<Span[]>({
   create: () => [],
   update(spans, transaction) {
-    let next = transaction.docChanged
-      ? spans.flatMap((span) => mapSpan(span, transaction, insertionChanges(transaction)))
-      : spans;
+    const insertions = transaction.docChanged ? insertionChanges(transaction) : [];
+    let next = transaction.docChanged ? spans.flatMap((span) => mapSpan(span, transaction, insertions)) : spans;
 
     for (const effect of transaction.effects) {
       if (effect.is(setSpans)) {


### PR DESCRIPTION
Audit findings #2, #3, #4: uncontrolled CodeMirror after mount (no per-keystroke full-doc copies or extension reconfigure), selection ticks record ranges only, inert margin-note field, cached Find matches, provenance hash retention + attribution-safe merging. All gates green; implemented by Codex Sol medium, reviewed by governor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)