### PR TITLE
Underline formatting, markdown-aware AI answers, PDF pane theme + instant open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable user-facing changes to Ticker are documented here.
 - Bridge v2 is the live bidirectional document-model contract, routed through feature handlers with surfaced errors.
 
 ### Fixed
+- The PDF pane now follows the app's light/dark theme: page margins and pane backgrounds previously stayed light in dark mode, and opening/closing no longer warps the window across the screen — the pane and window frame animate together.
 - The provenance-overlay popover now follows the hovered text and positions like the selection menu; it previously rendered cramped at the top-right of the stream regardless of the pointer.
 - Device-key changes now report disk-write failures in Settings and leave the durable key and in-memory auth state unchanged.
 - Source indexing can no longer remain stuck after terminal status-write failures, and refreshed file bookmarks now persist after stale recovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Underline joins bold and italic: ⌘U and a U button in the selection menu (stored as `<u>` in the markdown substrate, rendered with the tags concealed).
+- AI answers now use rudimentary Markdown structure — bolded key terms, short paragraphs, lists and headings where they genuinely organize the material — instead of uniformly flat prose.
 - Source answers now use on-device semantic retrieval alongside lexical matching, improving paraphrase recall while preserving the existing fallback behavior.
 - The Rewrite menu gained "With instructions…": describe how the selection should be rewritten and the AI replaces it accordingly. Re-develop with an edited prompt now actually obeys the prompt (it previously deferred to the fixed "develop" instruction and near-restated the passage).
 - In-editor AI now shows the same pulsing-dots indicator at the exact insertion point while waiting for the first chunk, matching quick-panel dispatches.

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -130,27 +130,34 @@ struct PDFPaneOpeningLayout: Equatable {
     let paneWidth: CGFloat
     let shouldResizeWindow: Bool
 
-    /// Accordion semantics: the editor must not change size when the pane
-    /// opens. The window widens by exactly the pane width (right edge grows),
-    /// slides left only when the screen edge would clip it, and never changes
-    /// height or vertical position. The editor only shrinks by whatever width
-    /// the screen genuinely cannot provide.
+    /// Accordion semantics — the pane lives on the LEFT of the editor. The
+    /// pane opens at its classic size (half the screen, capped by what the
+    /// screen and the editor's minimum allow), the window grows leftward by
+    /// exactly the pane width so the editor keeps its size, and the right
+    /// edge (the editor) stays put unless the left screen edge would clip the
+    /// pane — then the window slides right, translating but never resizing
+    /// the editor. Height and vertical position are never touched.
     static func calculate(
         currentFrame: CGRect,
         visibleFrame: CGRect,
         isNativeFullscreen: Bool
     ) -> PDFPaneOpeningLayout {
-        let paneWidth = floor(currentFrame.width * 0.5)
         if isNativeFullscreen || currentFrame.width >= visibleFrame.width {
             return PDFPaneOpeningLayout(
                 targetWindowFrame: currentFrame,
-                paneWidth: paneWidth,
+                paneWidth: floor(currentFrame.width * 0.5),
                 shouldResizeWindow: false
             )
         }
 
-        let targetWidth = min(currentFrame.width + paneWidth, visibleFrame.width)
-        let x = min(max(currentFrame.origin.x, visibleFrame.minX), visibleFrame.maxX - targetWidth)
+        let desiredPaneWidth = floor(visibleFrame.width * 0.5)
+        let growth = max(0, visibleFrame.width - currentFrame.width)
+        let rawPaneWidth = max(min(desiredPaneWidth, growth), PDFPaneWidthPolicy.minimumPDFPaneWidth)
+        let targetWidth = min(currentFrame.width + rawPaneWidth, visibleFrame.width)
+        let paneWidth = PDFPaneWidthPolicy.clampPDFPaneWidth(rawPaneWidth, hostWidth: targetWidth)
+
+        let idealX = currentFrame.maxX - targetWidth // right edge fixed
+        let x = min(max(idealX, visibleFrame.minX), visibleFrame.maxX - targetWidth)
         let targetFrame = CGRect(
             x: x,
             y: currentFrame.origin.y,
@@ -349,6 +356,7 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfOutlineStackView = NSStackView(frame: .zero)
     private let pdfPanePDFView = PDFView(frame: .zero)
     private var pdfPaneWidthConstraint: NSLayoutConstraint?
+    private var paneTransitionConstraint: NSLayoutConstraint?
     private var pdfFindBarHeightConstraint: NSLayoutConstraint?
     private var pdfOutlineWidthConstraint: NSLayoutConstraint?
     private var pdfPaneOutlineButtonWidthConstraint: NSLayoutConstraint?
@@ -555,6 +563,31 @@ final class PDFReaderPaneController: NSViewController {
     }
 
     @discardableResult
+    /// Window frame animation runs on NSWindow's own clock and ignores
+    /// NSAnimationContext, so a pane-width constraint can never stay in
+    /// lockstep with it — the editor visibly stretches from the drift. During
+    /// window-resizing transitions the EDITOR width is pinned instead
+    /// (pane = host − editor), so the pane absorbs every point of window
+    /// growth by construction, whatever the animation timing.
+    private func beginPaneTransition(editorWidth: CGFloat) {
+        guard let host = view.superview else { return }
+        paneTransitionConstraint?.isActive = false
+        pdfPaneWidthConstraint?.isActive = false
+        let pinned = pdfPaneView.widthAnchor.constraint(equalTo: host.widthAnchor, constant: -editorWidth)
+        pinned.isActive = true
+        paneTransitionConstraint = pinned
+        host.layoutSubtreeIfNeeded()
+    }
+
+    private func endPaneTransition(paneWidth: CGFloat) {
+        guard let widthConstraint = pdfPaneWidthConstraint else { return }
+        paneTransitionConstraint?.isActive = false
+        paneTransitionConstraint = nil
+        widthConstraint.constant = paneWidth
+        widthConstraint.isActive = true
+        view.superview?.layoutSubtreeIfNeeded()
+    }
+
     func setVisible(_ visible: Bool) -> Bool {
         guard let widthConstraint = pdfPaneWidthConstraint else { return false }
 
@@ -594,20 +627,34 @@ final class PDFReaderPaneController: NSViewController {
             pdfPaneView.isHidden = false
             isPDFPaneVisible = true
 
-            // Pane width and window frame animate in ONE group. Sequenced
-            // separately (constraint instantly, frame after), the editor first
-            // squeezes inside the old frame and the window then visibly warps
-            // to the screen edge.
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.26
-                context.allowsImplicitAnimation = true
-                widthConstraint.animator().constant = paneWidth
-                if shouldResizeWindow,
-                   let window = view.window,
-                   let targetWindowFrame {
-                    window.animator().setFrame(targetWindowFrame, display: true)
+            if shouldResizeWindow,
+               let window = view.window,
+               let targetWindowFrame {
+                beginPaneTransition(editorWidth: targetWindowFrame.width - paneWidth)
+                let settleDelay = window.animationResizeTime(targetWindowFrame) + 0.05
+                window.setFrame(targetWindowFrame, display: true, animate: true)
+                DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay) { [weak self] in
+                    guard let self, self.isPDFPaneVisible else { return }
+                    self.endPaneTransition(paneWidth: self.pdfPaneView.frame.width)
                 }
-                view.superview?.layoutSubtreeIfNeeded()
+            } else {
+                // Fullscreen / full-width (no room to grow) or no window yet:
+                // slide the pane open in place — the editor shrinks, there is
+                // no alternative. Window is static, so view animation is safe.
+                paneTransitionConstraint?.isActive = false
+                paneTransitionConstraint = nil
+                widthConstraint.isActive = true
+                if view.window != nil {
+                    NSAnimationContext.runAnimationGroup { context in
+                        context.duration = 0.26
+                        context.allowsImplicitAnimation = true
+                        widthConstraint.animator().constant = paneWidth
+                        view.superview?.layoutSubtreeIfNeeded()
+                    }
+                } else {
+                    widthConstraint.constant = paneWidth
+                    view.superview?.layoutSubtreeIfNeeded()
+                }
             }
             return true
         }
@@ -626,23 +673,36 @@ final class PDFReaderPaneController: NSViewController {
         )
         prePDFPaneWindowFrame = nil
         isPDFPaneVisible = false
-        // Mirror of the open animation; the document stays rendered while the
-        // pane slides closed, and teardown waits for the animation. Reopening
-        // mid-animation flips isPDFPaneVisible back, which voids the completion.
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.26
-            context.allowsImplicitAnimation = true
-            widthConstraint.animator().constant = 0
-            if let window = view.window,
-               let restoreFrame {
-                window.animator().setFrame(restoreFrame, display: true)
+
+        if let window = view.window, let restoreFrame {
+            // Mirror of the open: editor pinned at its restored width, the
+            // window shrink squeezes only the pane. Teardown waits for the
+            // animation so the document doesn't blank mid-slide; reopening
+            // mid-animation flips isPDFPaneVisible back, voiding the block.
+            beginPaneTransition(editorWidth: restoreFrame.width)
+            let settleDelay = window.animationResizeTime(restoreFrame) + 0.05
+            window.setFrame(restoreFrame, display: true, animate: true)
+            DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay) { [weak self] in
+                guard let self, !self.isPDFPaneVisible else { return }
+                self.endPaneTransition(paneWidth: 0)
+                self.pdfPaneView.isHidden = true
+                self.releaseActivePDFContext()
             }
-            view.superview?.layoutSubtreeIfNeeded()
-        }, completionHandler: { [weak self] in
-            guard let self, !self.isPDFPaneVisible else { return }
-            self.pdfPaneView.isHidden = true
-            self.releaseActivePDFContext()
-        })
+        } else {
+            paneTransitionConstraint?.isActive = false
+            paneTransitionConstraint = nil
+            widthConstraint.isActive = true
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = 0.26
+                context.allowsImplicitAnimation = true
+                widthConstraint.animator().constant = 0
+                view.superview?.layoutSubtreeIfNeeded()
+            }, completionHandler: { [weak self] in
+                guard let self, !self.isPDFPaneVisible else { return }
+                self.pdfPaneView.isHidden = true
+                self.releaseActivePDFContext()
+            })
+        }
         return true
     }
 

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -203,12 +203,6 @@ enum PDFPaneWidthPolicy {
     }
 }
 
-enum PDFPaneWindowRestore {
-    static func targetFrame(savedFrame: CGRect?, isNativeFullscreen: Bool) -> CGRect? {
-        isNativeFullscreen ? nil : savedFrame
-    }
-}
-
 enum PDFCitationNavigator {
     static func normalizeQuote(_ quote: String) -> String {
         NormalizedTextMap.build(from: quote).normalized
@@ -356,7 +350,9 @@ final class PDFReaderPaneController: NSViewController {
     private let pdfOutlineStackView = NSStackView(frame: .zero)
     private let pdfPanePDFView = PDFView(frame: .zero)
     private var pdfPaneWidthConstraint: NSLayoutConstraint?
-    private var paneTransitionConstraint: NSLayoutConstraint?
+    /// True while the pane's open expanded the window, so close knows to
+    /// give that width back (computed from the current frame, never saved).
+    private var didExpandWindowForPDFPane = false
     private var pdfFindBarHeightConstraint: NSLayoutConstraint?
     private var pdfOutlineWidthConstraint: NSLayoutConstraint?
     private var pdfPaneOutlineButtonWidthConstraint: NSLayoutConstraint?
@@ -367,7 +363,6 @@ final class PDFReaderPaneController: NSViewController {
     private let minimumPDFPaneWidth = PDFPaneWidthPolicy.minimumPDFPaneWidth
     private let minimumEditorPaneWidth = PDFPaneWidthPolicy.minimumEditorPaneWidth
     private var pdfPaneResizeStartWidth: CGFloat = 0
-    private var prePDFPaneWindowFrame: CGRect?
     private var activePDFContext: (streamId: UUID, sourceId: UUID, sourceName: String, fileURL: URL)?
     private var isAnchorPickMode = false
     private var anchorPickMouseMonitor: Any?
@@ -563,31 +558,11 @@ final class PDFReaderPaneController: NSViewController {
     }
 
     @discardableResult
-    /// Window frame animation runs on NSWindow's own clock and ignores
-    /// NSAnimationContext, so a pane-width constraint can never stay in
-    /// lockstep with it — the editor visibly stretches from the drift. During
-    /// window-resizing transitions the EDITOR width is pinned instead
-    /// (pane = host − editor), so the pane absorbs every point of window
-    /// growth by construction, whatever the animation timing.
-    private func beginPaneTransition(editorWidth: CGFloat) {
-        guard let host = view.superview else { return }
-        paneTransitionConstraint?.isActive = false
-        pdfPaneWidthConstraint?.isActive = false
-        let pinned = pdfPaneView.widthAnchor.constraint(equalTo: host.widthAnchor, constant: -editorWidth)
-        pinned.isActive = true
-        paneTransitionConstraint = pinned
-        host.layoutSubtreeIfNeeded()
-    }
-
-    private func endPaneTransition(paneWidth: CGFloat) {
-        guard let widthConstraint = pdfPaneWidthConstraint else { return }
-        paneTransitionConstraint?.isActive = false
-        paneTransitionConstraint = nil
-        widthConstraint.constant = paneWidth
-        widthConstraint.isActive = true
-        view.superview?.layoutSubtreeIfNeeded()
-    }
-
+    /// No animation, by design. NSWindow frame animation runs on its own
+    /// clock and cannot be synchronized with Auto Layout, so every animated
+    /// variant visibly stretched the editor. Instead the window frame and the
+    /// pane width change in the SAME layout pass: one paint, the pane is
+    /// simply there (or gone), and the editor never moves or resizes.
     func setVisible(_ visible: Bool) -> Bool {
         guard let widthConstraint = pdfPaneWidthConstraint else { return false }
 
@@ -603,9 +578,6 @@ final class PDFReaderPaneController: NSViewController {
 
             if let window = view.window {
                 let isFullscreen = window.styleMask.contains(.fullScreen)
-                if prePDFPaneWindowFrame == nil, !isFullscreen {
-                    prePDFPaneWindowFrame = window.frame
-                }
                 let screenFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? window.frame
                 let layout = PDFPaneOpeningLayout.calculate(
                     currentFrame: window.frame,
@@ -619,43 +591,19 @@ final class PDFReaderPaneController: NSViewController {
                 paneWidth = preferredPDFPaneWidth
             }
 
-            guard paneWidth >= minimumPDFPaneWidth else {
-                prePDFPaneWindowFrame = nil
-                return false
-            }
+            guard paneWidth >= minimumPDFPaneWidth else { return false }
 
+            widthConstraint.constant = paneWidth
             pdfPaneView.isHidden = false
             isPDFPaneVisible = true
-
+            didExpandWindowForPDFPane = false
             if shouldResizeWindow,
                let window = view.window,
                let targetWindowFrame {
-                beginPaneTransition(editorWidth: targetWindowFrame.width - paneWidth)
-                let settleDelay = window.animationResizeTime(targetWindowFrame) + 0.05
-                window.setFrame(targetWindowFrame, display: true, animate: true)
-                DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay) { [weak self] in
-                    guard let self, self.isPDFPaneVisible else { return }
-                    self.endPaneTransition(paneWidth: self.pdfPaneView.frame.width)
-                }
-            } else {
-                // Fullscreen / full-width (no room to grow) or no window yet:
-                // slide the pane open in place — the editor shrinks, there is
-                // no alternative. Window is static, so view animation is safe.
-                paneTransitionConstraint?.isActive = false
-                paneTransitionConstraint = nil
-                widthConstraint.isActive = true
-                if view.window != nil {
-                    NSAnimationContext.runAnimationGroup { context in
-                        context.duration = 0.26
-                        context.allowsImplicitAnimation = true
-                        widthConstraint.animator().constant = paneWidth
-                        view.superview?.layoutSubtreeIfNeeded()
-                    }
-                } else {
-                    widthConstraint.constant = paneWidth
-                    view.superview?.layoutSubtreeIfNeeded()
-                }
+                window.setFrame(targetWindowFrame, display: false)
+                didExpandWindowForPDFPane = true
             }
+            view.superview?.layoutSubtreeIfNeeded()
             return true
         }
 
@@ -667,42 +615,27 @@ final class PDFReaderPaneController: NSViewController {
 
         exitAnchorPickMode(notifyCancelled: true)
         dismissPDFFindBar(clearQuery: true, restoreFocus: false)
-        let restoreFrame = PDFPaneWindowRestore.targetFrame(
-            savedFrame: prePDFPaneWindowFrame,
-            isNativeFullscreen: view.window?.styleMask.contains(.fullScreen) == true
-        )
-        prePDFPaneWindowFrame = nil
-        isPDFPaneVisible = false
 
-        if let window = view.window, let restoreFrame {
-            // Mirror of the open: editor pinned at its restored width, the
-            // window shrink squeezes only the pane. Teardown waits for the
-            // animation so the document doesn't blank mid-slide; reopening
-            // mid-animation flips isPDFPaneVisible back, voiding the block.
-            beginPaneTransition(editorWidth: restoreFrame.width)
-            let settleDelay = window.animationResizeTime(restoreFrame) + 0.05
-            window.setFrame(restoreFrame, display: true, animate: true)
-            DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay) { [weak self] in
-                guard let self, !self.isPDFPaneVisible else { return }
-                self.endPaneTransition(paneWidth: 0)
-                self.pdfPaneView.isHidden = true
-                self.releaseActivePDFContext()
-            }
-        } else {
-            paneTransitionConstraint?.isActive = false
-            paneTransitionConstraint = nil
-            widthConstraint.isActive = true
-            NSAnimationContext.runAnimationGroup({ context in
-                context.duration = 0.26
-                context.allowsImplicitAnimation = true
-                widthConstraint.animator().constant = 0
-                view.superview?.layoutSubtreeIfNeeded()
-            }, completionHandler: { [weak self] in
-                guard let self, !self.isPDFPaneVisible else { return }
-                self.pdfPaneView.isHidden = true
-                self.releaseActivePDFContext()
-            })
+        // Inverse of the open, computed from the CURRENT frame — never from a
+        // saved one, which goes stale the moment the user resizes anything:
+        // the left edge moves right by the pane's width and the editor keeps
+        // its exact on-screen size and position.
+        let paneWidth = pdfPaneView.frame.width
+        widthConstraint.constant = 0
+        pdfPaneView.isHidden = true
+        isPDFPaneVisible = false
+        if didExpandWindowForPDFPane,
+           let window = view.window,
+           !window.styleMask.contains(.fullScreen),
+           paneWidth > 0 {
+            var frame = window.frame
+            frame.origin.x += paneWidth
+            frame.size.width -= paneWidth
+            window.setFrame(frame, display: false)
         }
+        didExpandWindowForPDFPane = false
+        view.superview?.layoutSubtreeIfNeeded()
+        releaseActivePDFContext()
         return true
     }
 

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -130,34 +130,38 @@ struct PDFPaneOpeningLayout: Equatable {
     let paneWidth: CGFloat
     let shouldResizeWindow: Bool
 
+    /// Accordion semantics: the editor must not change size when the pane
+    /// opens. The window widens by exactly the pane width (right edge grows),
+    /// slides left only when the screen edge would clip it, and never changes
+    /// height or vertical position. The editor only shrinks by whatever width
+    /// the screen genuinely cannot provide.
     static func calculate(
         currentFrame: CGRect,
         visibleFrame: CGRect,
         isNativeFullscreen: Bool
     ) -> PDFPaneOpeningLayout {
+        let paneWidth = floor(currentFrame.width * 0.5)
         if isNativeFullscreen || currentFrame.width >= visibleFrame.width {
             return PDFPaneOpeningLayout(
                 targetWindowFrame: currentFrame,
-                paneWidth: floor(currentFrame.width * 0.5),
+                paneWidth: paneWidth,
                 shouldResizeWindow: false
             )
         }
 
-        let height = min(currentFrame.height, visibleFrame.height)
-        let minY = visibleFrame.minY
-        let maxY = visibleFrame.maxY - height
-        let y = min(max(currentFrame.origin.y, minY), maxY)
+        let targetWidth = min(currentFrame.width + paneWidth, visibleFrame.width)
+        let x = min(max(currentFrame.origin.x, visibleFrame.minX), visibleFrame.maxX - targetWidth)
         let targetFrame = CGRect(
-            x: visibleFrame.minX,
-            y: y,
-            width: visibleFrame.width,
-            height: height
+            x: x,
+            y: currentFrame.origin.y,
+            width: targetWidth,
+            height: currentFrame.height
         )
 
         return PDFPaneOpeningLayout(
             targetWindowFrame: targetFrame,
-            paneWidth: floor(targetFrame.width * 0.5),
-            shouldResizeWindow: true
+            paneWidth: paneWidth,
+            shouldResizeWindow: targetFrame != currentFrame
         )
     }
 }

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -288,6 +288,18 @@ private final class PDFPaneResizeHandleView: NSView {
     }
 }
 
+/// CALayer colors and PDFView's background are one-shot snapshots, not
+/// appearance-dynamic like control text — they must be re-applied whenever the
+/// effective appearance (settings theme or system) changes.
+private final class PDFPaneAppearanceObservingView: NSView {
+    var onEffectiveAppearanceChange: (() -> Void)?
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        onEffectiveAppearanceChange?()
+    }
+}
+
 private final class PDFPaneFindSearchField: NSSearchField {
     var onKeyDown: ((NSEvent) -> Bool)?
 
@@ -313,8 +325,10 @@ final class PDFReaderPaneController: NSViewController {
     var highlightsProvider: ((UUID) -> [PDFHighlightRecord])?
     var onClose: (() -> Void)?
 
-    private let pdfPaneView = NSView(frame: .zero)
+    private let pdfPaneView = PDFPaneAppearanceObservingView(frame: .zero)
     private let pdfPaneHeaderView = NSView(frame: .zero)
+    private var paneBackgroundLayerViews: [NSView] = []
+    private var paneSeparatorLayerViews: [NSView] = []
     private let pdfPaneResizeHandle = PDFPaneResizeHandleView(frame: .zero)
     private let pdfPaneTitleField = NSTextField(labelWithString: "")
     private let pdfPaneStatusField = NSTextField(labelWithString: "")
@@ -573,15 +587,23 @@ final class PDFReaderPaneController: NSViewController {
                 return false
             }
 
-            widthConstraint.constant = paneWidth
-            view.superview?.layoutSubtreeIfNeeded()
             pdfPaneView.isHidden = false
             isPDFPaneVisible = true
 
-            if shouldResizeWindow,
-               let window = view.window,
-               let targetWindowFrame {
-                window.setFrame(targetWindowFrame, display: true, animate: true)
+            // Pane width and window frame animate in ONE group. Sequenced
+            // separately (constraint instantly, frame after), the editor first
+            // squeezes inside the old frame and the window then visibly warps
+            // to the screen edge.
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.26
+                context.allowsImplicitAnimation = true
+                widthConstraint.animator().constant = paneWidth
+                if shouldResizeWindow,
+                   let window = view.window,
+                   let targetWindowFrame {
+                    window.animator().setFrame(targetWindowFrame, display: true)
+                }
+                view.superview?.layoutSubtreeIfNeeded()
             }
             return true
         }
@@ -599,22 +621,52 @@ final class PDFReaderPaneController: NSViewController {
             isNativeFullscreen: view.window?.styleMask.contains(.fullScreen) == true
         )
         prePDFPaneWindowFrame = nil
-        widthConstraint.constant = 0
-        view.superview?.layoutSubtreeIfNeeded()
-        pdfPaneView.isHidden = true
         isPDFPaneVisible = false
-        if let window = view.window,
-           let restoreFrame {
-            window.setFrame(restoreFrame, display: true, animate: true)
-        }
-        releaseActivePDFContext()
+        // Mirror of the open animation; the document stays rendered while the
+        // pane slides closed, and teardown waits for the animation. Reopening
+        // mid-animation flips isPDFPaneVisible back, which voids the completion.
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.26
+            context.allowsImplicitAnimation = true
+            widthConstraint.animator().constant = 0
+            if let window = view.window,
+               let restoreFrame {
+                window.animator().setFrame(restoreFrame, display: true)
+            }
+            view.superview?.layoutSubtreeIfNeeded()
+        }, completionHandler: { [weak self] in
+            guard let self, !self.isPDFPaneVisible else { return }
+            self.pdfPaneView.isHidden = true
+            self.releaseActivePDFContext()
+        })
         return true
+    }
+
+    /// Layer backgrounds and PDFKit's margin color snapshot the appearance at
+    /// assignment time — resolve them under the pane's effective appearance and
+    /// re-run on every appearance change (settings theme toggle, system switch).
+    private func applyPDFPaneAppearanceColors() {
+        pdfPaneView.effectiveAppearance.performAsCurrentDrawingAppearance {
+            for view in paneBackgroundLayerViews {
+                view.layer?.backgroundColor = PDFPaneStyle.background.cgColor
+            }
+            for view in paneSeparatorLayerViews {
+                view.layer?.backgroundColor = PDFPaneStyle.separator.cgColor
+            }
+            let resolvedSurface = NSColor(cgColor: PDFPaneStyle.surface.cgColor) ?? PDFPaneStyle.surface
+            pdfPanePDFView.backgroundColor = resolvedSurface
+            pdfOutlineScrollView.backgroundColor = resolvedSurface
+            pdfFindSearchField.backgroundColor = resolvedSurface
+        }
     }
 
     private func configurePDFPane() {
         pdfPaneView.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneView.wantsLayer = true
-        pdfPaneView.layer?.backgroundColor = PDFPaneStyle.background.cgColor
+        paneBackgroundLayerViews.append(pdfPaneView)
+        pdfPaneView.onEffectiveAppearanceChange = { [weak self] in
+            self?.applyPDFPaneAppearanceColors()
+        }
         pdfPaneView.isHidden = true
 
         pdfPaneWidthConstraint = pdfPaneView.widthAnchor.constraint(equalToConstant: 0)
@@ -623,11 +675,11 @@ final class PDFReaderPaneController: NSViewController {
         let divider = NSView(frame: .zero)
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.wantsLayer = true
-        divider.layer?.backgroundColor = PDFPaneStyle.separator.cgColor
+        paneSeparatorLayerViews.append(divider)
 
         pdfPaneHeaderView.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneHeaderView.wantsLayer = true
-        pdfPaneHeaderView.layer?.backgroundColor = PDFPaneStyle.background.cgColor
+        paneBackgroundLayerViews.append(pdfPaneHeaderView)
         pdfPaneResizeHandle.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneTitleField.translatesAutoresizingMaskIntoConstraints = false
         pdfPaneStatusField.translatesAutoresizingMaskIntoConstraints = false
@@ -723,7 +775,7 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneCloseButton.setContentHuggingPriority(.required, for: .horizontal)
 
         pdfFindBarView.wantsLayer = true
-        pdfFindBarView.layer?.backgroundColor = PDFPaneStyle.background.cgColor
+        paneBackgroundLayerViews.append(pdfFindBarView)
         pdfFindBarView.isHidden = true
         pdfFindBarView.alphaValue = 0
 
@@ -733,7 +785,6 @@ final class PDFReaderPaneController: NSViewController {
         pdfFindSearchField.controlSize = .small
         pdfFindSearchField.isBordered = false
         pdfFindSearchField.drawsBackground = true
-        pdfFindSearchField.backgroundColor = PDFPaneStyle.surface
         pdfFindSearchField.focusRingType = .none
         pdfFindSearchField.delegate = self
         pdfFindSearchField.sendsSearchStringImmediately = true
@@ -761,7 +812,6 @@ final class PDFReaderPaneController: NSViewController {
         )
 
         pdfOutlineScrollView.drawsBackground = true
-        pdfOutlineScrollView.backgroundColor = PDFPaneStyle.surface
         pdfOutlineScrollView.hasVerticalScroller = true
         pdfOutlineScrollView.hasHorizontalScroller = false
         pdfOutlineScrollView.borderType = .noBorder
@@ -777,7 +827,6 @@ final class PDFReaderPaneController: NSViewController {
         pdfPanePDFView.displayMode = .singlePageContinuous
         pdfPanePDFView.displayDirection = .vertical
         pdfPanePDFView.displaysAsBook = false
-        pdfPanePDFView.backgroundColor = PDFPaneStyle.surface
         let pageControllerSelector = NSSelectorFromString("usePageViewController:withViewOptions:")
         if pdfPanePDFView.responds(to: pageControllerSelector) {
             pdfPanePDFView.perform(pageControllerSelector, with: NSNumber(value: true), with: nil)
@@ -786,12 +835,14 @@ final class PDFReaderPaneController: NSViewController {
         let headerSeparator = NSView(frame: .zero)
         headerSeparator.translatesAutoresizingMaskIntoConstraints = false
         headerSeparator.wantsLayer = true
-        headerSeparator.layer?.backgroundColor = PDFPaneStyle.separator.cgColor
+        paneSeparatorLayerViews.append(headerSeparator)
 
         let findSeparator = NSView(frame: .zero)
         findSeparator.translatesAutoresizingMaskIntoConstraints = false
         findSeparator.wantsLayer = true
-        findSeparator.layer?.backgroundColor = PDFPaneStyle.separator.cgColor
+        paneSeparatorLayerViews.append(findSeparator)
+
+        applyPDFPaneAppearanceColors()
 
         pdfPaneView.addSubview(divider)
         pdfPaneView.addSubview(pdfPaneResizeHandle)

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -13,8 +13,11 @@ enum Prompts {
     Rules:
     - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
       closing summary, no offers of further help.
-    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
-      API fields). Never use lists as the default shape. Never produce lists of bolded
+    - The document renders Markdown — format so the passage scans well: **bold** the few
+      load-bearing terms, *italicize* genuine emphasis, and break anything longer than a short
+      paragraph into several short ones.
+    - Use a heading or a list when it genuinely organizes the material (steps, ingredients,
+      comparisons, API fields) — never as the default shape, and never as lists of bolded
       term-colon-definition pairs.
     - When responding to a question, fold its substance into your opening sentence so the
       passage reads as complete on its own — like an interviewee restating the reporter's
@@ -34,8 +37,11 @@ enum Prompts {
     Rules:
     - Write flowing prose paragraphs. No greetings, no framing ("Here is…", "Certainly"), no
       closing summary, no offers of further help.
-    - Use a heading or a list ONLY when the content is genuinely enumerable (steps, ingredients,
-      API fields). Never use lists as the default shape. Never produce lists of bolded
+    - The document renders Markdown — format so the passage scans well: **bold** the few
+      load-bearing terms, *italicize* genuine emphasis, and break anything longer than a short
+      paragraph into several short ones.
+    - Use a heading or a list when it genuinely organizes the material (steps, ingredients,
+      comparisons, API fields) — never as the default shape, and never as lists of bolded
       term-colon-definition pairs.
     - When responding to a question, fold its substance into your opening sentence so the
       passage reads as complete on its own — like an interviewee restating the reporter's
@@ -45,12 +51,17 @@ enum Prompts {
     - Match the surrounding document's tone and terminology when context is provided.
     """
 
+    /// Appended to document-AI verbs whose answers can run long enough to need shape.
+    static let verbFormatting = """
+    Your output lands in a Markdown document: bold the few load-bearing terms, italicize genuine emphasis, and split long answers into short paragraphs. Use a list or heading only when the material is genuinely enumerable — never lists of bolded term-colon-definition pairs.
+    """
+
     static let verbDevelop = """
-    Develop the following passage into a fuller, clearer version of the same idea. Preserve the author's voice and intent; deepen, do not pad. Output only the developed passage.
+    Develop the following passage into a fuller, clearer version of the same idea. Preserve the author's voice and intent; deepen, do not pad. Output only the developed passage. \(verbFormatting)
     """
 
     static let verbAsk = """
-    Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose.
+    Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose. \(verbFormatting)
     """
 
     static let verbRewrite = """

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -23,6 +23,11 @@ enum Prompts {
       passage reads as complete on its own — like an interviewee restating the reporter's
       question ("What causes tides?" → "Tides are caused by…"). Never quote the question
       verbatim, and never open with a bare "Yes/No" that needs the question to make sense.
+    - ALWAYS answer. Never reply with a clarifying question or a menu of options ("do you
+      want a timeline or a summary?") — there is no conversation to ask into; your text IS
+      the document. Commit to the most reasonable reading, note a load-bearing assumption
+      in passing if you must, and give a complete, final answer. The author re-develops the
+      passage if they wanted a different angle.
     - Be concrete and specific. No filler, no hedging.
     - Match the surrounding document's tone and terminology when context is provided.
     """
@@ -47,6 +52,11 @@ enum Prompts {
       passage reads as complete on its own — like an interviewee restating the reporter's
       question ("What causes tides?" → "Tides are caused by…"). Never quote the question
       verbatim, and never open with a bare "Yes/No" that needs the question to make sense.
+    - ALWAYS answer. Never reply with a clarifying question or a menu of options ("do you
+      want a timeline or a summary?") — there is no conversation to ask into; your text IS
+      the document. Commit to the most reasonable reading, note a load-bearing assumption
+      in passing if you must, and give a complete, final answer. The author re-develops the
+      passage if they wanted a different angle.
     - Be concrete and specific. No filler, no hedging.
     - Match the surrounding document's tone and terminology when context is provided.
     """
@@ -61,7 +71,7 @@ enum Prompts {
     """
 
     static let verbAsk = """
-    Answer the question or continue the line of thought, grounded in the provided context. Output only the answer prose. \(verbFormatting)
+    Answer the question or continue the line of thought, grounded in the provided context. Never reply with a clarifying question or a menu of options — your text is inserted into the document, so there is no conversation to ask into. Commit to the most reasonable reading of the query, note a load-bearing assumption in passing if you must, and give a complete, final answer. Output only the answer prose. \(verbFormatting)
     """
 
     static let verbRewrite = """

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2723,32 +2723,36 @@ final class StreamDocumentTests: XCTestCase {
         )
     }
 
-    func test_pdfPaneOpeningLayoutWidensByPaneWidthKeepingEditorSize() throws {
-        // Accordion: the window grows by exactly the pane width; the editor's
-        // share (900) and the origin are untouched when the screen has room.
+    func test_pdfPaneOpeningLayoutGrowsLeftwardKeepingEditorSizeAndRightEdge() throws {
+        // Accordion, pane on the LEFT: the window grows leftward by the pane
+        // width — the right edge (the editor) and the editor's 800pt share
+        // stay exactly where they were.
         let layout = PDFPaneOpeningLayout.calculate(
-            currentFrame: CGRect(x: 220, y: 120, width: 900, height: 700),
+            currentFrame: CGRect(x: 800, y: 120, width: 800, height: 700),
             visibleFrame: CGRect(x: 0, y: 25, width: 1600, height: 875),
             isNativeFullscreen: false
         )
 
-        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 220, y: 120, width: 1350, height: 700))
-        XCTAssertEqual(layout.paneWidth, 450)
-        XCTAssertEqual(layout.targetWindowFrame.width - layout.paneWidth, 900) // editor unchanged
+        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 0, y: 120, width: 1600, height: 700))
+        XCTAssertEqual(layout.paneWidth, 800)
+        XCTAssertEqual(layout.targetWindowFrame.width - layout.paneWidth, 800) // editor unchanged
+        XCTAssertEqual(layout.targetWindowFrame.maxX, 1600) // right edge fixed
         XCTAssertTrue(layout.shouldResizeWindow)
     }
 
-    func test_pdfPaneOpeningLayoutSlidesLeftOnlyWhenScreenEdgeClips() throws {
-        // Not enough room on the right: the window slides left just enough to
-        // fit, and never changes height or vertical position.
+    func test_pdfPaneOpeningLayoutSlidesRightOnlyWhenLeftEdgeClips() throws {
+        // Not enough room to the left: the window slides right just enough to
+        // fit the pane — translating the editor, never resizing it — and
+        // height and vertical position stay untouched.
         let layout = PDFPaneOpeningLayout.calculate(
-            currentFrame: CGRect(x: 220, y: -200, width: 900, height: 900),
+            currentFrame: CGRect(x: 100, y: -200, width: 900, height: 900),
             visibleFrame: CGRect(x: 0, y: 25, width: 1440, height: 800),
             isNativeFullscreen: false
         )
 
-        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 90, y: -200, width: 1350, height: 900))
-        XCTAssertEqual(layout.paneWidth, 450)
+        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 0, y: -200, width: 1440, height: 900))
+        XCTAssertEqual(layout.paneWidth, 540)
+        XCTAssertEqual(layout.targetWindowFrame.width - layout.paneWidth, 900) // editor unchanged
         XCTAssertTrue(layout.shouldResizeWindow)
     }
 
@@ -2782,7 +2786,7 @@ final class StreamDocumentTests: XCTestCase {
         )
         let maxWidth = PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: visibleFrame.width)
 
-        XCTAssertEqual(layout.paneWidth, 450)
+        XCTAssertEqual(layout.paneWidth, 540)
         XCTAssertGreaterThan(layout.paneWidth, PDFPaneWidthPolicy.minimumPDFPaneWidth)
         XCTAssertLessThan(layout.paneWidth, maxWidth)
     }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2812,14 +2812,6 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(PDFPaneWidthPolicy.clampPDFPaneWidth(20, hostWidth: 260), 260)
     }
 
-    func test_pdfPaneWindowRestoreUsesSavedFrameExceptInFullscreen() throws {
-        let saved = CGRect(x: 120, y: 80, width: 900, height: 700)
-
-        XCTAssertEqual(PDFPaneWindowRestore.targetFrame(savedFrame: saved, isNativeFullscreen: false), saved)
-        XCTAssertNil(PDFPaneWindowRestore.targetFrame(savedFrame: saved, isNativeFullscreen: true))
-        XCTAssertNil(PDFPaneWindowRestore.targetFrame(savedFrame: nil, isNativeFullscreen: false))
-    }
-
     func test_pdfFindNavigationWrapsNextAndPrevious() throws {
         XCTAssertEqual(PDFFindNavigation.nextIndex(currentIndex: nil, matchCount: 3), 0)
         XCTAssertEqual(PDFFindNavigation.nextIndex(currentIndex: 0, matchCount: 3), 1)

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2723,27 +2723,32 @@ final class StreamDocumentTests: XCTestCase {
         )
     }
 
-    func test_pdfPaneOpeningLayoutExpandsToVisibleFrameWidthAndSplitsEvenly() throws {
+    func test_pdfPaneOpeningLayoutWidensByPaneWidthKeepingEditorSize() throws {
+        // Accordion: the window grows by exactly the pane width; the editor's
+        // share (900) and the origin are untouched when the screen has room.
         let layout = PDFPaneOpeningLayout.calculate(
             currentFrame: CGRect(x: 220, y: 120, width: 900, height: 700),
-            visibleFrame: CGRect(x: 0, y: 25, width: 1440, height: 875),
+            visibleFrame: CGRect(x: 0, y: 25, width: 1600, height: 875),
             isNativeFullscreen: false
         )
 
-        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 0, y: 120, width: 1440, height: 700))
-        XCTAssertEqual(layout.paneWidth, 720)
+        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 220, y: 120, width: 1350, height: 700))
+        XCTAssertEqual(layout.paneWidth, 450)
+        XCTAssertEqual(layout.targetWindowFrame.width - layout.paneWidth, 900) // editor unchanged
         XCTAssertTrue(layout.shouldResizeWindow)
     }
 
-    func test_pdfPaneOpeningLayoutClampsHeightAndVerticalPositionInsideVisibleFrame() throws {
+    func test_pdfPaneOpeningLayoutSlidesLeftOnlyWhenScreenEdgeClips() throws {
+        // Not enough room on the right: the window slides left just enough to
+        // fit, and never changes height or vertical position.
         let layout = PDFPaneOpeningLayout.calculate(
             currentFrame: CGRect(x: 220, y: -200, width: 900, height: 900),
             visibleFrame: CGRect(x: 0, y: 25, width: 1440, height: 800),
             isNativeFullscreen: false
         )
 
-        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 0, y: 25, width: 1440, height: 800))
-        XCTAssertEqual(layout.paneWidth, 720)
+        XCTAssertEqual(layout.targetWindowFrame, CGRect(x: 90, y: -200, width: 1350, height: 900))
+        XCTAssertEqual(layout.paneWidth, 450)
         XCTAssertTrue(layout.shouldResizeWindow)
     }
 
@@ -2777,7 +2782,7 @@ final class StreamDocumentTests: XCTestCase {
         )
         let maxWidth = PDFPaneWidthPolicy.maxAllowedPDFPaneWidth(hostWidth: visibleFrame.width)
 
-        XCTAssertEqual(layout.paneWidth, 720)
+        XCTAssertEqual(layout.paneWidth, 450)
         XCTAssertGreaterThan(layout.paneWidth, PDFPaneWidthPolicy.minimumPDFPaneWidth)
         XCTAssertLessThan(layout.paneWidth, maxWidth)
     }

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -40,7 +40,7 @@ import {
   mapPendingPDFAnchorSelection,
   type PendingPDFAnchorSelection,
 } from '../utils/pdfAnchorSelection';
-import { toggleInlineMark } from '../utils/inlineMarks';
+import { toggleInlineMark, type InlineMarker } from '../utils/inlineMarks';
 import { continueBulletListOnEnter, toggleLineFormat, type LineFormat } from '../utils/lineFormats';
 import { computeSelectionMenuPlacement } from '../utils/selectionMenuPlacement';
 
@@ -129,11 +129,13 @@ interface PDFPaneState {
 }
 
 const SELECTION_MENU_DELAY_MS = 180;
+/** Markdown has no underline syntax; inline HTML is the portable substrate. */
+const UNDERLINE_MARK: InlineMarker = { open: '<u>', close: '</u>' };
 const AI_ERROR_FEEDBACK_MS = 2200;
 const AI_INDEXING_NOTICE_MS = 4000;
 
-/** Keymap command for ⌘B/⌘I: toggle an inline markdown marker on the selection. */
-function toggleInlineMarkCommand(marker: string) {
+/** Keymap command for ⌘B/⌘I/⌘U: toggle an inline markdown marker on the selection. */
+function toggleInlineMarkCommand(marker: InlineMarker) {
   return (view: EditorView): boolean => {
     const edit = toggleInlineMark(view.state, view.state.selection.main, marker);
     if (edit) {
@@ -2331,7 +2333,7 @@ export function StreamEditor({
     setShowPrompt(true);
   }, [addToast, getSelectionContext, hideSelectionMenu, isAiThinking]);
 
-  const handleSelectionFormat = useCallback((marker: string) => {
+  const handleSelectionFormat = useCallback((marker: InlineMarker) => {
     const view = editorViewRef.current;
     if (!view) {
       hideSelectionMenu();
@@ -2714,6 +2716,7 @@ export function StreamEditor({
       { key: 'Enter', run: continueBulletListOnEnter },
       { key: 'Mod-b', run: toggleInlineMarkCommand('**') },
       { key: 'Mod-i', run: toggleInlineMarkCommand('*') },
+      { key: 'Mod-u', run: toggleInlineMarkCommand(UNDERLINE_MARK) },
       ...markdownKeymap,
     ])),
     syntaxHighlighting(markdownHighlightStyle),
@@ -2924,6 +2927,16 @@ export function StreamEditor({
             onClick={() => handleSelectionFormat('*')}
           >
             I
+          </button>
+          <button
+            type="button"
+            className="selection-action-button selection-action-button--format selection-action-button--underline"
+            title="Underline"
+            aria-label="Underline"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => handleSelectionFormat(UNDERLINE_MARK)}
+          >
+            U
           </button>
           <button
             type="button"

--- a/Web/src/extensions/MarkdownConceal.test.ts
+++ b/Web/src/extensions/MarkdownConceal.test.ts
@@ -82,6 +82,23 @@ describe('MarkdownConceal static concealment', () => {
     expect(concealRanges(buildMarkdownConcealDecorations(viewFor(back), true), doc.length).length).toBeGreaterThan(0);
   });
 
+  it('conceals paired underline tags but leaves an unmatched tag raw', () => {
+    const doc = 'a <u>keyword</u> and a stray <u> here';
+    const state = stateWithSelection(doc, 0);
+    const ranges = concealRanges(buildMarkdownConcealDecorations(viewFor(state), true), doc.length);
+
+    const openFrom = doc.indexOf('<u>');
+    const closeFrom = doc.indexOf('</u>');
+    const strayFrom = doc.indexOf('<u> here');
+    // Paired tags conceal, content between gets the underline mark, stray tag stays raw.
+    expect(ranges).toEqual([
+      [openFrom, openFrom + 3],
+      [openFrom + 3, closeFrom], // cm-md-underline mark over 'keyword'
+      [closeFrom, closeFrom + 4],
+    ]);
+    expect(ranges.some(([from]) => from === strayFrom)).toBe(false);
+  });
+
   it('leaves chip-eligible http links to the chip layer but conceals complete ticker-pdf links', () => {
     const doc = '[Safari](https://apple.com) and [Book p.3](ticker-pdf://abc?page=3)';
     const state = stateWithSelection(doc, doc.length);

--- a/Web/src/extensions/MarkdownConceal.ts
+++ b/Web/src/extensions/MarkdownConceal.ts
@@ -164,8 +164,10 @@ export function buildMarkdownConcealDecorations(view: EditorView, ensureInitialP
   const tree = markdownTreeForDecorations(view, ensureInitialParse);
   const rawLineFrom = view.state.field(revealRawLinksField, false);
   let skipLink: { from: number; to: number } | null = null;
+  let pendingUnderlineOpen: { from: number; to: number } | null = null;
 
   for (const visibleRange of view.visibleRanges) {
+    pendingUnderlineOpen = null;
     tree.iterate({
       from: visibleRange.from,
       to: visibleRange.to,
@@ -230,6 +232,25 @@ export function buildMarkdownConcealDecorations(view: EditorView, ensureInitialP
             }
             if (codeLine.to >= to || codeLine.number >= view.state.doc.lines) break;
             codeLine = view.state.doc.line(codeLine.number + 1);
+          }
+          return;
+        }
+
+        // Underline rides inline HTML (<u>…</u>) — markdown has no syntax for
+        // it. Only PAIRED tags conceal; an unmatched tag stays visibly raw so
+        // it can be seen and deleted.
+        if (node.name === 'HTMLTag') {
+          const tag = view.state.doc.sliceString(node.from, node.to);
+          if (/^<u\s*>$/i.test(tag)) {
+            pendingUnderlineOpen = { from: node.from, to: node.to };
+          } else if (/^<\/u\s*>$/i.test(tag) && pendingUnderlineOpen && pendingUnderlineOpen.to < node.from) {
+            const open = pendingUnderlineOpen;
+            pendingUnderlineOpen = null;
+            const openConceal = concealRange(open.from, open.to);
+            const closeConceal = concealRange(node.from, node.to);
+            if (openConceal) decorations.push(openConceal);
+            decorations.push(Decoration.mark({ class: 'cm-md-underline' }).range(open.to, node.from));
+            if (closeConceal) decorations.push(closeConceal);
           }
           return;
         }

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -952,6 +952,11 @@ body {
   font-style: italic;
 }
 
+.selection-action-button--underline {
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+}
+
 .selection-action-button--code {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
@@ -1254,6 +1259,11 @@ body {
 .document-editor-codemirror .cm-md-bullet {
   color: var(--color-text-secondary);
   padding-right: var(--space-2);
+}
+
+.document-editor-codemirror .cm-md-underline {
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
 }
 
 .document-editor-codemirror .cm-md-inline-code {

--- a/Web/src/utils/inlineMarks.test.ts
+++ b/Web/src/utils/inlineMarks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { EditorSelection, EditorState } from '@codemirror/state';
-import { toggleInlineMark } from './inlineMarks';
+import { toggleInlineMark, type InlineMarker } from './inlineMarks';
 
 interface ToggleResult {
   doc: string;
@@ -9,7 +9,7 @@ interface ToggleResult {
   selected: string;
 }
 
-function maybeToggle(doc: string, from: number, to: number, marker: string) {
+function maybeToggle(doc: string, from: number, to: number, marker: InlineMarker) {
   const state = EditorState.create({
     doc,
     selection: EditorSelection.range(from, to),
@@ -17,7 +17,7 @@ function maybeToggle(doc: string, from: number, to: number, marker: string) {
   return toggleInlineMark(state, state.selection.main, marker);
 }
 
-function toggle(doc: string, from: number, to: number, marker: string): ToggleResult {
+function toggle(doc: string, from: number, to: number, marker: InlineMarker): ToggleResult {
   const state = EditorState.create({
     doc,
     selection: EditorSelection.range(from, to),
@@ -126,5 +126,42 @@ describe('toggleInlineMark', () => {
       to: 10,
       selected: 'one \n two',
     });
+  });
+
+  const underline = { open: '<u>', close: '</u>' };
+
+  it('wraps with asymmetric underline markers', () => {
+    expect(toggle('Hello world', 6, 11, underline)).toEqual({
+      doc: 'Hello <u>world</u>',
+      from: 9,
+      to: 14,
+      selected: 'world',
+    });
+  });
+
+  it('unwraps a selection that exactly includes underline markers', () => {
+    expect(toggle('<u>world</u>', 0, 12, underline)).toEqual({
+      doc: 'world',
+      from: 0,
+      to: 5,
+      selected: 'world',
+    });
+  });
+
+  it('unwraps underline markers just outside the selection', () => {
+    expect(toggle('<u>world</u>', 3, 8, underline)).toEqual({
+      doc: 'world',
+      from: 0,
+      to: 5,
+      selected: 'world',
+    });
+  });
+
+  it('round-trips a multi-line underline wrap', () => {
+    const first = toggle('one\ntwo', 0, 7, underline);
+    expect(first.doc).toBe('<u>one</u>\n<u>two</u>');
+
+    const second = toggle(first.doc, first.from, first.to, underline);
+    expect(second.doc).toBe('one\ntwo');
   });
 });

--- a/Web/src/utils/inlineMarks.ts
+++ b/Web/src/utils/inlineMarks.ts
@@ -5,59 +5,72 @@ export interface InlineMarkToggle {
   newSelection: EditorSelection;
 }
 
+/** Symmetric markers ('**', '*', '`') pass a string; asymmetric pairs
+ * (underline's '<u>'/'</u>') pass open/close explicitly. */
+export interface InlineMarkPair {
+  open: string;
+  close: string;
+}
+
+export type InlineMarker = string | InlineMarkPair;
+
+function normalizeMarker(marker: InlineMarker): InlineMarkPair {
+  return typeof marker === 'string' ? { open: marker, close: marker } : marker;
+}
+
 export function toggleInlineMark(
   state: EditorState,
   selection: SelectionRange,
-  marker: string,
+  marker: InlineMarker,
 ): InlineMarkToggle | null {
-  if (!marker || selection.empty) return null;
+  const mark = normalizeMarker(marker);
+  if (!mark.open || !mark.close || selection.empty) return null;
 
   const { from, to } = selection;
   if (state.sliceDoc(from, to).includes('\n')) {
-    return toggleMultilineInlineMark(state, from, to, marker);
+    return toggleMultilineInlineMark(state, from, to, mark);
   }
 
-  return toggleSingleLineInlineMark(state, from, to, marker);
+  return toggleSingleLineInlineMark(state, from, to, mark);
 }
 
 function toggleSingleLineInlineMark(
   state: EditorState,
   from: number,
   to: number,
-  marker: string,
+  mark: InlineMarkPair,
 ): InlineMarkToggle | null {
   const core = trimmedRange(state, from, to);
   if (!core) return null;
 
-  const markerLength = marker.length;
   const selectedText = state.sliceDoc(core.from, core.to);
 
-  if (isExactlyWrapped(selectedText, marker)) {
+  if (isExactlyWrapped(selectedText, mark)) {
     return {
       changes: [
-        { from: core.from, to: core.from + markerLength },
-        { from: core.to - markerLength, to: core.to },
+        { from: core.from, to: core.from + mark.open.length },
+        { from: core.to - mark.close.length, to: core.to },
       ],
-      newSelection: EditorSelection.single(core.from, core.to - markerLength * 2),
+      newSelection: EditorSelection.single(core.from, core.to - mark.open.length - mark.close.length),
     };
   }
 
-  if (hasOutsideMarkers(state, core.from, core.to, marker)) {
+  if (hasOutsideMarkers(state, core.from, core.to, mark)) {
     return {
       changes: [
-        { from: core.from - markerLength, to: core.from },
-        { from: core.to, to: core.to + markerLength },
+        { from: core.from - mark.open.length, to: core.from },
+        { from: core.to, to: core.to + mark.close.length },
       ],
-      newSelection: EditorSelection.single(core.from - markerLength, core.to - markerLength),
+      newSelection: EditorSelection.single(core.from - mark.open.length, core.to - mark.open.length),
     };
   }
 
   return {
     changes: [
-      { from: core.from, insert: marker },
-      { from: core.to, insert: marker },
+      { from: core.from, insert: mark.open },
+      { from: core.to, insert: mark.close },
     ],
-    newSelection: EditorSelection.single(core.from + markerLength, core.to + markerLength),
+    newSelection: EditorSelection.single(core.from + mark.open.length, core.to + mark.open.length),
   };
 }
 
@@ -76,26 +89,26 @@ function toggleMultilineInlineMark(
   state: EditorState,
   from: number,
   to: number,
-  marker: string,
+  mark: InlineMarkPair,
 ): InlineMarkToggle | null {
   const cores = trimmedLineRanges(state, from, to);
   if (cores.length === 0) return null;
 
-  const unwrapActions = cores.map((core) => unwrapActionForRange(state, core, marker));
+  const unwrapActions = cores.map((core) => unwrapActionForRange(state, core, mark));
   if (unwrapActions.every((action): action is UnwrapAction => action !== null)) {
-    return unwrapLineRanges(unwrapActions, marker);
+    return unwrapLineRanges(unwrapActions, mark);
   }
 
   const rangesToWrap = cores.filter((_core, index) => unwrapActions[index] === null);
   if (rangesToWrap.length === 0) return null;
-  return wrapLineRanges(rangesToWrap, marker);
+  return wrapLineRanges(rangesToWrap, mark);
 }
 
-function wrapLineRanges(ranges: TextRange[], marker: string): InlineMarkToggle {
+function wrapLineRanges(ranges: TextRange[], mark: InlineMarkPair): InlineMarkToggle {
   const changes: ChangeSpec[] = [];
   for (const range of ranges) {
-    changes.push({ from: range.from, insert: marker });
-    changes.push({ from: range.to, insert: marker });
+    changes.push({ from: range.from, insert: mark.open });
+    changes.push({ from: range.to, insert: mark.close });
   }
 
   const firstRange = ranges[0];
@@ -109,13 +122,12 @@ function wrapLineRanges(ranges: TextRange[], marker: string): InlineMarkToggle {
   };
 }
 
-function unwrapLineRanges(actions: UnwrapAction[], marker: string): InlineMarkToggle {
-  const markerLength = marker.length;
+function unwrapLineRanges(actions: UnwrapAction[], mark: InlineMarkPair): InlineMarkToggle {
   const changes: ChangeSpec[] = [];
 
   for (const action of actions) {
-    changes.push({ from: action.range.from, to: action.range.from + markerLength });
-    changes.push({ from: action.range.to - markerLength, to: action.range.to });
+    changes.push({ from: action.range.from, to: action.range.from + mark.open.length });
+    changes.push({ from: action.range.to - mark.close.length, to: action.range.to });
   }
 
   const firstAction = actions[0];
@@ -129,23 +141,22 @@ function unwrapLineRanges(actions: UnwrapAction[], marker: string): InlineMarkTo
   };
 }
 
-function unwrapActionForRange(state: EditorState, range: TextRange, marker: string): UnwrapAction | null {
-  const markerLength = marker.length;
+function unwrapActionForRange(state: EditorState, range: TextRange, mark: InlineMarkPair): UnwrapAction | null {
   const selectedText = state.sliceDoc(range.from, range.to);
 
-  if (isExactlyWrapped(selectedText, marker)) {
+  if (isExactlyWrapped(selectedText, mark)) {
     return {
       range,
-      contentFrom: range.from + markerLength,
-      contentTo: range.to - markerLength,
+      contentFrom: range.from + mark.open.length,
+      contentTo: range.to - mark.close.length,
     };
   }
 
-  if (hasOutsideMarkers(state, range.from, range.to, marker)) {
+  if (hasOutsideMarkers(state, range.from, range.to, mark)) {
     return {
       range: {
-        from: range.from - markerLength,
-        to: range.to + markerLength,
+        from: range.from - mark.open.length,
+        to: range.to + mark.close.length,
       },
       contentFrom: range.from,
       contentTo: range.to,
@@ -207,20 +218,19 @@ function mapPositionAcrossDeletions(position: number, changes: ChangeSpec[]): nu
   return mapped;
 }
 
-function isExactlyWrapped(text: string, marker: string): boolean {
-  if (text.length < marker.length * 2) return false;
-  if (marker === '*') {
+function isExactlyWrapped(text: string, mark: InlineMarkPair): boolean {
+  if (text.length < mark.open.length + mark.close.length) return false;
+  if (mark.open === '*' && mark.close === '*') {
     return countLeading(text, '*') % 2 === 1 && countTrailing(text, '*') % 2 === 1;
   }
-  return text.startsWith(marker) && text.endsWith(marker);
+  return text.startsWith(mark.open) && text.endsWith(mark.close);
 }
 
-function hasOutsideMarkers(state: EditorState, from: number, to: number, marker: string): boolean {
-  const markerLength = marker.length;
-  if (from < markerLength || to + markerLength > state.doc.length) return false;
-  if (state.sliceDoc(from - markerLength, from) !== marker) return false;
-  if (state.sliceDoc(to, to + markerLength) !== marker) return false;
-  if (marker === '*') {
+function hasOutsideMarkers(state: EditorState, from: number, to: number, mark: InlineMarkPair): boolean {
+  if (from < mark.open.length || to + mark.close.length > state.doc.length) return false;
+  if (state.sliceDoc(from - mark.open.length, from) !== mark.open) return false;
+  if (state.sliceDoc(to, to + mark.close.length) !== mark.close) return false;
+  if (mark.open === '*' && mark.close === '*') {
     return countRepeatedBefore(state, from, '*') % 2 === 1
       && countRepeatedAfter(state, to, '*') % 2 === 1;
   }


### PR DESCRIPTION
- Underline: ⌘U + selection-menu button, stored as <u>…</u> (markdown has no underline syntax); toggleInlineMark generalizes to asymmetric markers; MarkdownConceal conceals paired tags and underlines the content, unmatched tags stay visibly raw.
- AI answers now use rudimentary Markdown structure (bold key terms, short paragraphs, lists/headings only when they organize) — the thinking-partner prompts suppressed structure and the document-AI verbs had no formatting guidance at all. Clarifying questions are now forbidden: inserted text is document content, so every answer must commit and be final.
- PDF pane follows the app theme (CALayer/PDFView colors snapshot the appearance; now re-resolved on effective-appearance change) and opens/closes instantly in one layout pass — the editor never moves or resizes; close is computed from the current frame, not a saved one. NSWindow frame animation can't be synchronized with Auto Layout, so the animated variants are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)