### PR TITLE
Audit P3: bridge correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Bridge callback failures now return immediately instead of timing out, and production surfaces a safe error when native actions fail.
 - Quick Panel AI now clears the editor typing indicator and shows an error if its answer cannot be saved.
 - Quick Panel now ignores late AI callbacks from a cancelled request after a new conversation request starts.
 - Bridge sends now enforce the main-thread boundary, and overlapping document AI cancellation can no longer race its request registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Quick Panel now ignores late AI callbacks from a cancelled request after a new conversation request starts.
 - Bridge sends now enforce the main-thread boundary, and overlapping document AI cancellation can no longer race its request registry.
 - Database upgrades now stop before migration when the required safety backup cannot be created.
 - Rapid stream navigation can no longer be overwritten by an older, slower stream load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Bridge sends now enforce the main-thread boundary, and overlapping document AI cancellation can no longer race its request registry.
 - Database upgrades now stop before migration when the required safety backup cannot be created.
 - Rapid stream navigation can no longer be overwritten by an older, slower stream load.
 - Leaving a stream now flushes pending edits, stops in-flight document AI, and visibly reports save failures instead of remaining stuck on “Saving…”.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Quick Panel AI now clears the editor typing indicator and shows an error if its answer cannot be saved.
 - Quick Panel now ignores late AI callbacks from a cancelled request after a new conversation request starts.
 - Bridge sends now enforce the main-thread boundary, and overlapping document AI cancellation can no longer race its request registry.
 - Database upgrades now stop before migration when the required safety backup cannot be created.

--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -107,6 +107,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     /// Complete startup after onboarding (or skip if not needed)
+    @MainActor
     private func completeStartup() {
         guard !didCompleteStartup else { return }
         didCompleteStartup = true
@@ -127,9 +128,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func showOnboarding() {
         let onboardingView = OnboardingView {
             // Onboarding complete callback
-            self.onboardingWindow?.close()
-            self.onboardingWindow = nil
-            self.completeStartup()
+            Task { @MainActor in
+                self.onboardingWindow?.close()
+                self.onboardingWindow = nil
+                self.completeStartup()
+            }
         }
 
         let hostingView = NSHostingView(rootView: onboardingView)
@@ -241,6 +244,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    @MainActor
     private func handleTickerURL(_ url: URL) {
         guard let command = TickerURLCommand.parse(url) else {
             DebugLog.log("[TickerURL] Ignored malformed URL: \(url.absoluteString)")
@@ -455,6 +459,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             && event.charactersIgnoringModifiers?.lowercased() == "f"
     }
 
+    @MainActor
     private func setupMainWindow(container: ServiceContainer) {
         let autosaveName = "TickerMainWindow"
         let hasSavedFrame = UserDefaults.standard.string(forKey: "NSWindow Frame \(autosaveName)") != nil

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -75,6 +75,7 @@ private enum DocumentAIVerb: String {
     }
 }
 
+@MainActor
 final class AIMessageHandler: BridgeMessageHandler {
     let handledTypes: Set<String> = [
         "thinkDocument",
@@ -107,7 +108,7 @@ final class AIMessageHandler: BridgeMessageHandler {
             bridgeService.send(message)
         }
         self.sendBridgeErrorMessage = { [bridgeService = container.bridgeService] type, reason in
-            await bridgeService.sendBridgeError(type: type, reason: reason)
+            bridgeService.sendBridgeError(type: type, reason: reason)
         }
         self.isProxyUsable = { [deviceKeyService = container.deviceKeyService] in
             await deviceKeyService.currentState.isUsable

--- a/Sources/Ticker/App/Bridge/BridgeRouter.swift
+++ b/Sources/Ticker/App/Bridge/BridgeRouter.swift
@@ -23,7 +23,7 @@ final class BridgeRouter {
     func route(_ message: BridgeMessage) async {
         guard let handler = handlersByType[message.type] else {
             DebugLog.log("[BridgeRouter] Unknown message type: \(message.type)")
-            await bridgeService.sendBridgeError(type: message.type, reason: "Unknown bridge message type")
+            await bridgeService.reject(message, reason: "Unknown bridge message type")
             return
         }
 

--- a/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
+++ b/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
@@ -64,11 +64,14 @@ final class ProxyAuthHandler: BridgeMessageHandler {
             }
 
         case "setProxyDeviceKey":
+            guard let callbackId = message.callbackId else {
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for setProxyDeviceKey")
+                return
+            }
             guard let payload = message.payload,
-                  let key = payload["key"]?.value as? String,
-                  let callbackId = message.callbackId else {
+                  let key = payload["key"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid setProxyDeviceKey payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid setProxyDeviceKey payload")
+                await bridgeService.respondWithError(to: callbackId, error: "Invalid setProxyDeviceKey payload")
                 return
             }
             Task {
@@ -166,12 +169,15 @@ final class ProxyAuthHandler: BridgeMessageHandler {
             }
 
         case "submitFeedback":
-            guard let callbackId = message.callbackId,
-                  let payload = message.payload,
+            guard let callbackId = message.callbackId else {
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for submitFeedback")
+                return
+            }
+            guard let payload = message.payload,
                   let feedbackType = payload["type"]?.value as? String,
                   let title = payload["title"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid submitFeedback payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid submitFeedback payload")
+                await bridgeService.respondWithError(to: callbackId, error: "Invalid submitFeedback payload")
                 return
             }
             let description = payload["description"]?.value as? String

--- a/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SearchMessageHandler.swift
@@ -16,11 +16,14 @@ final class SearchMessageHandler: BridgeMessageHandler {
     func handle(_ message: BridgeMessage) async {
         switch message.type {
         case "hybridSearch":
+            guard let callbackId = message.callbackId else {
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for hybridSearch")
+                return
+            }
             guard let payload = message.payload,
-                  let query = payload["query"]?.value as? String,
-                  let callbackId = message.callbackId else {
+                  let query = payload["query"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid hybridSearch payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid hybridSearch payload")
+                await bridgeService.respondWithError(to: callbackId, error: "Invalid hybridSearch payload")
                 return
             }
 
@@ -31,7 +34,6 @@ final class SearchMessageHandler: BridgeMessageHandler {
 
             guard let searchService = searchService else {
                 Task { @MainActor in
-                    bridgeService.sendBridgeError(type: message.type, reason: "Search service not available")
                     bridgeService.respondWithError(to: callbackId, error: "Search service not available")
                 }
                 return

--- a/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SettingsMessageHandler.swift
@@ -20,7 +20,7 @@ final class SettingsMessageHandler: BridgeMessageHandler {
         switch message.type {
         case "loadSettings":
             let settings = settingsProvider()
-            bridgeService.send(BridgeMessage(
+            await bridgeService.send(BridgeMessage(
                 type: "settingsLoaded",
                 payload: ["settings": AnyCodable(settings)]
             ))
@@ -84,7 +84,7 @@ final class SettingsMessageHandler: BridgeMessageHandler {
 
             // Send back updated settings
             let settings = settingsProvider()
-            bridgeService.send(BridgeMessage(
+            await bridgeService.send(BridgeMessage(
                 type: "settingsLoaded",
                 payload: ["settings": AnyCodable(settings)]
             ))

--- a/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/SourceMessageHandler.swift
@@ -135,11 +135,11 @@ final class SourceMessageHandler: BridgeMessageHandler {
             do {
                 let source = try sourceService.addSource(from: url, to: streamId)
                 let sourcePayload = StreamCodec.encodeSource(source)
-                bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
+                await bridgeService.send(BridgeMessage(type: "sourceAdded", payload: ["source": AnyCodable(sourcePayload)]))
                 ingestService?.enqueue(source: source)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to add source from path (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
+                await bridgeService.send(BridgeMessage(type: "sourceError", payload: ["error": AnyCodable(error.localizedDescription)]))
             }
 
         case "removeSource":
@@ -153,10 +153,10 @@ final class SourceMessageHandler: BridgeMessageHandler {
             }
             do {
                 try sourceService.removeSource(id: id)
-                bridgeService.send(BridgeMessage(type: "sourceRemoved", payload: ["id": AnyCodable(id.uuidString)]))
+                await bridgeService.send(BridgeMessage(type: "sourceRemoved", payload: ["id": AnyCodable(id.uuidString)]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to remove source (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "sourceRemoveError", payload: [
+                await bridgeService.send(BridgeMessage(type: "sourceRemoveError", payload: [
                     "id": AnyCodable(id.uuidString),
                     "error": AnyCodable(error.localizedDescription)
                 ]))
@@ -174,7 +174,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
 
             do {
                 guard var source = try persistence.loadSource(id: sourceId) else {
-                    sendSourceError("Source not found.")
+                    await sendSourceError("Source not found.")
                     return
                 }
 
@@ -187,7 +187,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 ingestService.enqueue(source: source)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to retry source indexing (\(DebugLog.errorSummary(error)))")
-                sendSourceError(error.localizedDescription)
+                await sendSourceError(error.localizedDescription)
             }
 
         case "setSourceAIExclusion":
@@ -202,7 +202,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
 
             do {
                 guard try persistence.loadSource(id: sourceId) != nil else {
-                    sendSourceError("Source not found.")
+                    await sendSourceError("Source not found.")
                     return
                 }
 
@@ -210,7 +210,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 DebugLog.log("[SourceMessageHandler] setSourceAIExclusion sourceId=\(sourceId.uuidString) excluded=\(excluded)")
             } catch {
                 DebugLog.log("[SourceMessageHandler] Failed to set source AI exclusion (\(DebugLog.errorSummary(error)))")
-                sendSourceError(error.localizedDescription)
+                await sendSourceError(error.localizedDescription)
             }
 
         case "openSource":
@@ -225,13 +225,13 @@ final class SourceMessageHandler: BridgeMessageHandler {
 
             do {
                 guard let source = try persistence.loadSource(id: sourceId) else {
-                    sendSourceError("Source not found.")
+                    await sendSourceError("Source not found.")
                     return
                 }
                 delegate?.openSourceReference(source, sourceService: sourceService)
             } catch {
                 DebugLog.log("[WebViewManager] Failed to open source (\(DebugLog.errorSummary(error)))")
-                sendSourceError(error.localizedDescription)
+                await sendSourceError(error.localizedDescription)
             }
 
         case "openPdfDestination":
@@ -240,7 +240,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                   let streamId = UUID(uuidString: streamIdValue),
                   let sourceService else {
                 DebugLog.log("[WebViewManager] Invalid openPdfDestination payload")
-                sendPDFDestinationFailure(.damagedLink)
+                await sendPDFDestinationFailure(.damagedLink)
                 return
             }
 
@@ -264,7 +264,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 if let sourceId {
                     guard let loadedSource = try persistence.loadSource(id: sourceId) else {
                         DebugLog.log("[WebViewManager] PDF destination source is missing")
-                        sendPDFDestinationFailure(.missingSource)
+                        await sendPDFDestinationFailure(.missingSource)
                         return
                     }
                     source = loadedSource
@@ -272,7 +272,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 } else if let highlightId {
                     guard UUID(uuidString: highlightId) != nil else {
                         DebugLog.log("[WebViewManager] Invalid PDF highlight destination")
-                        sendPDFDestinationFailure(.damagedLink)
+                        await sendPDFDestinationFailure(.damagedLink)
                         return
                     }
                     guard let legacyDestination = try legacyPDFHighlightDestination(
@@ -280,25 +280,25 @@ final class SourceMessageHandler: BridgeMessageHandler {
                         highlightId: highlightId
                     ) else {
                         DebugLog.log("[WebViewManager] PDF highlight destination is missing")
-                        sendPDFDestinationFailure(.missingSource)
+                        await sendPDFDestinationFailure(.missingSource)
                         return
                     }
                     source = legacyDestination.source
                     pageToOpen = page ?? legacyDestination.page
                 } else {
                     DebugLog.log("[WebViewManager] Invalid openPdfDestination payload")
-                    sendPDFDestinationFailure(.damagedLink)
+                    await sendPDFDestinationFailure(.damagedLink)
                     return
                 }
 
                 guard source.streamId == streamId else {
                     DebugLog.log("[WebViewManager] PDF destination source belongs to another stream")
-                    sendPDFDestinationFailure(.wrongStream)
+                    await sendPDFDestinationFailure(.wrongStream)
                     return
                 }
                 guard source.fileType == .pdf else {
                     DebugLog.log("[WebViewManager] PDF destination source is not a PDF")
-                    sendPDFDestinationFailure(.damagedLink)
+                    await sendPDFDestinationFailure(.damagedLink)
                     return
                 }
 
@@ -312,7 +312,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 )
             } catch {
                 DebugLog.log("[WebViewManager] Failed to open PDF destination (\(DebugLog.errorSummary(error)))")
-                sendPDFDestinationFailure(.damagedLink)
+                await sendPDFDestinationFailure(.damagedLink)
             }
 
         case "beginPdfAnchorPick":
@@ -336,7 +336,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 DebugLog.log("[WebViewManager] Invalid saveImage payload")
                 let requestId = message.payload?["requestId"]?.value as? String
                 await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveImage payload")
-                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
+                await bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
                     "error": AnyCodable("Invalid image data"),
                     "requestId": AnyCodable(requestId as Any)
                 ]))
@@ -349,14 +349,14 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 let relativePath = try assetService.saveImage(data: imageData, streamId: streamId)
                 let assetUrl = "ticker-asset:///\(relativePath)"
 
-                bridgeService.send(BridgeMessage(type: "imageSaved", payload: [
+                await bridgeService.send(BridgeMessage(type: "imageSaved", payload: [
                     "relativePath": AnyCodable(relativePath),
                     "assetUrl": AnyCodable(assetUrl),
                     "requestId": AnyCodable(requestId as Any)
                 ]))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to save image (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
+                await bridgeService.send(BridgeMessage(type: "imageSaveError", payload: [
                     "error": AnyCodable(error.localizedDescription),
                     "requestId": AnyCodable(requestId as Any)
                 ]))
@@ -371,7 +371,7 @@ final class SourceMessageHandler: BridgeMessageHandler {
                 return
             }
             let fullPath = assetService.assetURL(for: relativePath).path
-            bridgeService.send(BridgeMessage(type: "assetPath", payload: [
+            await bridgeService.send(BridgeMessage(type: "assetPath", payload: [
                 "relativePath": AnyCodable(relativePath),
                 "fullPath": AnyCodable(fullPath)
             ]))
@@ -381,12 +381,14 @@ final class SourceMessageHandler: BridgeMessageHandler {
         }
     }
 
+    @MainActor
     private func sendSourceError(_ message: String) {
         bridgeService.send(BridgeMessage(type: "sourceError", payload: [
             "error": AnyCodable(message)
         ]))
     }
 
+    @MainActor
     private func sendPDFDestinationFailure(_ failure: OpenPDFDestinationFailure) {
         sendSourceError(failure.userMessage)
     }

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -165,15 +165,18 @@ final class StreamMessageHandler: BridgeMessageHandler {
             }
 
         case "saveStreamDocument":
+            guard let callbackId = message.callbackId else {
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for saveStreamDocument")
+                return
+            }
             guard let payload = message.payload,
                   let streamIdValue = payload["streamId"]?.value as? String,
                   let streamId = UUID(uuidString: streamIdValue),
                   let markdown = payload["markdown"]?.value as? String,
                   let baseRevision = payload["baseRevision"]?.intValue,
-                  let spans = decodeSpans(payload["spans"]?.value, streamId: streamId),
-                  let callbackId = message.callbackId else {
+                  let spans = decodeSpans(payload["spans"]?.value, streamId: streamId) else {
                 DebugLog.log("[WebViewManager] Invalid saveStreamDocument payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid saveStreamDocument payload")
+                await bridgeService.respondWithError(to: callbackId, error: "Invalid saveStreamDocument payload")
                 return
             }
             do {
@@ -257,11 +260,14 @@ final class StreamMessageHandler: BridgeMessageHandler {
             }
 
         case "getExchange":
+            guard let callbackId = message.callbackId else {
+                await bridgeService.sendBridgeError(type: message.type, reason: "Missing callbackId for getExchange")
+                return
+            }
             guard let payload = message.payload,
-                  let requestId = payload["requestId"]?.value as? String,
-                  let callbackId = message.callbackId else {
+                  let requestId = payload["requestId"]?.value as? String else {
                 DebugLog.log("[WebViewManager] Invalid getExchange payload")
-                await bridgeService.sendBridgeError(type: message.type, reason: "Invalid getExchange payload")
+                await bridgeService.respondWithError(to: callbackId, error: "Invalid getExchange payload")
                 return
             }
             do {

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -81,7 +81,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
             do {
                 let summaries = try persistence.loadStreamSummaries()
                 let payload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
+                await bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
                     "streams": payload["streams"]!
                 ]))
                 if let restoreId = delegate?.consumeLastOpenStreamIdForLaunchRestore() {
@@ -119,7 +119,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     "spans": AnyCodable(StreamCodec.encodeSpans([])),
                     "marginNotes": AnyCodable([])
                 ]
-                bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
+                await bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
             } catch {
                 DebugLog.log("[WebViewManager] Failed to create stream (\(DebugLog.errorSummary(error)))")
             }
@@ -135,7 +135,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
             }
             do {
                 if try persistence.updateStreamTitle(id: id, title: title) {
-                    bridgeService.send(BridgeMessage(type: "streamTitleUpdated", payload: ["id": AnyCodable(id.uuidString), "title": AnyCodable(title)]))
+                    await bridgeService.send(BridgeMessage(type: "streamTitleUpdated", payload: ["id": AnyCodable(id.uuidString), "title": AnyCodable(title)]))
                 }
             } catch {
                 DebugLog.log("[WebViewManager] Failed to update stream title (\(DebugLog.errorSummary(error)))")
@@ -157,7 +157,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 // Reload streams list
                 let summaries = try persistence.loadStreamSummaries()
                 let summariesPayload = StreamCodec.encodeSummaries(summaries)
-                bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
+                await bridgeService.send(BridgeMessage(type: "streamsLoaded", payload: [
                     "streams": summariesPayload["streams"]!
                 ]))
             } catch {
@@ -304,7 +304,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
             do {
                 guard let stream = try persistence.loadStream(id: streamId) else {
                     DebugLog.log("[WebViewManager] Stream not found for export")
-                    bridgeService.send(BridgeMessage(type: "exportError", payload: [
+                    await bridgeService.send(BridgeMessage(type: "exportError", payload: [
                         "streamId": AnyCodable(streamIdString),
                         "error": AnyCodable("Stream not found")
                     ]))
@@ -353,7 +353,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 }
             } catch {
                 DebugLog.log("[WebViewManager] Failed to load stream for export (\(DebugLog.errorSummary(error)))")
-                bridgeService.send(BridgeMessage(type: "exportError", payload: [
+                await bridgeService.send(BridgeMessage(type: "exportError", payload: [
                     "streamId": AnyCodable(streamIdString),
                     "error": AnyCodable(error.localizedDescription)
                 ]))
@@ -382,7 +382,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         if let requestId {
             payload["requestId"] = AnyCodable(requestId)
         }
-        bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
+        await bridgeService.send(BridgeMessage(type: "streamLoaded", payload: payload))
         ingestService?.enqueuePendingSources(for: id)
     }
 

--- a/Sources/Ticker/App/BridgeService.swift
+++ b/Sources/Ticker/App/BridgeService.swift
@@ -177,6 +177,15 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
         ]))
     }
 
+    @MainActor
+    func reject(_ message: BridgeMessage, reason: String) {
+        if let callbackId = message.callbackId {
+            respondWithError(to: callbackId, error: reason)
+        } else {
+            sendBridgeError(type: message.type, reason: reason)
+        }
+    }
+
     private func originalType(from body: Any) -> String {
         if let dict = body as? [String: Any],
            let type = dict["type"] as? String {

--- a/Sources/Ticker/App/BridgeService.swift
+++ b/Sources/Ticker/App/BridgeService.swift
@@ -125,6 +125,7 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
     }
 
     /// Send a message to JavaScript
+    @MainActor
     func send(_ message: BridgeMessage) {
         guard let webView else {
             DebugLog.log("Bridge send: No webView available for message: \(message.type)")
@@ -152,12 +153,14 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
     }
 
     /// Send a response to a callback
+    @MainActor
     func respond(to callbackId: String, with payload: [String: AnyCodable]) {
         let message = BridgeMessage(type: "callback", payload: payload, callbackId: callbackId)
         send(message)
     }
 
     /// Send an error response
+    @MainActor
     func respondWithError(to callbackId: String, error: String) {
         let payload: [String: AnyCodable] = [
             "error": AnyCodable(error)
@@ -166,6 +169,7 @@ final class BridgeService: NSObject, WKScriptMessageHandler {
         send(message)
     }
 
+    @MainActor
     func sendBridgeError(type originalType: String, reason: String) {
         send(BridgeMessage(type: "bridgeError", payload: [
             "originalType": AnyCodable(originalType),

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -135,6 +135,23 @@ struct QuickPanelStatus: Equatable {
 @MainActor
 final class QuickPanelManager: ObservableObject {
 
+    struct StreamingGeneration {
+        private(set) var current = 0
+
+        mutating func begin() -> Int {
+            current += 1
+            return current
+        }
+
+        mutating func invalidate() {
+            current += 1
+        }
+
+        func owns(_ generation: Int) -> Bool {
+            generation == current
+        }
+    }
+
     // MARK: - Published State
 
     @Published private(set) var isVisible: Bool = false
@@ -167,7 +184,7 @@ final class QuickPanelManager: ObservableObject {
     private var documentAITasks: [UUID: Task<Void, Never>] = [:]
     private var statusClearTask: Task<Void, Never>?
     private var saveFeedbackTask: Task<Void, Never>?
-    private var isStreamingCancelled = false  // Explicit flag since nested Tasks don't inherit cancellation
+    private var streamingGeneration = StreamingGeneration()
 
     // MARK: - Height Management
 
@@ -417,7 +434,7 @@ final class QuickPanelManager: ObservableObject {
 
     /// Cancel any active streaming task
     private func cancelStreaming() {
-        isStreamingCancelled = true
+        streamingGeneration.invalidate()
         streamingTask?.cancel()
         streamingTask = nil
         ephemeralConversation.isStreaming = false
@@ -537,7 +554,7 @@ final class QuickPanelManager: ObservableObject {
 
         // Cancel any existing streaming task
         streamingTask?.cancel()
-        isStreamingCancelled = false  // Reset flag for new streaming session
+        let generation = streamingGeneration.begin()
 
         // Build context for first turn only
         let isFirstTurn = ephemeralConversation.turns.isEmpty
@@ -584,13 +601,13 @@ final class QuickPanelManager: ObservableObject {
                 onChunk: { [weak self] chunk in
                     responseRaw += chunk
                     Task { @MainActor in
-                        guard let self = self, !self.isStreamingCancelled else { return }
+                        guard let self, self.streamingGeneration.owns(generation) else { return }
                         self.ephemeralConversation.currentResponse += chunk
                     }
                 },
                 onComplete: { [weak self] sourceContext in
                     Task { @MainActor in
-                        guard let self = self, !self.isStreamingCancelled else { return }
+                        guard let self, self.streamingGeneration.owns(generation) else { return }
                         // Record assistant turn with completed response
                         let manifest = DocumentAICitationManifest.entries(from: sourceContext) ?? []
                         let displayContent = CitationMarkerSwap.swap(responseRaw, manifest: manifest, mode: .plainLabel)
@@ -614,13 +631,17 @@ final class QuickPanelManager: ObservableObject {
                         ))
                         self.ephemeralConversation.isStreaming = false
                         self.ephemeralConversation.currentResponse = ""
+                        self.streamingTask = nil
+                        self.streamingGeneration.invalidate()
                     }
                 },
                 onError: { [weak self] err in
                     Task { @MainActor in
-                        guard let self = self, !self.isStreamingCancelled else { return }
+                        guard let self, self.streamingGeneration.owns(generation) else { return }
                         self.error = err.localizedDescription
                         self.ephemeralConversation.isStreaming = false
+                        self.streamingTask = nil
+                        self.streamingGeneration.invalidate()
                     }
                 },
                 onModelSelected: { model in

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -1126,6 +1126,10 @@ final class QuickPanelManager: ObservableObject {
             )
         } catch {
             DebugLog.log("[QuickPanel] Failed to append AI response (\(DebugLog.errorSummary(error)))")
+            bridgeService?.send(BridgeMessage(type: "quickPanelAIFailed", payload: [
+                "streamId": AnyCodable(streamId.uuidString),
+                "message": AnyCodable("Quick Panel AI answer could not be saved. Try again.")
+            ]))
         }
     }
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -26,6 +26,7 @@ final class WebViewManager: NSObject {
     private var pendingEditorSelectionRequests: [String: (String?) -> Void] = [:]
     private let editorSelectionTimeoutNanoseconds: UInt64 = 50_000_000
 
+    @MainActor
     init(container: ServiceContainer) {
         let config = WKWebViewConfiguration()
         #if DEBUG
@@ -84,11 +85,13 @@ final class WebViewManager: NSObject {
 
         Task { [weak self] in
             guard let self else { return }
-            await deviceKeyService.onStateChange = { [weak self] state in
-                self?.bridgeService.send(BridgeMessage(
-                    type: "proxyAuthState",
-                    payload: ["state": AnyCodable(state.rawValue)]
-                ))
+            deviceKeyService.onStateChange = { [weak self] state in
+                Task { @MainActor in
+                    self?.bridgeService.send(BridgeMessage(
+                        type: "proxyAuthState",
+                        payload: ["state": AnyCodable(state.rawValue)]
+                    ))
+                }
             }
             await deviceKeyService.initialize()
         }
@@ -134,33 +137,39 @@ final class WebViewManager: NSObject {
             }
         }
         pdfPaneController.onLinkSelection = { [weak self] payload in
-            guard let self, let persistence = self.persistence else { return }
-            do {
-                try persistence.savePDFHighlight(payload.highlight)
-                self.sendPDFHighlightLinked(payload)
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to save PDF highlight (\(DebugLog.errorSummary(error)))")
-                self.sendSourceError("Could not save PDF highlight.")
+            Task { @MainActor in
+                guard let self, let persistence = self.persistence else { return }
+                do {
+                    try persistence.savePDFHighlight(payload.highlight)
+                    self.sendPDFHighlightLinked(payload)
+                } catch {
+                    DebugLog.log("[WebViewManager] Failed to save PDF highlight (\(DebugLog.errorSummary(error)))")
+                    self.sendSourceError("Could not save PDF highlight.")
+                }
             }
         }
         pdfPaneController.onAnchorPlaced = { [weak self] payload in
-            guard let self else { return }
-            guard let persistence = self.persistence else {
-                self.sendSourceError("Could not save PDF anchor.")
-                self.sendPDFAnchorPickCancelled(streamId: payload.streamId)
-                return
-            }
-            do {
-                try persistence.savePDFHighlight(payload.highlight)
-                self.sendPDFAnchorPlaced(payload)
-            } catch {
-                DebugLog.log("[WebViewManager] Failed to save PDF anchor (\(DebugLog.errorSummary(error)))")
-                self.sendSourceError("Could not save PDF anchor.")
-                self.sendPDFAnchorPickCancelled(streamId: payload.streamId)
+            Task { @MainActor in
+                guard let self else { return }
+                guard let persistence = self.persistence else {
+                    self.sendSourceError("Could not save PDF anchor.")
+                    self.sendPDFAnchorPickCancelled(streamId: payload.streamId)
+                    return
+                }
+                do {
+                    try persistence.savePDFHighlight(payload.highlight)
+                    self.sendPDFAnchorPlaced(payload)
+                } catch {
+                    DebugLog.log("[WebViewManager] Failed to save PDF anchor (\(DebugLog.errorSummary(error)))")
+                    self.sendSourceError("Could not save PDF anchor.")
+                    self.sendPDFAnchorPickCancelled(streamId: payload.streamId)
+                }
             }
         }
         pdfPaneController.onAnchorPickCancelled = { [weak self] streamId in
-            self?.sendPDFAnchorPickCancelled(streamId: streamId)
+            Task { @MainActor in
+                self?.sendPDFAnchorPickCancelled(streamId: streamId)
+            }
         }
         pdfPaneController.onPageChanged = { [weak self] sourceId, pageIndex in
             guard let self, let persistence = self.persistence else { return }
@@ -171,11 +180,14 @@ final class WebViewManager: NSObject {
             }
         }
         pdfPaneController.onClose = { [weak self] in
-            self?.activePDFPaneStreamId = nil
-            self?.sendPDFPaneStateChanged(visible: false)
+            Task { @MainActor in
+                self?.activePDFPaneStreamId = nil
+                self?.sendPDFPaneStateChanged(visible: false)
+            }
         }
     }
 
+    @MainActor
     private func handleDroppedFiles(_ urls: [URL]) {
         guard !urls.isEmpty else { return }
 
@@ -199,6 +211,7 @@ final class WebViewManager: NSObject {
         }
     }
 
+    @MainActor
     private func handleDroppedFilesFromStreamList(_ urls: [URL]) {
         guard let persistence else {
             bridgeService.send(BridgeMessage(type: "fileDropError", payload: [
@@ -270,6 +283,7 @@ final class WebViewManager: NSObject {
         return try work()
     }
 
+    @MainActor
     private func processDroppedImage(_ url: URL, streamId: UUID) {
         do {
             let imageData = try withSecurityScopedAccess(url) { try Data(contentsOf: url) }
@@ -294,6 +308,7 @@ final class WebViewManager: NSObject {
         }
     }
 
+    @MainActor
     private func processDroppedDocument(_ url: URL, streamId: UUID) {
         guard let sourceService else {
             bridgeService.send(BridgeMessage(type: "sourceError", payload: [
@@ -316,12 +331,14 @@ final class WebViewManager: NSObject {
         }
     }
 
+    @MainActor
     private func sendSourceError(_ message: String) {
         bridgeService.send(BridgeMessage(type: "sourceError", payload: [
             "error": AnyCodable(message)
         ]))
     }
 
+    @MainActor
     private func sendPDFHighlightLinked(_ payload: PDFHighlightLinkPayload) {
         bridgeService.send(BridgeMessage(
             type: "pdfHighlightLinked",
@@ -337,6 +354,7 @@ final class WebViewManager: NSObject {
         ))
     }
 
+    @MainActor
     private func sendPDFPaneStateChanged(
         visible: Bool,
         streamId: UUID? = nil,
@@ -357,6 +375,7 @@ final class WebViewManager: NSObject {
         bridgeService.send(BridgeMessage(type: "pdfPaneStateChanged", payload: payload))
     }
 
+    @MainActor
     private func sendPDFAnchorPlaced(_ payload: PDFHighlightLinkPayload) {
         bridgeService.send(BridgeMessage(
             type: "pdfAnchorPlaced",
@@ -371,6 +390,7 @@ final class WebViewManager: NSObject {
         ))
     }
 
+    @MainActor
     private func sendPDFAnchorPickCancelled(streamId: UUID) {
         bridgeService.send(BridgeMessage(
             type: "pdfAnchorPickCancelled",
@@ -415,7 +435,9 @@ final class WebViewManager: NSObject {
             }
         } catch {
             DebugLog.log("[WebViewManager] Failed to open source (\(DebugLog.errorSummary(error)))")
-            sendSourceError(error.localizedDescription)
+            Task { @MainActor in
+                sendSourceError(error.localizedDescription)
+            }
         }
     }
 
@@ -431,7 +453,9 @@ final class WebViewManager: NSObject {
                 }
             } catch {
                 DebugLog.log("[WebViewManager] Failed to open source (\(DebugLog.errorSummary(error)))")
-                sendSourceError(error.localizedDescription)
+                Task { @MainActor in
+                    sendSourceError(error.localizedDescription)
+                }
             }
         }
     }
@@ -445,7 +469,7 @@ final class WebViewManager: NSObject {
         quote: String?
     ) async {
         guard source.fileType == .pdf else {
-            sendSourceError("Source is not a PDF.")
+            await sendSourceError("Source is not a PDF.")
             return
         }
 
@@ -495,8 +519,8 @@ final class WebViewManager: NSObject {
         }
 
         if !didStart {
-            sendSourceError("Open a PDF source before linking to PDF.")
-            sendPDFAnchorPickCancelled(streamId: streamId)
+            await sendSourceError("Open a PDF source before linking to PDF.")
+            await sendPDFAnchorPickCancelled(streamId: streamId)
         }
     }
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -626,6 +626,10 @@ final class WebViewManager: NSObject {
             guard let self else { return }
             guard persistence != nil else {
                 DebugLog.log("[WebViewManager] Persistence not available")
+                await bridgeService.reject(
+                    message,
+                    reason: "Ticker storage is unavailable. Restart the app and try again."
+                )
                 return
             }
             await bridgeRouter.route(message)

--- a/Sources/Ticker/Models/BridgePayloads.swift
+++ b/Sources/Ticker/Models/BridgePayloads.swift
@@ -54,6 +54,7 @@ struct SourcePayload: Codable {
 
 extension BridgeService {
     /// Send a typed payload to JavaScript
+    @MainActor
     func send<T: Encodable>(_ type: String, payload: T) {
         do {
             let encoder = JSONEncoder()
@@ -71,16 +72,19 @@ extension BridgeService {
 
     // MARK: - Source Convenience Methods
 
+    @MainActor
     func sendSourceAdded(_ source: SourceReference) {
         send("sourceAdded", payload: SourceAddedPayload(source: SourcePayload(from: source)))
     }
 
+    @MainActor
     func sendSourceRemoved(id: String) {
         send("sourceRemoved", payload: SourceRemovedPayload(id: id))
     }
 
     // MARK: - Image Convenience Methods
 
+    @MainActor
     func sendImageDropped(assetUrl: String) {
         send("imageDropped", payload: ImageDroppedPayload(assetUrl: assetUrl))
     }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -997,6 +997,7 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_documentAICancelStopsSlowStreamingProvider() async throws {
         let recorder = BridgeMessageRecorder()
         let provider = SlowDocumentAIProvider()
@@ -1045,6 +1046,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertTrue(recorder.messages(ofType: "documentAIComplete").isEmpty)
     }
 
+    @MainActor
     func test_documentAICompletionSavesExchangeReceipt() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Exchange Receipt")

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -611,6 +611,17 @@ final class StreamDocumentTests: XCTestCase {
         sectionPath: String?
     )
 
+    func test_quickPanelStreamingGenerationRejectsCancelledRequestCallbacks() {
+        var gate = QuickPanelManager.StreamingGeneration()
+        let requestA = gate.begin()
+
+        gate.invalidate()
+        let requestB = gate.begin()
+
+        XCTAssertFalse(gate.owns(requestA))
+        XCTAssertTrue(gate.owns(requestB))
+    }
+
     func test_v14MigrationCreatesPDFHighlightsTable() throws {
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -171,6 +171,8 @@ export function App() {
             const originalType = String(message.payload?.originalType ?? 'unknown');
             const reason = String(message.payload?.reason ?? 'Unknown bridge error');
             addToast(`Bridge error (${originalType}): ${reason}`, 'error', 10000);
+          } else {
+            addToast('Ticker could not complete that action. Try again.', 'error');
           }
           break;
         case 'proxyAuthState':

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1038,6 +1038,13 @@ export function StreamEditor({
         return;
       }
 
+      if (message.type === 'quickPanelAIFailed') {
+        if (message.payload?.streamId !== stream.id) return;
+        clearQuickPanelPending();
+        addToast('Quick Panel AI answer could not be saved. Try again.', 'error');
+        return;
+      }
+
       if (message.type === 'streamDocumentConflict') {
         const payloadStreamId = message.payload?.streamId as string | undefined;
         const markdown = message.payload?.markdown as string | undefined;

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -20,6 +20,7 @@ export const SWIFT_TO_WEB_MESSAGE_TYPES = [
   'imageSaved',
   'marginNotesChanged',
   'proxyAuthState',
+  'quickPanelAIFailed',
   'quickPanelAIStarted',
   'pdfAnchorPickCancelled',
   'pdfAnchorPlaced',

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -79,6 +79,9 @@
       "proxyAuthState": {
         "requiredPayloadKeys": ["state"]
       },
+      "quickPanelAIFailed": {
+        "requiredPayloadKeys": ["streamId", "message"]
+      },
       "quickPanelAIStarted": {
         "requiredPayloadKeys": ["streamId"]
       },


### PR DESCRIPTION
Audit findings #5, #7, #8, #11: @MainActor bridge send boundary + isolated AI request registry, quick-panel per-request generation tokens, quickPanelAIFailed terminal event, callbackId answered on every failure path incl. the persistence gate, sanitized production bridge errors. All gates green; implemented by Codex Sol high, reviewed by governor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)