### PR TITLE
Quick Window: send captured images to AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Added
+- Quick Window AI can now see an attached clipboard image in both Ask and develop + save flows, including the first image copied after launch, and marks ephemeral turns when captured context was included.
 - Editor chrome now prioritizes sources, tucks destructive actions into overflow, simplifies selection tools, and gives background AI work action-specific status.
 - PDF section actions now use a labeled Section control instead of an ambiguous icon.
 - Saved PDF highlights and point anchors now reveal their linked text in the stream when clicked, while PDF text drags continue to select normally.

--- a/Sources/Ticker/App/AppDelegate.swift
+++ b/Sources/Ticker/App/AppDelegate.swift
@@ -94,6 +94,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         CrashSessionSentinel.markLaunch()
+        ClipboardService.syncChangeCount()
         setupStatusItem()
         setupMenuBar()
         setupAppearanceObserver()

--- a/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelManager.swift
@@ -464,11 +464,22 @@ final class QuickPanelManager: ObservableObject {
         // Build context for first turn only
         let isFirstTurn = ephemeralConversation.turns.isEmpty
         let contextForAI: String? = isFirstTurn ? context?.contextText : nil
+        let queryImages: [String]
+        do {
+            queryImages = try Self.imageDataURLsForAI(
+                isFirstTurn ? context?.clipboardImage : nil,
+                using: assetService
+            )
+        } catch {
+            self.error = error.localizedDescription
+            return
+        }
         let pickedStream = try? pickedStreamForAI()
         let streamIdForAI = pickedStream?.id
         let sourceScopeForAI = pickedStream?.sourceScope ?? .auto
         let requestId = UUID().uuidString
-        let userInput = "Selection:\n\(contextForAI ?? "")\n\nPrompt:\n\(query)"
+        let capturedContext = contextForAI ?? (queryImages.isEmpty ? "" : "[Image attached]")
+        let userInput = "Selection:\n\(capturedContext)\n\nPrompt:\n\(query)"
         var responseRaw = ""
         var selectedModel: String?
 
@@ -476,7 +487,7 @@ final class QuickPanelManager: ObservableObject {
         ephemeralConversation.turns.append(ConversationTurn(
             role: .user,
             content: query,
-            contextIncluded: contextForAI != nil
+            contextIncluded: contextForAI != nil || !queryImages.isEmpty
         ))
 
         // Clear input, start streaming
@@ -498,6 +509,7 @@ final class QuickPanelManager: ObservableObject {
         streamingTask = Task { [weak self] in
             await orchestrator.route(
                 query: query,
+                queryImages: queryImages,
                 streamId: streamIdForAI,
                 sourceScope: sourceScopeForAI,
                 priorCells: priorCells,
@@ -723,6 +735,7 @@ final class QuickPanelManager: ObservableObject {
                 aiOperations.begin(streamId: streamId, verb: "develop", origin: "quickPanel")
             }
             var documentMarkdownForAI: String?
+            var queryImagesForAI: [String] = []
             var aiStartupError: String?
 
             if let aiRequestId {
@@ -735,6 +748,17 @@ final class QuickPanelManager: ObservableObject {
                     } catch {
                         aiStartupError = "Could not load document context"
                         DebugLog.log("[QuickPanel] Failed to load document context for AI (\(DebugLog.errorSummary(error)))")
+                    }
+
+                    do {
+                        queryImagesForAI = try Self.imageDataURLsForAI(
+                            context?.clipboardImage,
+                            using: assetService
+                        )
+                    } catch {
+                        documentMarkdownForAI = nil
+                        aiStartupError = error.localizedDescription
+                        DebugLog.log("[QuickPanel] Failed to prepare attached image for AI (\(DebugLog.errorSummary(error)))")
                     }
                 }
             }
@@ -750,6 +774,7 @@ final class QuickPanelManager: ObservableObject {
                         streamId: streamId,
                         prompt: aiPrompt,
                         documentMarkdown: documentMarkdownForAI,
+                        queryImages: queryImagesForAI,
                         persistence: persistence,
                         orchestrator: orchestratorForAI
                     )
@@ -933,6 +958,7 @@ final class QuickPanelManager: ObservableObject {
         streamId: UUID,
         prompt: String,
         documentMarkdown: String,
+        queryImages: [String],
         persistence: PersistenceService,
         orchestrator: AIOrchestrator
     ) {
@@ -942,6 +968,7 @@ final class QuickPanelManager: ObservableObject {
         let task = Task { [weak self] in
             await orchestrator.route(
                 query: prompt,
+                queryImages: queryImages,
                 streamId: nil,
                 priorCells: [],
                 sourceContext: SourceContext(text: documentMarkdown, chunks: [], mode: .passthrough),
@@ -999,6 +1026,14 @@ final class QuickPanelManager: ObservableObject {
             )
         }
         aiOperations.attach(task, to: requestId)
+    }
+
+    static func imageDataURLsForAI(_ imageData: Data?, using assetService: AssetService?) throws -> [String] {
+        guard let imageData else { return [] }
+        guard let dataURL = assetService?.imageToDataURL(imageData) else {
+            throw QuickPanelError.imagePreparationFailed
+        }
+        return [dataURL]
     }
 
     @discardableResult
@@ -1315,6 +1350,7 @@ enum QuickPanelMarkdownFormatter {
 enum QuickPanelError: Error, LocalizedError {
     case persistenceNotConfigured
     case assetServiceNotConfigured
+    case imagePreparationFailed
 
     var errorDescription: String? {
         switch self {
@@ -1322,6 +1358,8 @@ enum QuickPanelError: Error, LocalizedError {
             return "Database not configured"
         case .assetServiceNotConfigured:
             return "Asset storage not configured"
+        case .imagePreparationFailed:
+            return "Attached image could not be prepared for AI"
         }
     }
 }

--- a/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
+++ b/Sources/Ticker/App/QuickPanel/QuickPanelView.swift
@@ -450,10 +450,13 @@ struct QuickPanelView: View {
     }
 
     private func turnView(_ turn: ConversationTurn, id: Int) -> some View {
-        HStack(alignment: .top, spacing: Spacing.xs) {
+        let roleLabel = turn.role == .assistant
+            ? "AI"
+            : turn.contextIncluded ? "You · context included" : "You"
+        return HStack(alignment: .top, spacing: Spacing.xs) {
             VStack(alignment: .leading, spacing: 2) {
                 // Role indicator
-                Text(turn.role == .user ? "You" : "AI")
+                Text(roleLabel)
                     .font(QuickPanelStyle.font(size: QuickPanelStyle.microTextSize, weight: .medium))
                     .foregroundColor(QuickPanelStyle.textSubtle)
 

--- a/Sources/Ticker/Services/AssetService.swift
+++ b/Sources/Ticker/Services/AssetService.swift
@@ -197,23 +197,18 @@ final class AssetService: @unchecked Sendable {
             return nil
         }
 
-        // Resize image if needed and convert to JPEG for efficient encoding
-        guard let (finalData, mimeType) = resizeImageForAPI(
-            data: data,
-            metadata: metadata,
-            maxDimension: 2048
-        ) else {
-            return nil
-        }
-
-        // Convert to data URL
-        let base64 = finalData.base64EncodedString()
-        return "data:\(mimeType);base64,\(base64)"
+        return dataURL(data: data, metadata: metadata)
     }
 
     /// Convert multiple asset URLs to data URLs
     func assetsToDataURLs(_ assetURLs: [String]) -> [String] {
         assetURLs.compactMap { assetToDataURL($0) }
+    }
+
+    /// Convert in-memory image data to a data URL for API consumption.
+    func imageToDataURL(_ data: Data) -> String? {
+        guard let metadata = try? ImageImportPolicy.metadata(for: data) else { return nil }
+        return dataURL(data: data, metadata: metadata)
     }
 
     // MARK: - Private Helpers
@@ -257,6 +252,18 @@ final class AssetService: @unchecked Sendable {
         )
         guard CGImageDestinationFinalize(destination) else { return nil }
         return (output as Data, "image/jpeg")
+    }
+
+    private func dataURL(data: Data, metadata: ImageImportPolicy.Metadata) -> String? {
+        guard let (finalData, mimeType) = resizeImageForAPI(
+            data: data,
+            metadata: metadata,
+            maxDimension: 2048
+        ) else {
+            return nil
+        }
+
+        return "data:\(mimeType);base64,\(finalData.base64EncodedString())"
     }
 
     /// Get MIME type for file extension

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -405,7 +405,7 @@ final class ProxyLLMService {
     // MARK: - Message Building
 
     /// Convert LLMRequest messages to proxy format
-    private func buildProxyMessages(from request: LLMRequest) -> [[String: Any]] {
+    func buildProxyMessages(from request: LLMRequest) -> [[String: Any]] {
         var messages: [[String: Any]] = [
             ["role": "system", "content": request.systemPrompt]
         ]

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1909,6 +1909,31 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: assetService.assetURL(for: secondPath)), secondData)
     }
 
+    @MainActor
+    func test_quickPanelImageBecomesProxyVisionPart() throws {
+        let imageData = try makePNG(red: 255, green: 0, blue: 0)
+        let assetService = AssetService(baseDirectory: FileManager.default.temporaryDirectory)
+        let imageURLs = try QuickPanelManager.imageDataURLsForAI(imageData, using: assetService)
+        let request = LLMRequest(
+            systemPrompt: "Test",
+            messages: [LLMMessage(role: "user", content: "Describe this", imageURLs: imageURLs)]
+        )
+
+        let messages = ProxyLLMService().buildProxyMessages(from: request)
+        let content = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
+        let image = try XCTUnwrap(content.last?["source"] as? [String: String])
+
+        XCTAssertEqual(content.first?["text"] as? String, "Describe this")
+        XCTAssertEqual(image["type"], "base64")
+        XCTAssertEqual(image["media_type"], "image/png")
+        XCTAssertEqual(Data(base64Encoded: try XCTUnwrap(image["data"])), imageData)
+        XCTAssertThrowsError(
+            try QuickPanelManager.imageDataURLsForAI(Data("not an image".utf8), using: assetService)
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "Attached image could not be prepared for AI")
+        }
+    }
+
     func test_imageImportRejectsOversizedBytesAndDimensions() throws {
         let assetService = AssetService(baseDirectory: FileManager.default.temporaryDirectory)
 


### PR DESCRIPTION
## What changed

- Send attached clipboard images through both Quick Window AI actions: Ask and develop + save.
- Reuse the existing validated image-to-data-URL path and report preparation failures instead of silently falling back to text.
- Mark ephemeral turns when captured context was included.
- Prime clipboard recency tracking at launch so the first image copied after launch is detected.
- Add a positive test for the final proxy vision payload.

## Why

Quick Window already displayed and saved clipboard images, but its AI routes omitted the image payload. The model therefore saw only text or a Markdown asset reference. Clipboard recency tracking also initialized too late on a fresh launch, causing the first copied image to look stale.

## Impact

Users can copy a screenshot or image, open Quick Window, and use either AI action with the model receiving the actual pixels. No persistence migration or bridge-contract change is involved.

## Validation

- `HOME="$PWD/.build/home" ./tickerctl.sh swift-test`
- `HOME="$PWD/.build/home" ./tickerctl.sh build-dev`
- `cd Web && npm run typecheck && npm test && npm run build` (151 tests)
- `node tools/contracts/check_bridge_contract.mjs`
- Live GUI smoke: first copied image attached after launch; proxy reported an image-bearing request; GPT-5 mini correctly identified the image content.
