### PR TITLE
Delete the semantic-retrieval kill switch

### DIFF
--- a/Sources/Ticker/Services/RetrievalService.swift
+++ b/Sources/Ticker/Services/RetrievalService.swift
@@ -5,7 +5,6 @@ final class RetrievalService {
     private let persistence: PersistenceService
     private let embeddingProvider: EmbeddingProvider?
     private let operatingPoint: RetrievalOperatingPoint?
-    private let semanticDisabled: () -> Bool
     private let queryBudget: TimeInterval
 
     private static let topK = 8
@@ -30,16 +29,11 @@ final class RetrievalService {
         persistence: PersistenceService,
         embeddingProvider: EmbeddingProvider? = nil,
         operatingPoint: RetrievalOperatingPoint? = nil,
-        semanticDisabled: @escaping () -> Bool = {
-            // ponytail: One-release emergency switch; delete retrieval.semantic.disabled by 2026-08-10.
-            UserDefaults.standard.bool(forKey: "retrieval.semantic.disabled")
-        },
         queryBudget: TimeInterval = 0.1 // ponytail: hard 100ms wall; tune only from measured release telemetry.
     ) {
         self.persistence = persistence
         self.embeddingProvider = embeddingProvider
         self.operatingPoint = operatingPoint ?? RetrievalOperatingPoint.bundled()
-        self.semanticDisabled = semanticDisabled
         self.queryBudget = queryBudget
     }
 
@@ -173,7 +167,7 @@ final class RetrievalService {
         bm25: [RetrievedChunk],
         excludeAIPrivateSources: Bool
     ) -> [RetrievedChunk]? {
-        guard !semanticDisabled(), let provider = embeddingProvider, let operatingPoint else { return nil }
+        guard let provider = embeddingProvider, let operatingPoint else { return nil }
         do {
             let embedded = try persistence.loadChunkEmbeddings(
                 streamId: streamId,

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1755,11 +1755,11 @@ final class StreamDocumentTests: XCTestCase {
 
             let gated = RetrievalService(
                 persistence: service, embeddingProvider: provider,
-                operatingPoint: .init(cosineFloor: 0.5, rrfK: 60), semanticDisabled: { false }
+                operatingPoint: .init(cosineFloor: 0.5, rrfK: 60)
             )
             let passing = RetrievalService(
                 persistence: service, embeddingProvider: provider,
-                operatingPoint: .init(cosineFloor: 0.3, rrfK: 60), semanticDisabled: { false }
+                operatingPoint: .init(cosineFloor: 0.3, rrfK: 60)
             )
 
             XCTAssertTrue(try gated.retrieve(query: "conceptual question", streamId: stream.id).isEmpty)
@@ -1796,33 +1796,7 @@ final class StreamDocumentTests: XCTestCase {
             let actual = try RetrievalService(
                 persistence: service, embeddingProvider: slow,
                 operatingPoint: .init(cosineFloor: 0.3, rrfK: 60),
-                semanticDisabled: { false }, queryBudget: 0.001
-            ).retrieve(query: "anvil receipt", streamId: stream.id)
-
-            XCTAssertEqual(actual.map(\.id), baseline.map(\.id))
-            XCTAssertEqual(actual.map(\.score), baseline.map(\.score))
-        }
-    }
-
-    func test_semanticKillSwitchFallsBackWithoutEmbedding() throws {
-        try withTempPersistenceService { service in
-            let stream = Stream(title: "Kill switch")
-            try service.saveStream(stream)
-            let source = try saveRetrievalSource(
-                in: service, streamId: stream.id, displayName: "Lexical.pdf",
-                extractedText: largeExtractedText(), chunks: [(0, "anvil anvil anvil receipt", 1, 1, nil)]
-            )
-            let chunk = try XCTUnwrap(service.loadSourceChunks(sourceId: source.id).first)
-            try service.saveChunkEmbeddings([[1, 0]], for: [chunk], modelId: "test-model")
-            let baseline = try RetrievalService(persistence: service)
-                .retrieve(query: "anvil receipt", streamId: stream.id)
-            let provider = TestEmbeddingProvider { _ in
-                XCTFail("kill switch must skip embedding")
-                return [[1, 0]]
-            }
-            let actual = try RetrievalService(
-                persistence: service, embeddingProvider: provider,
-                operatingPoint: .init(cosineFloor: 0.3, rrfK: 60), semanticDisabled: { true }
+                queryBudget: 0.001
             ).retrieve(query: "anvil receipt", streamId: stream.id)
 
             XCTAssertEqual(actual.map(\.id), baseline.map(\.id))


### PR DESCRIPTION
retrieval.semantic.disabled was a one-release emergency switch (delete-by 2026-08-10). Semantic retrieval is merged and live-verified, so the switch, its test, and the injection seam go now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)