### PR TITLE
Editor geometry: fix click-jump/phantom-selection and x-ray popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- The provenance-overlay popover now follows the hovered text and positions like the selection menu; it previously rendered cramped at the top-right of the stream regardless of the pointer.
 - Device-key changes now report disk-write failures in Settings and leave the durable key and in-memory auth state unchanged.
 - Source indexing can no longer remain stuck after terminal status-write failures, and refreshed file bookmarks now persist after stale recovery.
 - Source-required AI requests now fail when local retrieval fails, while Auto answers clearly disclose retrieval degradation.

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -586,6 +586,7 @@ export function StreamEditor({
   const provenanceHoverTimerRef = useRef<number | null>(null);
   const provenanceHideTimerRef = useRef<number | null>(null);
   const provenanceSpanIdRef = useRef<string | null>(null);
+  const provenancePinnedRef = useRef(false);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
@@ -1766,20 +1767,40 @@ export function StreamEditor({
       provenanceHoverTimerRef.current = null;
     }
     cancelProvenancePopoverHide();
+    provenancePinnedRef.current = false;
     provenanceSpanIdRef.current = null;
     setProvenancePopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
   }, [cancelProvenancePopoverHide]);
 
   // Grace period so the pointer can travel from the hovered span into the
   // popover (and across gaps between spans) without it vanishing mid-flight.
+  // While the pointer is inside the popover (pinned), nothing may hide it —
+  // only leaving it, clicking an action, or toggling the overlay off.
   const scheduleProvenancePopoverHide = useCallback(() => {
     cancelProvenancePopoverHide();
+    if (provenancePinnedRef.current) return;
     provenanceHideTimerRef.current = window.setTimeout(() => {
       provenanceHideTimerRef.current = null;
+      if (provenancePinnedRef.current) return;
       provenanceSpanIdRef.current = null;
       setProvenancePopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
     }, 400);
   }, [cancelProvenancePopoverHide]);
+
+  const pinProvenancePopover = useCallback(() => {
+    provenancePinnedRef.current = true;
+    cancelProvenancePopoverHide();
+    // A retarget resting from just before entry must not fire while inside.
+    if (provenanceHoverTimerRef.current !== null) {
+      window.clearTimeout(provenanceHoverTimerRef.current);
+      provenanceHoverTimerRef.current = null;
+    }
+  }, [cancelProvenancePopoverHide]);
+
+  const unpinProvenancePopover = useCallback(() => {
+    provenancePinnedRef.current = false;
+    scheduleProvenancePopoverHide();
+  }, [scheduleProvenancePopoverHide]);
 
   const showProvenancePopover = useCallback((span: Span, anchorPos: number) => {
     if (provenanceSpanIdRef.current === span.spanId) return;
@@ -3141,8 +3162,8 @@ export function StreamEditor({
           ref={provenancePopoverRef}
           className="cm-provenance-tooltip provenance-popover"
           style={{ left: `${provenancePopover.left}px`, top: `${provenancePopover.top}px` }}
-          onMouseEnter={cancelProvenancePopoverHide}
-          onMouseLeave={scheduleProvenancePopoverHide}
+          onMouseEnter={pinProvenancePopover}
+          onMouseLeave={unpinProvenancePopover}
         >
           <div className="cm-provenance-tooltip-line">
             {originLine(provenancePopover.span, sources)}

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -1771,14 +1771,14 @@ export function StreamEditor({
   }, [cancelProvenancePopoverHide]);
 
   // Grace period so the pointer can travel from the hovered span into the
-  // popover (and between spans) without the popover vanishing under it.
+  // popover (and across gaps between spans) without it vanishing mid-flight.
   const scheduleProvenancePopoverHide = useCallback(() => {
     cancelProvenancePopoverHide();
     provenanceHideTimerRef.current = window.setTimeout(() => {
       provenanceHideTimerRef.current = null;
       provenanceSpanIdRef.current = null;
       setProvenancePopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
-    }, 240);
+    }, 400);
   }, [cancelProvenancePopoverHide]);
 
   const showProvenancePopover = useCallback((span: Span, anchorPos: number) => {
@@ -2642,7 +2642,12 @@ export function StreamEditor({
     cancelProvenancePopoverHide();
     if (provenanceHoverTimerRef.current !== null) {
       window.clearTimeout(provenanceHoverTimerRef.current);
+      provenanceHoverTimerRef.current = null;
     }
+    // Pointer is over the span whose popover is already showing — keep it.
+    if (provenanceSpanIdRef.current === span.spanId) return;
+    // Rest-detection: this fires per mousemove, so the timer restarts while
+    // the pointer is traveling and only a pointer at rest shows/retargets.
     provenanceHoverTimerRef.current = window.setTimeout(() => {
       provenanceHoverTimerRef.current = null;
       showProvenancePopover(span, pos);

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -20,7 +20,7 @@ import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetE
 import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
-import { canRedevelopSpan, provenanceXrayExtension } from '../extensions/ProvenanceXray';
+import { canRedevelopSpan, provenanceXrayExtension, setProvenanceXrayVisible, type ProvenanceXrayOptions } from '../extensions/ProvenanceXray';
 import { pendingAppendField, setPendingAppend } from '../extensions/PendingAppend';
 import {
   marginNotesField,
@@ -263,6 +263,13 @@ const clickToDocumentEndExtension: Extension = EditorView.domEventHandlers({
   mousedown: (event, view) => {
     if (event.button !== 0 || event.defaultPrevented) return false;
     if (!(event.target instanceof Node) || !view.scrollDOM.contains(event.target)) return false;
+
+    // A precise hit on rendered content vetoes the jump outright. The
+    // estimated height map under-measures long documents (this editor's
+    // page-scrolls layout keeps scrollDOM.scrollTop at 0), so the
+    // coords-based check below can misclassify mid-document clicks as
+    // "past the end" — jumping the viewport and seeding phantom selections.
+    if (view.posAtCoords({ x: event.clientX, y: event.clientY }) !== null) return false;
 
     const endCoords = view.coordsAtPos(view.state.doc.length, 1);
     if (!endCoords) return false;
@@ -2463,18 +2470,32 @@ export function StreamEditor({
     });
   }, [stream.id]);
 
-  const provenanceXray = useMemo<Extension>(() => (
-    isProvenanceXrayVisible
-      ? provenanceXrayExtension({
-        sources,
-        isAiThinking,
-        loadExchange: getExchange,
-        onShowExchange: (exchange, span) => setExchangeOverlay({ exchange, span }),
-        onRedevelop: openRedevelopPrompt,
-        onOpenSource: handleOpenSourceById,
-      })
-      : []
-  ), [handleOpenSourceById, isAiThinking, isProvenanceXrayVisible, openRedevelopPrompt, sources]);
+  // X-ray options are a stable object mutated per render and read lazily at
+  // event time (hover/click), so the extension identity NEVER changes —
+  // toggling visibility must not reconfigure the editor (see ProvenanceXray.ts).
+  const xrayOptionsRef = useRef<ProvenanceXrayOptions>({
+    sources: [],
+    isAiThinking: false,
+    loadExchange: getExchange,
+    onShowExchange: () => {},
+    onRedevelop: () => {},
+    onOpenSource: () => {},
+  });
+  xrayOptionsRef.current.sources = sources;
+  xrayOptionsRef.current.isAiThinking = isAiThinking;
+  xrayOptionsRef.current.onShowExchange = (exchange, span) => setExchangeOverlay({ exchange, span });
+  xrayOptionsRef.current.onRedevelop = openRedevelopPrompt;
+  xrayOptionsRef.current.onOpenSource = handleOpenSourceById;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- stable by design
+  const provenanceXray = useMemo<Extension>(() => provenanceXrayExtension(xrayOptionsRef.current), []);
+
+  useEffect(() => {
+    editorViewRef.current?.dispatch({
+      effects: setProvenanceXrayVisible.of(isProvenanceXrayVisible),
+      annotations: Transaction.addToHistory.of(false),
+    });
+  }, [isProvenanceXrayVisible]);
 
   const editorExtensions = useMemo<Extension[]>(() => [
     EditorView.lineWrapping,

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -20,7 +20,7 @@ import { buildMarkdownImageToken, extractMarkdownImageUrls, markdownImageWidgetE
 import { buildLinkEditChange, linkInteractionExtension, type MarkdownLinkInfo } from '../extensions/LinkInteraction';
 import { tickerPDFLinkExtension } from '../extensions/PDFHighlightLink';
 import { addSpans, currentSpans, dissolveSpans, normalizeSpans, provenanceField, setSpans, type Span } from '../extensions/ProvenanceField';
-import { canRedevelopSpan, provenanceXrayExtension, setProvenanceXrayVisible, type ProvenanceXrayOptions } from '../extensions/ProvenanceXray';
+import { canRedevelopSpan, originLine, provenanceXrayExtension, setProvenanceXrayVisible, type ProvenanceXrayOptions } from '../extensions/ProvenanceXray';
 import { pendingAppendField, setPendingAppend } from '../extensions/PendingAppend';
 import {
   marginNotesField,
@@ -98,6 +98,18 @@ interface LinkPopoverState {
   labelFrom: number;
   label: string;
   url: string;
+  menuWidth?: number;
+  menuHeight?: number;
+}
+
+interface ProvenancePopoverState {
+  visible: boolean;
+  left: number;
+  top: number;
+  anchorPos: number;
+  span: Span | null;
+  exchange: AIExchangeJSON | null;
+  exchangeStatus: 'idle' | 'loading' | 'loaded' | 'missing';
   menuWidth?: number;
   menuHeight?: number;
 }
@@ -548,6 +560,15 @@ export function StreamEditor({
     label: '',
     url: '',
   });
+  const [provenancePopover, setProvenancePopover] = useState<ProvenancePopoverState>({
+    visible: false,
+    left: 0,
+    top: 0,
+    anchorPos: 0,
+    span: null,
+    exchange: null,
+    exchangeStatus: 'idle',
+  });
   const [aiFeedback, setAiFeedback] = useState<AiFeedbackState>({
     visible: false,
     kind: 'writing',
@@ -561,6 +582,10 @@ export function StreamEditor({
   const editorViewRef = useRef<EditorView | null>(null);
   const selectionActionMenuRef = useRef<HTMLDivElement>(null);
   const linkPopoverRef = useRef<HTMLDivElement>(null);
+  const provenancePopoverRef = useRef<HTMLDivElement>(null);
+  const provenanceHoverTimerRef = useRef<number | null>(null);
+  const provenanceHideTimerRef = useRef<number | null>(null);
+  const provenanceSpanIdRef = useRef<string | null>(null);
   const lastSavedContentRef = useRef(stream.document?.markdown ?? '');
   const markdownContentRef = useRef(stream.document?.markdown ?? '');
   const revisionRef = useRef(stream.document?.revision ?? 0);
@@ -1704,6 +1729,97 @@ export function StreamEditor({
     });
   }, []);
 
+  const getProvenancePopoverPlacement = useCallback((
+    view: EditorView,
+    anchorPos: number,
+    measuredMenuSize?: { width: number; height: number }
+  ): { left: number; top: number } | null => {
+    const shell = editorShellRef.current;
+    if (!shell) return null;
+
+    const coords = view.coordsAtPos(Math.min(anchorPos, view.state.doc.length));
+    if (!coords) return null;
+
+    const shellRect = shell.getBoundingClientRect();
+    const menu = provenancePopoverRef.current;
+    return computeSelectionMenuPlacement({
+      coords,
+      shellRect,
+      menuSize: measuredMenuSize ?? {
+        width: menu?.offsetWidth,
+        height: menu?.offsetHeight,
+      },
+      viewportHeight: window.innerHeight,
+    });
+  }, []);
+
+  const cancelProvenancePopoverHide = useCallback(() => {
+    if (provenanceHideTimerRef.current !== null) {
+      window.clearTimeout(provenanceHideTimerRef.current);
+      provenanceHideTimerRef.current = null;
+    }
+  }, []);
+
+  const hideProvenancePopover = useCallback(() => {
+    if (provenanceHoverTimerRef.current !== null) {
+      window.clearTimeout(provenanceHoverTimerRef.current);
+      provenanceHoverTimerRef.current = null;
+    }
+    cancelProvenancePopoverHide();
+    provenanceSpanIdRef.current = null;
+    setProvenancePopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+  }, [cancelProvenancePopoverHide]);
+
+  // Grace period so the pointer can travel from the hovered span into the
+  // popover (and between spans) without the popover vanishing under it.
+  const scheduleProvenancePopoverHide = useCallback(() => {
+    cancelProvenancePopoverHide();
+    provenanceHideTimerRef.current = window.setTimeout(() => {
+      provenanceHideTimerRef.current = null;
+      provenanceSpanIdRef.current = null;
+      setProvenancePopover((previous) => (previous.visible ? { ...previous, visible: false } : previous));
+    }, 240);
+  }, [cancelProvenancePopoverHide]);
+
+  const showProvenancePopover = useCallback((span: Span, anchorPos: number) => {
+    if (provenanceSpanIdRef.current === span.spanId) return;
+
+    const view = editorViewRef.current;
+    if (!view) return;
+    const placement = getProvenancePopoverPlacement(view, anchorPos);
+    if (!placement) return;
+
+    provenanceSpanIdRef.current = span.spanId;
+    const wantsExchange = span.origin === 'ai' && !!span.requestId;
+    setProvenancePopover({
+      visible: true,
+      left: placement.left,
+      top: placement.top,
+      anchorPos,
+      span,
+      exchange: null,
+      exchangeStatus: wantsExchange ? 'loading' : 'idle',
+    });
+
+    if (wantsExchange) {
+      getExchange(span.requestId!)
+        .then(({ exchange }) => {
+          setProvenancePopover((previous) => (
+            previous.visible && previous.span?.spanId === span.spanId
+              ? { ...previous, exchange, exchangeStatus: exchange ? 'loaded' : 'missing' }
+              : previous
+          ));
+        })
+        .catch(() => {
+          setProvenancePopover((previous) => (
+            previous.visible && previous.span?.spanId === span.spanId
+              ? { ...previous, exchange: null, exchangeStatus: 'missing' }
+              : previous
+          ));
+        });
+    }
+  }, [getProvenancePopoverPlacement]);
+
   useLayoutEffect(() => {
     if (!floatingMenu.visible) return;
 
@@ -1798,6 +1914,44 @@ export function StreamEditor({
     pdfPaneState.visible,
     stream.id,
   ]);
+
+  useLayoutEffect(() => {
+    if (!provenancePopover.visible) return;
+
+    const menu = provenancePopoverRef.current;
+    const view = editorViewRef.current;
+    if (!menu || !view) return;
+
+    const measuredMenuSize = {
+      width: menu.offsetWidth,
+      height: menu.offsetHeight,
+    };
+    if (measuredMenuSize.width <= 0 || measuredMenuSize.height <= 0) return;
+
+    const placement = getProvenancePopoverPlacement(view, provenancePopover.anchorPos, measuredMenuSize);
+    if (!placement) return;
+
+    setProvenancePopover((previous) => {
+      if (!previous.visible) return previous;
+
+      const sameSize = previous.menuWidth === measuredMenuSize.width &&
+        previous.menuHeight === measuredMenuSize.height;
+      const samePlacement = Math.abs(previous.left - placement.left) < 0.5 &&
+        Math.abs(previous.top - placement.top) < 0.5;
+
+      if (sameSize && samePlacement) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        left: placement.left,
+        top: placement.top,
+        menuWidth: measuredMenuSize.width,
+        menuHeight: measuredMenuSize.height,
+      };
+    });
+  }, [getProvenancePopoverPlacement, provenancePopover]);
 
   const scheduleSelectionMenu = useCallback((view: EditorView) => {
     clearSelectionMenuTimer();
@@ -2346,6 +2500,13 @@ export function StreamEditor({
   }, [clearSelectionMenuTimer]);
 
   useEffect(() => {
+    return () => {
+      if (provenanceHoverTimerRef.current !== null) window.clearTimeout(provenanceHoverTimerRef.current);
+      if (provenanceHideTimerRef.current !== null) window.clearTimeout(provenanceHideTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
     return () => clearAiFeedbackTimer();
   }, [clearAiFeedbackTimer]);
 
@@ -2471,21 +2632,29 @@ export function StreamEditor({
   }, [stream.id]);
 
   // X-ray options are a stable object mutated per render and read lazily at
-  // event time (hover/click), so the extension identity NEVER changes —
-  // toggling visibility must not reconfigure the editor (see ProvenanceXray.ts).
+  // event time (hover), so the extension identity NEVER changes — toggling
+  // visibility must not reconfigure the editor (see ProvenanceXray.ts).
   const xrayOptionsRef = useRef<ProvenanceXrayOptions>({
-    sources: [],
-    isAiThinking: false,
-    loadExchange: getExchange,
-    onShowExchange: () => {},
-    onRedevelop: () => {},
-    onOpenSource: () => {},
+    onSpanHover: () => {},
+    onSpanHoverEnd: () => {},
   });
-  xrayOptionsRef.current.sources = sources;
-  xrayOptionsRef.current.isAiThinking = isAiThinking;
-  xrayOptionsRef.current.onShowExchange = (exchange, span) => setExchangeOverlay({ exchange, span });
-  xrayOptionsRef.current.onRedevelop = openRedevelopPrompt;
-  xrayOptionsRef.current.onOpenSource = handleOpenSourceById;
+  xrayOptionsRef.current.onSpanHover = (span, pos) => {
+    cancelProvenancePopoverHide();
+    if (provenanceHoverTimerRef.current !== null) {
+      window.clearTimeout(provenanceHoverTimerRef.current);
+    }
+    provenanceHoverTimerRef.current = window.setTimeout(() => {
+      provenanceHoverTimerRef.current = null;
+      showProvenancePopover(span, pos);
+    }, 180);
+  };
+  xrayOptionsRef.current.onSpanHoverEnd = () => {
+    if (provenanceHoverTimerRef.current !== null) {
+      window.clearTimeout(provenanceHoverTimerRef.current);
+      provenanceHoverTimerRef.current = null;
+    }
+    scheduleProvenancePopoverHide();
+  };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- stable by design
   const provenanceXray = useMemo<Extension>(() => provenanceXrayExtension(xrayOptionsRef.current), []);
@@ -2495,7 +2664,8 @@ export function StreamEditor({
       effects: setProvenanceXrayVisible.of(isProvenanceXrayVisible),
       annotations: Transaction.addToHistory.of(false),
     });
-  }, [isProvenanceXrayVisible]);
+    if (!isProvenanceXrayVisible) hideProvenancePopover();
+  }, [hideProvenancePopover, isProvenanceXrayVisible]);
 
   const editorExtensions = useMemo<Extension[]>(() => [
     EditorView.lineWrapping,
@@ -2536,6 +2706,16 @@ export function StreamEditor({
     const view = editorViewRef.current;
     if (!isProvenanceXrayVisible || !floatingMenu.visible || !view) return [];
     return spanIdsIntersectingRange(currentSpans(view.state), floatingMenu.selectionFrom, floatingMenu.selectionTo);
+  })();
+
+  // Clamped: the popover's span offsets are a snapshot and the doc can
+  // change underneath an open popover.
+  const provenancePopoverCoveredText = (() => {
+    const view = editorViewRef.current;
+    const span = provenancePopover.visible ? provenancePopover.span : null;
+    if (!view || !span) return '';
+    const docLength = view.state.doc.length;
+    return view.state.doc.sliceString(Math.min(span.start, docLength), Math.min(span.end, docLength));
   })();
 
   return (
@@ -2948,6 +3128,90 @@ export function StreamEditor({
           >
             Remove
           </button>
+        </div>
+      )}
+
+      {provenancePopover.visible && provenancePopover.span && (
+        <div
+          ref={provenancePopoverRef}
+          className="cm-provenance-tooltip provenance-popover"
+          style={{ left: `${provenancePopover.left}px`, top: `${provenancePopover.top}px` }}
+          onMouseEnter={cancelProvenancePopoverHide}
+          onMouseLeave={scheduleProvenancePopoverHide}
+        >
+          <div className="cm-provenance-tooltip-line">
+            {originLine(provenancePopover.span, sources)}
+          </div>
+          <div className="cm-provenance-tooltip-actions">
+            <button
+              type="button"
+              className="selection-action-button selection-action-button--text"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                const view = editorViewRef.current;
+                const span = provenancePopover.span;
+                if (!view || !span) return;
+                view.dispatch({
+                  effects: dissolveSpans.of([span.spanId]),
+                  annotations: Transaction.addToHistory.of(true),
+                });
+                hideProvenancePopover();
+                view.focus();
+              }}
+            >
+              Dissolve
+            </button>
+            {provenancePopover.span.origin === 'ai' && provenancePopover.span.requestId && (
+              <>
+                <button
+                  type="button"
+                  className="selection-action-button selection-action-button--text"
+                  disabled={provenancePopover.exchangeStatus !== 'loaded'}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    const { exchange, span } = provenancePopover;
+                    if (!exchange || !span) return;
+                    setExchangeOverlay({ exchange, span });
+                    hideProvenancePopover();
+                  }}
+                >
+                  {provenancePopover.exchangeStatus === 'missing' ? 'Exchange no longer stored' : 'Show exchange'}
+                </button>
+                <button
+                  type="button"
+                  className="selection-action-button selection-action-button--text"
+                  disabled={
+                    provenancePopover.exchangeStatus !== 'loaded' ||
+                    !canRedevelopSpan(provenancePopover.span, provenancePopoverCoveredText, isAiThinking)
+                  }
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    const { exchange, span } = provenancePopover;
+                    if (!exchange || !span) return;
+                    hideProvenancePopover();
+                    openRedevelopPrompt(span, exchange);
+                  }}
+                >
+                  Re-develop
+                </button>
+              </>
+            )}
+            {provenancePopover.span.origin === 'source' && provenancePopover.span.sourceId && (
+              <button
+                type="button"
+                className="selection-action-button selection-action-button--text"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  const sourceId = provenancePopover.span?.sourceId;
+                  if (!sourceId) return;
+                  hideProvenancePopover();
+                  handleOpenSourceById(sourceId);
+                }}
+              >
+                Open source →
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/Web/src/extensions/MarkdownImageWidget.ts
+++ b/Web/src/extensions/MarkdownImageWidget.ts
@@ -275,37 +275,14 @@ function buildImageDecorations(view: EditorView): DecorationSet {
 
 function visibleLineRanges(view: EditorView): Array<{ from: number; to: number }> {
   const doc = view.state.doc;
-  const ranges: Array<{ from: number; to: number }> = [];
 
-  for (const visibleRange of view.visibleRanges) {
-    const fromLine = doc.lineAt(Math.min(visibleRange.from, doc.length));
-    const toLine = doc.lineAt(Math.min(visibleRange.to, doc.length));
-    ranges.push({
-      from: fromLine.from,
-      to: toLine.to,
-    });
-  }
-
-  return mergeRanges(ranges);
-}
-
-function mergeRanges(ranges: Array<{ from: number; to: number }>): Array<{ from: number; to: number }> {
-  if (ranges.length < 2) return ranges;
-
-  const sorted = [...ranges].sort((a, b) => a.from - b.from || a.to - b.to);
-  const merged: Array<{ from: number; to: number }> = [];
-
-  for (const range of sorted) {
-    const previous = merged[merged.length - 1];
-    if (!previous || range.from > previous.to) {
-      merged.push({ ...range });
-      continue;
-    }
-
-    previous.to = Math.max(previous.to, range.to);
-  }
-
-  return merged;
+  // Decorate the whole viewport (CM's viewport already extends beyond what's
+  // strictly visible), not just visibleRanges: an image the height map has
+  // never measured contributes one text line of estimated height, and that
+  // under-measurement desyncs click hit-testing in long documents.
+  const fromLine = doc.lineAt(Math.min(view.viewport.from, doc.length));
+  const toLine = doc.lineAt(Math.min(view.viewport.to, doc.length));
+  return [{ from: fromLine.from, to: toLine.to }];
 }
 
 const markdownImageWidgetPlugin = ViewPlugin.fromClass(class {

--- a/Web/src/extensions/ProvenanceXray.ts
+++ b/Web/src/extensions/ProvenanceXray.ts
@@ -1,16 +1,13 @@
-import { RangeSetBuilder, StateEffect, StateField, Transaction, type EditorState, type Extension } from '@codemirror/state';
+import { RangeSetBuilder, StateEffect, StateField, type EditorState, type Extension } from '@codemirror/state';
 import {
   Decoration,
   EditorView,
   ViewPlugin,
-  hoverTooltip,
   type DecorationSet,
-  type Tooltip,
   type ViewUpdate,
 } from '@codemirror/view';
 import type { SourceReference } from '../types';
-import type { AIExchangeJSON } from '../types';
-import { currentSpans, dissolveSpans, type Span } from './ProvenanceField';
+import { currentSpans, type Span } from './ProvenanceField';
 
 export interface ProvenanceRange {
   from: number;
@@ -45,12 +42,8 @@ export function provenanceXrayIsVisible(state: EditorState): boolean {
 }
 
 export interface ProvenanceXrayOptions {
-  sources: SourceReference[];
-  isAiThinking: boolean;
-  loadExchange: (requestId: string) => Promise<{ exchange: AIExchangeJSON | null }>;
-  onShowExchange: (exchange: AIExchangeJSON, span: Span) => void;
-  onRedevelop: (span: Span, exchange: AIExchangeJSON) => void;
-  onOpenSource: (sourceId: string) => void;
+  onSpanHover: (span: Span, pos: number) => void;
+  onSpanHoverEnd: () => void;
 }
 
 function classForOrigin(origin: Span['origin']): string {
@@ -166,7 +159,7 @@ export function canRedevelopSpan(span: Pick<Span, 'origin'>, coveredText: string
   return span.origin === 'ai' && !isAiThinking && coveredText.trim().split(/\s+/).filter(Boolean).length >= 3;
 }
 
-function originLine(span: Span, sources: SourceReference[]): string {
+export function originLine(span: Span, sources: SourceReference[]): string {
   if (span.origin === 'capture') {
     return `Captured from ${textMeta(span.meta.sourceApp, 'unknown app')}`;
   }
@@ -185,81 +178,6 @@ function spanAt(view: EditorView, pos: number): Span | null {
 
 function isAtomicPosition(view: EditorView, pos: number): boolean {
   return atomicRangesInView(view).some((range) => range.from <= pos && pos < range.to);
-}
-
-function button(label: string, onClick?: () => void): HTMLButtonElement {
-  const element = document.createElement('button');
-  element.type = 'button';
-  element.className = 'selection-action-button selection-action-button--text';
-  element.textContent = label;
-  element.disabled = !onClick;
-  element.onmousedown = (event) => event.preventDefault();
-  if (onClick) element.onclick = onClick;
-  return element;
-}
-
-function setButtonAction(element: HTMLButtonElement, onClick?: () => void): void {
-  element.disabled = !onClick;
-  element.onclick = onClick ?? null;
-}
-
-function tooltipForSpan(view: EditorView, span: Span, options: ProvenanceXrayOptions): Tooltip {
-  return {
-    pos: span.start,
-    end: span.end,
-    above: true,
-    create() {
-      const dom = document.createElement('div');
-      dom.className = 'cm-provenance-tooltip';
-
-      const line = document.createElement('div');
-      line.className = 'cm-provenance-tooltip-line';
-      line.textContent = originLine(span, options.sources);
-      dom.append(line);
-
-      const actions = document.createElement('div');
-      actions.className = 'cm-provenance-tooltip-actions';
-      actions.append(button('Dissolve', () => {
-        view.dispatch({
-          effects: dissolveSpans.of([span.spanId]),
-          annotations: Transaction.addToHistory.of(true),
-        });
-        view.focus();
-      }));
-      if (span.origin === 'ai' && span.requestId) {
-        const showExchangeButton = button('Show exchange');
-        actions.append(showExchangeButton);
-
-        const coveredText = view.state.doc.sliceString(span.start, span.end);
-        const redevelopButton = button('Re-develop');
-        actions.append(redevelopButton);
-
-        void options.loadExchange(span.requestId).then(({ exchange }) => {
-          if (!exchange) {
-            showExchangeButton.textContent = 'Exchange no longer stored';
-            setButtonAction(showExchangeButton);
-            setButtonAction(redevelopButton);
-            return;
-          }
-
-          setButtonAction(showExchangeButton, () => options.onShowExchange(exchange, span));
-          if (canRedevelopSpan(span, coveredText, options.isAiThinking)) {
-            setButtonAction(redevelopButton, () => options.onRedevelop(span, exchange));
-          }
-        }).catch(() => {
-          showExchangeButton.textContent = 'Exchange no longer stored';
-          setButtonAction(showExchangeButton);
-          setButtonAction(redevelopButton);
-        });
-      }
-      if (span.origin === 'source' && span.sourceId) {
-        actions.append(button('Open source →', () => options.onOpenSource(span.sourceId!)));
-      }
-      dom.append(actions);
-
-      return { dom };
-    },
-  };
 }
 
 const provenanceXrayPlugin = ViewPlugin.fromClass(class {
@@ -284,15 +202,40 @@ const provenanceXrayPlugin = ViewPlugin.fromClass(class {
   decorations: (value) => value.decorations,
 });
 
+/**
+ * The popover itself is a React element in StreamEditor, positioned by the
+ * same rules as the selection menu. CM's hoverTooltip positions against
+ * scrollDOM geometry, which the page-scrolls layout breaks (tooltip pinned
+ * to the top-right regardless of pointer). This extension only reports which
+ * span is under the pointer.
+ */
 export function provenanceXrayExtension(options: ProvenanceXrayOptions): Extension {
+  let lastSpanId: string | null = null;
+
+  const report = (span: Span | null, pos: number) => {
+    const spanId = span?.spanId ?? null;
+    if (spanId === lastSpanId) return;
+    lastSpanId = spanId;
+    if (span) options.onSpanHover(span, pos);
+    else options.onSpanHoverEnd();
+  };
+
   return [
     provenanceXrayVisibleField,
     provenanceXrayPlugin,
-    hoverTooltip((view, pos) => {
-      if (!provenanceXrayIsVisible(view.state)) return null;
-      if (isAtomicPosition(view, pos)) return null;
-      const span = spanAt(view, pos);
-      return span ? tooltipForSpan(view, span, options) : null;
-    }, { hoverTime: 180, hideOnChange: true }),
+    EditorView.domEventHandlers({
+      mousemove(event, view) {
+        if (!provenanceXrayIsVisible(view.state)) {
+          report(null, 0);
+          return;
+        }
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        const span = pos !== null && !isAtomicPosition(view, pos) ? spanAt(view, pos) : null;
+        report(span, pos ?? 0);
+      },
+      mouseleave() {
+        report(null, 0);
+      },
+    }),
   ];
 }

--- a/Web/src/extensions/ProvenanceXray.ts
+++ b/Web/src/extensions/ProvenanceXray.ts
@@ -206,18 +206,23 @@ const provenanceXrayPlugin = ViewPlugin.fromClass(class {
  * The popover itself is a React element in StreamEditor, positioned by the
  * same rules as the selection menu. CM's hoverTooltip positions against
  * scrollDOM geometry, which the page-scrolls layout breaks (tooltip pinned
- * to the top-right regardless of pointer). This extension only reports which
- * span is under the pointer.
+ * to the top-right regardless of pointer). This extension only reports what
+ * is under the pointer: onSpanHover fires on EVERY mousemove over a span
+ * (the React side does rest-detection with it — an AI answer is stored as
+ * many sibling fragments, so a pointer traveling toward the popover crosses
+ * other spans and must not retarget it), onSpanHoverEnd on leaving spans.
  */
 export function provenanceXrayExtension(options: ProvenanceXrayOptions): Extension {
-  let lastSpanId: string | null = null;
+  let wasOverSpan = false;
 
   const report = (span: Span | null, pos: number) => {
-    const spanId = span?.spanId ?? null;
-    if (spanId === lastSpanId) return;
-    lastSpanId = spanId;
-    if (span) options.onSpanHover(span, pos);
-    else options.onSpanHoverEnd();
+    if (span) {
+      wasOverSpan = true;
+      options.onSpanHover(span, pos);
+    } else if (wasOverSpan) {
+      wasOverSpan = false;
+      options.onSpanHoverEnd();
+    }
   };
 
   return [

--- a/Web/src/extensions/ProvenanceXray.ts
+++ b/Web/src/extensions/ProvenanceXray.ts
@@ -1,4 +1,4 @@
-import { RangeSetBuilder, Transaction, type Extension } from '@codemirror/state';
+import { RangeSetBuilder, StateEffect, StateField, Transaction, type EditorState, type Extension } from '@codemirror/state';
 import {
   Decoration,
   EditorView,
@@ -20,6 +20,28 @@ export interface ProvenanceRange {
 export interface ProvenanceDecorationRange extends ProvenanceRange {
   className: string;
   span: Span;
+}
+
+/**
+ * Visibility rides a StateField, NOT extension add/remove: swapping the
+ * extensions array forces a full StateEffect.reconfigure on every toggle,
+ * which rebuilds all view plugins mid-gesture and desyncs click geometry
+ * in long documents (live bug: click → jump to end + phantom selection).
+ */
+export const setProvenanceXrayVisible = StateEffect.define<boolean>();
+
+export const provenanceXrayVisibleField = StateField.define<boolean>({
+  create: () => false,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setProvenanceXrayVisible)) return effect.value;
+    }
+    return value;
+  },
+});
+
+export function provenanceXrayIsVisible(state: EditorState): boolean {
+  return state.field(provenanceXrayVisibleField, false) ?? false;
 }
 
 export interface ProvenanceXrayOptions {
@@ -116,6 +138,7 @@ function atomicRangesInView(view: EditorView): ProvenanceRange[] {
 }
 
 function buildDecorations(view: EditorView): DecorationSet {
+  if (!provenanceXrayIsVisible(view.state)) return Decoration.none;
   const builder = new RangeSetBuilder<Decoration>();
   for (const range of buildProvenanceDecorationRanges(currentSpans(view.state), view.visibleRanges, atomicRangesInView(view))) {
     builder.add(range.from, range.to, Decoration.mark({ class: range.className }));
@@ -251,7 +274,8 @@ const provenanceXrayPlugin = ViewPlugin.fromClass(class {
       update.docChanged ||
       update.viewportChanged ||
       update.geometryChanged ||
-      currentSpans(update.startState) !== currentSpans(update.state)
+      currentSpans(update.startState) !== currentSpans(update.state) ||
+      provenanceXrayIsVisible(update.startState) !== provenanceXrayIsVisible(update.state)
     ) {
       this.decorations = buildDecorations(update.view);
     }
@@ -262,8 +286,10 @@ const provenanceXrayPlugin = ViewPlugin.fromClass(class {
 
 export function provenanceXrayExtension(options: ProvenanceXrayOptions): Extension {
   return [
+    provenanceXrayVisibleField,
     provenanceXrayPlugin,
     hoverTooltip((view, pos) => {
+      if (!provenanceXrayIsVisible(view.state)) return null;
       if (isAtomicPosition(view, pos)) return null;
       const span = spanAt(view, pos);
       return span ? tooltipForSpan(view, span, options) : null;

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1507,11 +1507,12 @@ body {
   border-bottom: 1px dotted var(--prov-capture-border);
 }
 
-/* CodeMirror's default tooltip wrapper draws its own gray border/background;
-   the provenance card inside is the whole visual — neutralize the wrapper. */
-.document-editor-codemirror .cm-tooltip {
-  border: none;
-  background: transparent;
+/* React popover (StreamEditor), positioned by the selection-menu rules —
+   left is the clamped center point, like .selection-action-menu. */
+.provenance-popover {
+  position: fixed;
+  z-index: 920;
+  transform: translateX(-50%);
 }
 
 .cm-provenance-tooltip {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -1515,6 +1515,13 @@ body {
   transform: translateX(-50%);
 }
 
+/* Disabled buttons swallow mouse events (WebKit fires mouseleave on the
+   parent when the pointer crosses one), which read as "pointer left the
+   popover" and hid it under a resting cursor. */
+.provenance-popover button:disabled {
+  pointer-events: none;
+}
+
 .cm-provenance-tooltip {
   max-width: 320px;
   padding: var(--space-2) var(--space-2) var(--space-1);


### PR DESCRIPTION
Root cause of the live jump+phantom-selection bug: the page-scrolls layout desyncs CM's height-map estimates, so mid-document clicks classified as past-end triggered the click-to-end jump and CM's mouse handling unioned a stale doc-end anchor into a phantom selection. Fixes: provenance x-ray visibility rides a StateField (toggling never reconfigures the editor), a precise posAtCoords hit-test vetoes click-to-end, and image widgets register heights across the whole viewport.

The x-ray popover is now a React element positioned by the same rules as the selection menu (CM's hoverTooltip positions against scrollDOM geometry, broken in this layout), with rest-detection so a traveling pointer never retargets it, and pinning while the pointer is inside (disabled buttons are pointer-transparent — WebKit fires mouseleave on the parent when crossing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)