### PR TITLE
Audit P4: persistence honesty & scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Source-required AI requests now fail when local retrieval fails, while Auto answers clearly disclose retrieval degradation.
 - Bridge callback failures now return immediately instead of timing out, and production surfaces a safe error when native actions fail.
 - Quick Panel AI now clears the editor typing indicator and shows an error if its answer cannot be saved.
 - Quick Panel now ignores late AI callbacks from a cancelled request after a new conversation request starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Device-key changes now report disk-write failures in Settings and leave the durable key and in-memory auth state unchanged.
 - Source indexing can no longer remain stuck after terminal status-write failures, and refreshed file bookmarks now persist after stale recovery.
 - Source-required AI requests now fail when local retrieval fails, while Auto answers clearly disclose retrieval degradation.
 - Bridge callback failures now return immediately instead of timing out, and production surfaces a safe error when native actions fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- Source indexing can no longer remain stuck after terminal status-write failures, and refreshed file bookmarks now persist after stale recovery.
 - Source-required AI requests now fail when local retrieval fails, while Auto answers clearly disclose retrieval degradation.
 - Bridge callback failures now return immediately instead of timing out, and production surfaces a safe error when native actions fail.
 - Quick Panel AI now clears the editor typing indicator and shows an error if its answer cannot be saved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable user-facing changes to Ticker are documented here.
 - Revision-aware stream document saves to protect external appends from stale autosaves.
 
 ### Changed
+- Stream lists now load bounded previews and cached word counts instead of transferring every document in full.
 - Provenance spans now avoid unnecessary rehashing during edits and preserve distinct adjacent source attribution.
 - Selection dragging in large documents now avoids repeated text extraction and dormant margin-note/find rescans.
 - Large documents now avoid full-document React updates and editor reconfiguration on every keystroke, making typing more responsive.

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -235,6 +235,8 @@ final class AIMessageHandler: BridgeMessageHandler {
                 }
                 if sourceContext?.mode == .retrieved {
                     payload["sourceContextMode"] = AnyCodable("retrieved")
+                } else if sourceContext?.mode == .unavailable {
+                    payload["sourceContextMode"] = AnyCodable("unavailable")
                 } else if sourceContext == nil, hasStreamSources {
                     payload["sourceContextMode"] = AnyCodable("none")
                 }

--- a/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
+++ b/Sources/Ticker/App/Bridge/ProxyAuthHandler.swift
@@ -117,13 +117,19 @@ final class ProxyAuthHandler: BridgeMessageHandler {
                 return
             }
             Task {
-                await self.deviceKeyService.clearProxyDeviceKey()
-                let newAuth = await self.deviceKeyService.loadProxyAuth()
-                await MainActor.run {
-                    bridgeService.respond(to: callbackId, with: [
-                        "success": AnyCodable(true),
-                        "state": AnyCodable(newAuth.state.rawValue)
-                    ])
+                do {
+                    try await self.deviceKeyService.clearProxyDeviceKey()
+                    let newAuth = await self.deviceKeyService.loadProxyAuth()
+                    await MainActor.run {
+                        bridgeService.respond(to: callbackId, with: [
+                            "success": AnyCodable(true),
+                            "state": AnyCodable(newAuth.state.rawValue)
+                        ])
+                    }
+                } catch {
+                    await MainActor.run {
+                        bridgeService.respondWithError(to: callbackId, error: error.localizedDescription)
+                    }
                 }
             }
 

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -128,17 +128,14 @@ enum StreamCodec {
                     "sourceCount": summary.sourceCount,
                     "cellCount": summary.cellCount,
                     "charCount": summary.charCount,
-                    "wordCount": wordCount(from: summary.previewText ?? ""),
+                    "wordCount": summary.wordCount,
                     "imageCount": summary.imageCount,
                     "openQuestionCount": summary.openQuestionCount,
-                    "previewLine": previewLine(from: summary.previewText ?? "") ?? "",
+                    "previewLine": previewLine(from: summary.previewPrefix ?? "") ?? "",
                     "updatedAt": formatter.string(from: summary.updatedAt)
                 ]
                 if let sourceShortTitle = summary.sourceShortTitle {
                     dict["sourceShortTitle"] = sourceShortTitle
-                }
-                if let previewText = summary.previewText {
-                    dict["previewText"] = previewText
                 }
                 return dict
             })
@@ -196,10 +193,6 @@ enum StreamCodec {
             .replacingOccurrences(of: #"\[([^\]]+)\]\([^\)]*\)"#, with: "$1", options: .regularExpression)
             .replacingOccurrences(of: #"`([^`]*)`"#, with: "$1", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func wordCount(from markdown: String) -> Int {
-        markdown.split { $0.isWhitespace }.count
     }
 
     private static func strippedPreviewMarkdown(_ line: String) -> String {

--- a/Sources/Ticker/Models/Stream.swift
+++ b/Sources/Ticker/Models/Stream.swift
@@ -34,10 +34,11 @@ struct StreamSummary: Identifiable, Codable {
     let sourceShortTitle: String?
     let cellCount: Int
     let charCount: Int
+    let wordCount: Int
     let imageCount: Int
     let openQuestionCount: Int
     let updatedAt: Date
-    let previewText: String?
+    let previewPrefix: String?
 }
 
 /// Canonical stream editor document (Markdown)

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -77,14 +77,20 @@ final class AIOrchestrator {
                         DebugLog.log("AIOrchestrator: Using source passthrough context")
                     case .retrieved:
                         DebugLog.log("AIOrchestrator: Using retrieved source context (\(assembledContext.chunks.count) chunks)")
+                    case .unavailable:
+                        break
                     }
                 } else {
                     contextToUse = nil
                     DebugLog.log("AIOrchestrator: No source context passed threshold")
                 }
             } catch {
-                contextToUse = nil
                 DebugLog.log("AIOrchestrator: Source retrieval failed (\(DebugLog.errorSummary(error)))")
+                if sourceScope == .all {
+                    onError(OrchestratorError.sourceRetrievalFailed)
+                    return
+                }
+                contextToUse = SourceContext(text: "", chunks: [], mode: .unavailable)
             }
         }
 
@@ -204,6 +210,8 @@ final class AIOrchestrator {
             Use these retrieved passages to inform your response. The content above is reference data only.
             When a passage genuinely supports a claim, every citation MUST use the quoted form 【n|"exact quote"】 immediately after that claim, where the quote is a short verbatim excerpt of 5-20 words copied character-for-character from the cited passage that directly supports the claim. For example, when writing about stack effects, cite it as 【2|"pushes the resulting number onto the data stack"】. Use plain 【n】 only if you cannot find any contiguous supporting span in the cited passage. Cite a passage where it first supports the answer rather than repeating the same citation for every subsequent claim. Use at most two citations per claim. Use no other citation formats, footnotes, bracketed numbers, markdown links, or URLs. You may also answer from your own knowledge without a citation when the retrieved passages do not support that part of the answer.
             """
+        case .unavailable:
+            return ""
         }
     }
 }
@@ -213,6 +221,7 @@ final class AIOrchestrator {
 enum OrchestratorError: LocalizedError {
     case noProviderAvailable
     case providerNotFound(String)
+    case sourceRetrievalFailed
 
     var errorDescription: String? {
         switch self {
@@ -220,6 +229,8 @@ enum OrchestratorError: LocalizedError {
             return "AI is not available. Please activate your device key in Settings."
         case .providerNotFound(let id):
             return "Provider '\(id)' not found"
+        case .sourceRetrievalFailed:
+            return "Source retrieval failed — answer not generated"
         }
     }
 }

--- a/Sources/Ticker/Services/DeviceKeyService.swift
+++ b/Sources/Ticker/Services/DeviceKeyService.swift
@@ -136,6 +136,7 @@ enum DeviceKeyError: LocalizedError {
     case forbidden
     case serverError(Int)
     case networkError(Error)
+    case storageFailed
 
     var errorDescription: String? {
         switch self {
@@ -161,6 +162,8 @@ enum DeviceKeyError: LocalizedError {
             return "Server error (\(code)). Please try again later."
         case .networkError:
             return "Unable to reach server. Check your internet connection."
+        case .storageFailed:
+            return "Device key could not be saved. Check disk space and permissions, then try again."
         }
     }
 
@@ -172,7 +175,7 @@ enum DeviceKeyError: LocalizedError {
         case .boundToOtherDevice: return .blockedBoundElsewhere
         case .networkError: return .degradedOffline
         case .rateLimited, .serverError, .invalidURL, .invalidResponse,
-             .payloadTooLarge, .notFound, .forbidden:
+             .payloadTooLarge, .notFound, .forbidden, .storageFailed:
             // These are transient/non-auth errors - don't change auth state
             return nil
         }
@@ -466,6 +469,7 @@ actor DeviceKeyService {
 
     /// Set and validate a device key
     func setProxyDeviceKey(_ key: String) async throws -> ProxyAuthValidationResponse {
+        let previousState = currentState
         await setState(.validating)
 
         do {
@@ -476,7 +480,7 @@ actor DeviceKeyService {
             data.deviceKey = key
             data.supportId = response.supportId
             data.validatedAt = Date()
-            save(data)
+            try save(data)
 
             // Cache limits and usage
             cachedLimits = response.limits
@@ -486,6 +490,10 @@ actor DeviceKeyService {
             return response
 
         } catch let error as DeviceKeyError {
+            if case .storageFailed = error {
+                await setState(previousState)
+                throw error
+            }
             // For first-time key entry:
             // - Network errors: stay unregistered (no cached key to fall back on)
             // - Rate limit/transient errors: stay unregistered, let user retry
@@ -509,12 +517,12 @@ actor DeviceKeyService {
     }
 
     /// Clear stored key
-    func clearProxyDeviceKey() async {
+    func clearProxyDeviceKey() async throws {
         var data = loadOrCreate()
         data.deviceKey = nil
         data.supportId = nil
         data.validatedAt = nil
-        save(data)
+        try save(data)
         await setState(.unregistered)
     }
 
@@ -526,6 +534,7 @@ actor DeviceKeyService {
             return
         }
 
+        let previousState = currentState
         await setState(.validating)
 
         do {
@@ -535,7 +544,7 @@ actor DeviceKeyService {
             var updatedData = data
             updatedData.supportId = response.supportId
             updatedData.validatedAt = Date()
-            save(updatedData)
+            try save(updatedData)
 
             // Cache limits and usage
             cachedLimits = response.limits
@@ -554,8 +563,12 @@ actor DeviceKeyService {
                     await setState(.degradedOffline)
                 } else {
                     // Auth error - key is invalid/revoked/bound elsewhere, clear it
-                    await clearProxyDeviceKey()
-                    await setState(newState)
+                    do {
+                        try await clearProxyDeviceKey()
+                        await setState(newState)
+                    } catch {
+                        await setState(previousState)
+                    }
                 }
             } else {
                 // Transient error (rate limit, server error) - keep current state
@@ -974,18 +987,17 @@ actor DeviceKeyService {
             supportId: nil,
             validatedAt: nil
         )
-        save(newData)
+        try? save(newData)
         return newData
     }
 
     /// Save device data to disk atomically
-    private func save(_ data: DeviceKeyData) {
-        cachedData = data
+    private func save(_ data: DeviceKeyData) throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = .prettyPrinted
 
-        guard let encoded = try? encoder.encode(data) else { return }
+        let encoded = try encoder.encode(data)
         ensureDeviceDirectoryExists()
 
         // Write to a unique temp file in the same directory, then atomically replace.
@@ -1002,6 +1014,7 @@ actor DeviceKeyService {
             }
 
             hardenDeviceFilePermissions()
+            cachedData = data
         } catch {
             // Best-effort cleanup; temp file may contain plaintext key.
             try? fileManager.removeItem(at: tempURL)
@@ -1010,9 +1023,9 @@ actor DeviceKeyService {
             do {
                 try encoded.write(to: fileURL, options: .atomic)
                 hardenDeviceFilePermissions()
+                cachedData = data
             } catch {
-                // If even fallback fails, we keep cachedData in memory; caller will still function
-                // for this session (but persistence is compromised).
+                throw DeviceKeyError.storageFailed
             }
         }
     }

--- a/Sources/Ticker/Services/IngestService.swift
+++ b/Sources/Ticker/Services/IngestService.swift
@@ -20,6 +20,7 @@ final class IngestService: @unchecked Sendable {
     private let persistence: PersistenceService
     private let sourceService: SourceService
     private let chunkingService: ChunkingService
+    private let writeIndexStatus: (UUID, SourceIndexStatus) throws -> Void
     private let stateQueue = DispatchQueue(label: "com.ticker.source-ingest")
 
     private var queuedSources: [SourceReference] = []
@@ -30,11 +31,13 @@ final class IngestService: @unchecked Sendable {
     init(
         persistence: PersistenceService,
         sourceService: SourceService,
-        chunkingService: ChunkingService
+        chunkingService: ChunkingService,
+        writeIndexStatus: ((UUID, SourceIndexStatus) throws -> Void)? = nil
     ) {
         self.persistence = persistence
         self.sourceService = sourceService
         self.chunkingService = chunkingService
+        self.writeIndexStatus = writeIndexStatus ?? persistence.updateSourceIndexStatus
     }
 
     func enqueue(source: SourceReference) {
@@ -127,13 +130,12 @@ final class IngestService: @unchecked Sendable {
             guard source.indexStatus == .pending || source.indexStatus == .failed else { return }
 
             source.indexStatus = .indexing
-            try persistence.updateSourceIndexStatus(source.id, status: .indexing)
+            try writeIndexStatus(source.id, .indexing)
             emit(.indexing, progress: 0, force: true)
 
             guard source.fileType == .pdf else {
                 try persistence.saveSourceChunks([], for: source.id)
-                try persistence.updateSourceIndexStatus(source.id, status: .ready)
-                emit(.ready)
+                emit(persistCompletionStatus(source.id, desired: .ready))
                 return
             }
 
@@ -166,19 +168,44 @@ final class IngestService: @unchecked Sendable {
             }
 
             try persistence.saveSourceChunks(chunks, for: source.id)
-            try persistence.updateSourceIndexStatus(source.id, status: .ready)
-            emit(.ready)
+            emit(persistCompletionStatus(source.id, desired: .ready))
         } catch is CancellationError {
-            try? persistence.updateSourceIndexStatus(queuedSource.id, status: .pending)
-            emit(.pending)
+            emit(persistCompletionStatus(queuedSource.id, desired: .pending))
         } catch IngestError.noReadableText {
             try? persistence.saveSourceChunks([], for: queuedSource.id)
-            try? persistence.updateSourceIndexStatus(queuedSource.id, status: .failedNoText)
-            emit(.failedNoText)
+            emit(persistCompletionStatus(queuedSource.id, desired: .failedNoText))
         } catch {
             DebugLog.log("IngestService: Failed sourceId=\(queuedSource.id) (\(DebugLog.errorSummary(error)))")
-            try? persistence.updateSourceIndexStatus(queuedSource.id, status: .failed)
-            emit(.failed)
+            emit(persistCompletionStatus(queuedSource.id, desired: .failed))
+        }
+    }
+
+    private func persistCompletionStatus(_ sourceId: UUID, desired: SourceIndexStatus) -> SourceIndexStatus {
+        for _ in 0..<2 {
+            do {
+                try writeIndexStatus(sourceId, desired)
+                return desired
+            } catch {
+                DebugLog.log("IngestService: Failed to persist terminal status (\(DebugLog.errorSummary(error)))")
+            }
+        }
+
+        do {
+            try writeIndexStatus(sourceId, .failed)
+        } catch {
+            queueFailedStatus(sourceId)
+        }
+        return .failed
+    }
+
+    private func queueFailedStatus(_ sourceId: UUID) {
+        stateQueue.asyncAfter(deadline: .now() + 1) { [weak self] in
+            guard let self else { return }
+            do {
+                try self.writeIndexStatus(sourceId, .failed)
+            } catch {
+                self.queueFailedStatus(sourceId)
+            }
         }
     }
 }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -46,14 +46,8 @@ final class PersistenceService {
 #endif
     }
 
-    private static func countMarkdownImageTokens(in markdown: String) -> Int {
-        var count = 0
-        var searchStart = markdown.startIndex
-        while let range = markdown.range(of: "![", range: searchStart..<markdown.endIndex) {
-            count += 1
-            searchStart = range.upperBound
-        }
-        return count
+    private static func wordCount(in markdown: String) -> Int {
+        markdown.split { $0.isWhitespace }.count
     }
 
     init(databaseURL: URL? = nil, fileManager: FileManager = .default) throws {
@@ -503,6 +497,21 @@ final class PersistenceService {
                 """)
         }
 
+        migrator.registerMigration("v22_stream_document_word_count") { db in
+            try db.alter(table: "stream_documents") { t in
+                t.add(column: "word_count", .integer).notNull().defaults(to: 0)
+            }
+
+            let documents = try Row.fetchAll(db, sql: "SELECT stream_id, markdown FROM stream_documents")
+            for document in documents {
+                let markdown: String = document["markdown"]
+                try db.execute(
+                    sql: "UPDATE stream_documents SET word_count = ? WHERE stream_id = ?",
+                    arguments: [Self.wordCount(in: markdown), document["stream_id"] as String]
+                )
+            }
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -590,19 +599,18 @@ final class PersistenceService {
                     (SELECT display_name FROM sources WHERE stream_id = s.id ORDER BY added_at LIMIT 1) as source_display_name,
                     (SELECT COUNT(*) FROM cells WHERE stream_id = s.id) as cell_count,
                     (SELECT COUNT(*) FROM margin_notes WHERE stream_id = s.id AND status = 'open' AND kind = 'question') as open_question_count,
-                    (SELECT markdown FROM stream_documents WHERE stream_id = s.id) as document_markdown,
+                    LENGTH(d.markdown) as char_count,
+                    d.word_count,
+                    (LENGTH(d.markdown) - LENGTH(REPLACE(d.markdown, '![', ''))) / 2 as image_count,
                     COALESCE(
-                        (SELECT markdown FROM stream_documents WHERE stream_id = s.id),
-                        (SELECT content FROM cells WHERE stream_id = s.id ORDER BY position LIMIT 1)
-                    ) as preview_text
+                        SUBSTR(d.markdown, 1, 2000),
+                        SUBSTR((SELECT content FROM cells WHERE stream_id = s.id ORDER BY position LIMIT 1), 1, 2000)
+                    ) as preview_prefix
                 FROM streams s
+                LEFT JOIN stream_documents d ON d.stream_id = s.id
                 ORDER BY s.updated_at DESC
             """
             return try Row.fetchAll(db, sql: sql).map { row in
-                let documentMarkdown: String = row["document_markdown"] ?? ""
-                // ponytail: raw markdown counts are the ceiling here; upgrade to parser-backed rendered-text/image metrics if list metadata needs semantic precision.
-                let charCount = documentMarkdown.count
-                let imageCount = Self.countMarkdownImageTokens(in: documentMarkdown)
                 let sourceCount: Int = row["source_count"]
                 let sourceDisplayName: String? = row["source_display_name"]
                 return StreamSummary(
@@ -611,11 +619,12 @@ final class PersistenceService {
                     sourceCount: sourceCount,
                     sourceShortTitle: sourceCount == 1 ? sourceDisplayName.map { SourceShortTitle.derive(displayName: $0) } : nil,
                     cellCount: row["cell_count"],
-                    charCount: charCount,
-                    imageCount: imageCount,
+                    charCount: row["char_count"] ?? 0,
+                    wordCount: row["word_count"] ?? 0,
+                    imageCount: row["image_count"] ?? 0,
                     openQuestionCount: row["open_question_count"],
                     updatedAt: Date(timeIntervalSince1970: row["updated_at"]),
-                    previewText: row["preview_text"]
+                    previewPrefix: row["preview_prefix"]
                 )
             }
         }
@@ -951,10 +960,10 @@ final class PersistenceService {
                 try db.execute(
                     sql: """
                         UPDATE stream_documents
-                        SET markdown = ?, revision = ?, updated_at = ?
+                        SET markdown = ?, word_count = ?, revision = ?, updated_at = ?
                         WHERE stream_id = ?
                     """,
-                    arguments: [markdown, newRevision, now, streamId.uuidString]
+                    arguments: [markdown, Self.wordCount(in: markdown), newRevision, now, streamId.uuidString]
                 )
 
                 try db.execute(
@@ -984,10 +993,10 @@ final class PersistenceService {
             let newRevision = 1
             try db.execute(
                 sql: """
-                    INSERT INTO stream_documents (stream_id, markdown, revision, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO stream_documents (stream_id, markdown, word_count, revision, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                arguments: [streamId.uuidString, markdown, newRevision, now, now]
+                arguments: [streamId.uuidString, markdown, Self.wordCount(in: markdown), newRevision, now, now]
             )
 
             try db.execute(
@@ -1052,14 +1061,15 @@ final class PersistenceService {
 
             try db.execute(
                 sql: """
-                    INSERT INTO stream_documents (stream_id, markdown, revision, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO stream_documents (stream_id, markdown, word_count, revision, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     ON CONFLICT(stream_id) DO UPDATE SET
                         markdown = excluded.markdown,
+                        word_count = excluded.word_count,
                         revision = excluded.revision,
                         updated_at = excluded.updated_at
                 """,
-                arguments: [streamId.uuidString, markdown, newRevision, now, now]
+                arguments: [streamId.uuidString, markdown, Self.wordCount(in: markdown), newRevision, now, now]
             )
 
             try db.execute(

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -183,7 +183,7 @@ final class ProxyLLMService {
 
                 // Invalidate key on auth errors
                 if error.shouldInvalidateKey {
-                    await deviceKeyService.clearProxyDeviceKey()
+                    try? await deviceKeyService.clearProxyDeviceKey()
                 }
 
                 await MainActor.run { onError(error) }

--- a/Sources/Ticker/Services/RetrievalService.swift
+++ b/Sources/Ticker/Services/RetrievalService.swift
@@ -191,6 +191,7 @@ struct SourceContext {
 enum SourceContextMode: Equatable {
     case passthrough
     case retrieved
+    case unavailable
 }
 
 enum SourceScope: String, Codable {

--- a/Sources/Ticker/Services/SourceService.swift
+++ b/Sources/Ticker/Services/SourceService.swift
@@ -56,10 +56,14 @@ final class SourceService {
             )
 
             if isStale {
-                // Bookmark is stale - mark source and try to refresh
                 var updated = source
-                updated.status = .stale
-                try? persistence.saveSource(updated)
+                updated.bookmarkData = try url.bookmarkData(
+                    options: [.withSecurityScope],
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                updated.status = updated.extractedText == nil ? .pending : .ready
+                try persistence.saveSource(updated)
             }
 
             guard url.startAccessingSecurityScopedResource() else {

--- a/Tests/TickerTests/DeviceKeyServiceTests.swift
+++ b/Tests/TickerTests/DeviceKeyServiceTests.swift
@@ -86,6 +86,42 @@ final class DeviceKeyServiceTests: XCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
     }
 
+    func test_clearProxyDeviceKeyDoesNotUpdateCacheWhenDiskWriteFails() async throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let deviceDir = tempRoot.appendingPathComponent("device", isDirectory: true)
+        try fileManager.createDirectory(at: deviceDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let fileURL = deviceDir.appendingPathComponent("device.json")
+        let stored = DeviceKeyData(
+            deviceId: UUID().uuidString,
+            deviceKey: "tk_live_test_key",
+            supportId: "sup_test",
+            validatedAt: Date()
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(stored).write(to: fileURL)
+
+        let service = DeviceKeyService(fileURL: fileURL)
+        let initialAuth = await service.loadProxyAuth()
+        XCTAssertEqual(initialAuth.supportId, "sup_test")
+
+        try fileManager.removeItem(at: deviceDir)
+        try Data().write(to: deviceDir)
+
+        do {
+            try await service.clearProxyDeviceKey()
+            XCTFail("Expected clear to report the failed durable write")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, DeviceKeyError.storageFailed.localizedDescription)
+        }
+
+        let authAfterFailedClear = await service.loadProxyAuth()
+        XCTAssertEqual(authAfterFailedClear.supportId, "sup_test")
+    }
+
     func test_getSupportBundle_neverIncludesDeviceKey() async throws {
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2262,6 +2262,47 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_ingestServiceFallsBackToFailedWhenReadyStatusCannotPersist() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Terminal Status")
+            try service.saveStream(stream)
+            let source = SourceReference(
+                streamId: stream.id,
+                displayName: "Notes.txt",
+                fileType: .text,
+                bookmarkData: Data(),
+                status: .ready
+            )
+            try service.saveSource(source)
+
+            var readyAttempts = 0
+            let ingestService = IngestService(
+                persistence: service,
+                sourceService: SourceService(persistence: service),
+                chunkingService: ChunkingService(),
+                writeIndexStatus: { sourceId, status in
+                    if status == .ready {
+                        readyAttempts += 1
+                        throw TestPDFError.creationFailed
+                    }
+                    try service.updateSourceIndexStatus(sourceId, status: status)
+                }
+            )
+            let failed = expectation(description: "terminal status fell back to failed")
+            ingestService.onStatusChange = { update in
+                if update.status == .failed {
+                    failed.fulfill()
+                }
+            }
+
+            ingestService.enqueue(source: source)
+            wait(for: [failed], timeout: 5)
+
+            XCTAssertEqual(readyAttempts, 2)
+            XCTAssertEqual(try service.loadSource(id: source.id)?.indexStatus, .failed)
+        }
+    }
+
     func test_savePDFHighlightRoundTripsRects() throws {
         try withTempPersistenceService { service in
             let source = try savePDFSource(in: service)

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -3280,14 +3280,15 @@ final class StreamDocumentTests: XCTestCase {
             )
 
             let newerSummary = try XCTUnwrap(summaries.first { $0.id == newerStream.id })
-            XCTAssertEqual(newerSummary.previewText, newerMarkdown)
+            XCTAssertEqual(newerSummary.previewPrefix, String(newerMarkdown.prefix(2_000)))
             XCTAssertEqual(newerSummary.sourceCount, 1)
             XCTAssertEqual(newerSummary.sourceShortTitle, "Notebook")
             XCTAssertEqual(newerSummary.charCount, newerMarkdown.count)
+            XCTAssertEqual(newerSummary.wordCount, newerMarkdown.split { $0.isWhitespace }.count)
             XCTAssertEqual(newerSummary.imageCount, 2)
 
             let olderSummary = try XCTUnwrap(summaries.first { $0.id == olderStream.id })
-            XCTAssertEqual(olderSummary.previewText, olderMarkdown)
+            XCTAssertEqual(olderSummary.previewPrefix, String(olderMarkdown.prefix(2_000)))
             XCTAssertEqual(olderSummary.charCount, olderMarkdown.count)
             XCTAssertEqual(olderSummary.imageCount, 0)
 
@@ -3298,6 +3299,11 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(encodedSummary["sourceShortTitle"] as? String, "Notebook")
             XCTAssertEqual(encodedSummary["wordCount"] as? Int, newerMarkdown.split { $0.isWhitespace }.count)
             XCTAssertEqual(encodedSummary["charCount"] as? Int, newerMarkdown.count)
+            XCTAssertNil(encodedSummary["previewText"])
+
+            _ = try service.appendToStreamDocument(streamId: olderStream.id, fragment: "three appended words")
+            let appendedSummary = try XCTUnwrap(service.loadStreamSummaries().first { $0.id == olderStream.id })
+            XCTAssertEqual(appendedSummary.wordCount, olderMarkdown.split { $0.isWhitespace }.count + 3)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1008,6 +1008,35 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_sourceRetrievalFailureHasHonestErrorAndCompletionMode() async throws {
+        XCTAssertEqual(
+            OrchestratorError.sourceRetrievalFailed.localizedDescription,
+            "Source retrieval failed — answer not generated"
+        )
+
+        let recorder = BridgeMessageRecorder()
+        let handler = await AIMessageHandler(
+            sendToWeb: { recorder.send($0) },
+            routeDocumentAI: { _, _, _, _, _, _, _, onComplete, _, _ in
+                onComplete(SourceContext(text: "", chunks: [], mode: .unavailable))
+            }
+        )
+        let requestId = UUID().uuidString
+
+        await handler.handle(BridgeMessage(type: "thinkDocument", payload: [
+            "requestId": AnyCodable(requestId),
+            "query": AnyCodable("Use my sources"),
+            "sourceScope": AnyCodable("auto"),
+            "imageURLs": AnyCodable([])
+        ]))
+
+        try await waitUntil {
+            recorder.messages(ofType: "documentAIComplete").contains { message in
+                message.payload?["sourceContextMode"]?.value as? String == "unavailable"
+            }
+        }
+    }
+
     @MainActor
     func test_documentAICancelStopsSlowStreamingProvider() async throws {
         let recorder = BridgeMessageRecorder()

--- a/Web/src/components/Settings.tsx
+++ b/Web/src/components/Settings.tsx
@@ -189,11 +189,12 @@ export function Settings({ onClose }: SettingsProps) {
 
   // Clear device key
   const handleClearDeviceKey = async () => {
+    setDeviceKeyError(null);
     try {
       const result = await bridge.sendAsync<{ success: boolean; state: ProxyAuthState }>('clearProxyDeviceKey');
       setProxyAuth((prev) => (prev ? { ...prev, state: result.state, supportId: null, limits: null, usage: null } : null));
     } catch (err) {
-      debugError('Failed to clear device key');
+      setDeviceKeyError(err instanceof Error ? err.message : 'Failed to clear device key');
     }
   };
 
@@ -384,10 +385,10 @@ export function Settings({ onClose }: SettingsProps) {
                     {deviceKeyValidating ? 'Validating...' : 'Validate'}
                   </button>
                 </div>
-                {deviceKeyError && (
-                  <p className="settings-error">{deviceKeyError}</p>
-                )}
               </div>
+            )}
+            {deviceKeyError && (
+              <p className="settings-error">{deviceKeyError}</p>
             )}
           </div>
         </section>

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -218,8 +218,8 @@ function parseDocumentAICitations(value: unknown): DocumentAICitation[] | null {
   });
 }
 
-function parseDocumentAISourceContextMode(value: unknown): DocumentAISourceContextMode | undefined {
-  if (value === 'passthrough' || value === 'retrieved' || value === 'none') {
+export function parseDocumentAISourceContextMode(value: unknown): DocumentAISourceContextMode | undefined {
+  if (value === 'passthrough' || value === 'retrieved' || value === 'none' || value === 'unavailable') {
     return value;
   }
   return undefined;
@@ -1287,6 +1287,8 @@ export function StreamEditor({
           provenanceLine = buildProvenanceLine(result.swappedCitations);
         } else if (sourceContextMode === 'none') {
           provenanceLine = '*From model knowledge.*';
+        } else if (sourceContextMode === 'unavailable') {
+          provenanceLine = '*Source retrieval unavailable — answered from model knowledge.*';
         }
 
         if (provenanceLine) {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -119,7 +119,7 @@ export interface SourceTitlePayload {
   shortTitle?: string;
 }
 
-export type DocumentAISourceContextMode = 'passthrough' | 'retrieved' | 'none';
+export type DocumentAISourceContextMode = 'passthrough' | 'retrieved' | 'none' | 'unavailable';
 
 /** Callback registry for async responses */
 type CallbackFn = (payload: Record<string, unknown>) => void;

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -72,7 +72,6 @@ export interface StreamSummary {
   imageCount: number;
   openQuestionCount: number;
   updatedAt: string;
-  previewText: string | null;
   previewLine: string | null;
 }
 


### PR DESCRIPTION
Audit findings #9, #12, #13, #14: bounded stream-list queries + stored word_count (v22 append-only migration with backfill), Sources: All fails honestly on retrieval errors with visible Auto degradation, durable indexing/bookmark state, device-key writes report success only after the disk write. All gates green; implemented by Codex Sol medium, reviewed by governor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)