### PR TITLE
C1: adopt the conversation design language (iA-calm revamp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: adopt the inline-conversation design language (phase C1)
 - editor: replace the thread drawer prototype with inline conversations (phase C0: drawer removed)
 - Quick Window now names the save destination and chat persistence in its footer, confirms saves during dismissal, and closes without discarding a draft.
 

--- a/Web/src/App.integration.test.tsx
+++ b/Web/src/App.integration.test.tsx
@@ -149,10 +149,25 @@ afterEach(async () => {
   });
   useToastStore.getState().clearToasts();
   vi.restoreAllMocks();
+  Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 });
   document.body.innerHTML = '';
 });
 
 describe('App stream loading', () => {
+  it('shows typographic list metadata and a hairline only after scrolling', async () => {
+    await boot();
+
+    const first = document.querySelector('.stream-item') as HTMLButtonElement;
+    expect(first.querySelector('.stream-meta')?.textContent).toMatch(/ago$/);
+    expect(first.textContent).not.toContain('word');
+    expect(first.textContent).not.toContain('source');
+    expect(first.textContent).not.toContain('open question');
+
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 1 });
+    await act(async () => { window.dispatchEvent(new Event('scroll')); });
+    expect(document.querySelector('.stream-list-header')?.classList.contains('stream-list-header--scrolled')).toBe(true);
+  });
+
   it('keeps the list recoverable while a stream load is pending', async () => {
     await boot();
     await selectStream();

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -654,34 +654,21 @@ function formatRelativeTime(dateString: string): string {
   if (diffMins < 1) return 'just now';
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
-}
-
-function formatCompactCount(count: number): string {
-  if (count < 1000) {
-    return new Intl.NumberFormat().format(count);
-  }
-  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(count / 1000)}k`;
-}
-
-function formatStreamMetadata(stream: StreamSummary): string {
-  const segments = [formatRelativeTime(stream.updatedAt)];
-
-  if (stream.sourceCount === 1) {
-    segments.push(stream.sourceShortTitle ?? '1 source');
-  } else if (stream.sourceCount > 1) {
-    segments.push(`${stream.sourceCount} sources`);
-  }
-  segments.push(`${formatCompactCount(stream.wordCount)} ${stream.wordCount === 1 ? 'word' : 'words'}`);
-  if (stream.imageCount > 0) {
-    segments.push(`${stream.imageCount} ${stream.imageCount === 1 ? 'image' : 'images'}`);
-  }
-
-  return segments.join(' · ');
+  if (diffDays < 30) return `${diffDays}d ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
+  return `${Math.floor(diffDays / 365)}y ago`;
 }
 
 function StreamListView({ streams, isLoading, error, onSelect, onCreate, onSettings, onRetry }: StreamListViewProps) {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const update = () => setScrolled(window.scrollY > 0);
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    return () => window.removeEventListener('scroll', update);
+  }, []);
+
   // Sort streams by updatedAt (most recent first)
   const sortedStreams = [...streams].sort((a, b) =>
     new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
@@ -689,7 +676,7 @@ function StreamListView({ streams, isLoading, error, onSelect, onCreate, onSetti
 
   return (
     <div className="stream-list">
-      <header className="stream-list-header">
+      <header className={`stream-list-header ${scrolled ? 'stream-list-header--scrolled' : ''}`}>
         <h1>Streams</h1>
         <div className="stream-list-actions">
           <button onClick={onSettings} className="settings-button">
@@ -737,7 +724,7 @@ function StreamListView({ streams, isLoading, error, onSelect, onCreate, onSetti
                 <span className="stream-preview">{stream.previewLine}</span>
               )}
               <span className="stream-meta">
-                {formatStreamMetadata(stream)}
+                {formatRelativeTime(stream.updatedAt)}
               </span>
             </button>
           ))

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -365,6 +365,57 @@ describe('RichStreamEditor chrome parity', () => {
     });
     expect(onDelete).toHaveBeenCalledOnce();
   });
+
+  it('fades Saving… after a save settles without rendering Saved', async () => {
+    vi.useFakeTimers();
+    try {
+      let finishSave: (() => void) | null = null;
+      vi.mocked(bridge.sendAsync).mockImplementation((async (type) => {
+        if (type === 'saveRichStreamDocument') {
+          await new Promise<void>((resolve) => { finishSave = resolve; });
+        }
+        return { revision: 2 };
+      }) as typeof bridge.sendAsync);
+      let liveView: EditorView | null = null;
+      const updateState = EditorView.prototype.updateState;
+      vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+        this: EditorView,
+        state,
+      ) {
+        liveView = this;
+        return updateState.call(this, state);
+      });
+      await renderStream({ ...stream, id: 'save-status-stream' });
+      await selectEditorText('Original');
+      expect(liveView).not.toBe(null);
+
+      await act(async () => {
+        liveView!.dispatch(liveView!.state.tr.insertText('More ', 1));
+        await Promise.resolve();
+      });
+
+      expect(document.querySelector('.stream-save-status')?.textContent).toBe('Saving…');
+      await act(async () => { await vi.advanceTimersByTimeAsync(350); });
+      expect(finishSave).not.toBe(null);
+      await act(async () => {
+        finishSave!();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const status = document.querySelector('.stream-save-status');
+      expect(status?.textContent).toBe('Saving…');
+      expect(status?.classList.contains('stream-save-status--settled')).toBe(true);
+      expect(document.body.textContent).not.toContain('Saved');
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(799); });
+      expect(document.querySelector('.stream-save-status')).not.toBe(null);
+      await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+      expect(document.querySelector('.stream-save-status')).toBe(null);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('an image save that lands after the editor is gone', () => {
@@ -623,7 +674,7 @@ describe('RichStreamEditor document AI', () => {
     await clickAI('Develop with AI');
     const requestId = activeRequestId();
     expect(editor().getAttribute('contenteditable')).toBe('false');
-    expect(document.querySelector('.document-ai-status-pill')?.textContent)
+    expect(document.querySelector('.document-ai-status')?.textContent)
       .toContain('AI is writing');
     expect((document.querySelector('[aria-label="Stop document AI"]') as HTMLButtonElement).disabled)
       .toBe(false);
@@ -650,7 +701,7 @@ describe('RichStreamEditor document AI', () => {
 
     expect(editor().textContent).toBe('A streamed reply.');
     expect(editor().getAttribute('contenteditable')).toBe('true');
-    expect(document.querySelector('.document-ai-status-pill')).toBe(null);
+    expect(document.querySelector('.document-ai-status')).toBe(null);
     await act(async () => {
       editor().dispatchEvent(new KeyboardEvent('keydown', {
         key: 'z', ctrlKey: true, bubbles: true, cancelable: true,
@@ -1227,8 +1278,11 @@ describe('RichStreamEditor scroll position', () => {
       sent = [];
       const scroller = document.querySelector('.stream-content') as HTMLElement;
 
-      scroller.scrollTop = 40;
-      scroller.dispatchEvent(new Event('scroll'));
+      await act(async () => {
+        scroller.scrollTop = 40;
+        scroller.dispatchEvent(new Event('scroll'));
+      });
+      expect(document.querySelector('.stream-header')?.classList.contains('stream-header--scrolled')).toBe(true);
       await vi.advanceTimersByTimeAsync(600);
       scroller.scrollTop = 75;
       scroller.dispatchEvent(new Event('scroll'));
@@ -1240,6 +1294,12 @@ describe('RichStreamEditor scroll position', () => {
         type: 'saveScrollPosition',
         payload: { streamId: 'scroll-stream', offset: 75 },
       }]);
+
+      await act(async () => {
+        scroller.scrollTop = 0;
+        scroller.dispatchEvent(new Event('scroll'));
+      });
+      expect(document.querySelector('.stream-header')?.classList.contains('stream-header--scrolled')).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -171,12 +171,6 @@ const decodePendingAppends = (rows: Stream['pendingAppends']): PendingAppend[] =
   rawSpans: parseRawSpans(append.rawSpansJSON),
 }));
 
-const SAVE_LABEL: Record<SaveState, string> = {
-  saved: 'Saved',
-  saving: 'Saving…',
-  error: 'Save failed',
-};
-
 export function RichStreamEditor({
   stream,
   onBack,
@@ -205,6 +199,9 @@ export function RichStreamEditor({
 
   const [editor, setEditor] = useState<RichTextEditor | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('saved');
+  const [showSaving, setShowSaving] = useState(false);
+  const wasSaving = useRef(false);
+  const [headerScrolled, setHeaderScrolled] = useState(false);
   const [aiRunning, setAIRunning] = useState(false);
   const [aiDetail, setAIDetail] = useState<string | null>(null);
   const [sourceIndexNotice, setSourceIndexNotice] = useState<string | null>(null);
@@ -271,6 +268,23 @@ export function RichStreamEditor({
     onFlushAvailable?.(flushAll);
     return () => onFlushAvailable?.(null);
   }, [flushAll, onFlushAvailable]);
+
+  useEffect(() => {
+    if (saveState === 'saving') {
+      wasSaving.current = true;
+      setShowSaving(true);
+      return;
+    }
+    if (saveState === 'error') {
+      wasSaving.current = false;
+      setShowSaving(false);
+      return;
+    }
+    if (!wasSaving.current) return;
+    wasSaving.current = false;
+    const timer = window.setTimeout(() => setShowSaving(false), 800);
+    return () => window.clearTimeout(timer);
+  }, [saveState]);
 
   const canStartAI = useCallback(() => {
     if (!aiInFlightRef.current && !pdfAIInFlightRef.current) return true;
@@ -1332,7 +1346,7 @@ export function RichStreamEditor({
         }
       }}
     >
-      <header className="stream-header">
+      <header className={`stream-header ${headerScrolled ? 'stream-header--scrolled' : ''}`}>
         <button onClick={leave} disabled={leaving} className="back-button">← Back</button>
         {isEditingTitle ? (
           <input
@@ -1351,16 +1365,18 @@ export function RichStreamEditor({
           </h1>
         )}
         <div className="stream-header-actions">
-          {saveState !== 'saved' && (
+          {(saveState === 'error' || showSaving) && (
             <span
-              className={`stream-save-status stream-save-status--${saveState}`}
+              className={`stream-save-status stream-save-status--${saveState === 'error' ? 'error' : saveState === 'saved' ? 'settled' : 'saving'}`}
               role="status"
               aria-live="polite"
-              aria-label={SAVE_LABEL[saveState]}
-              title={SAVE_LABEL[saveState]}
+              aria-label={saveState === 'error' ? 'Save failed' : 'Saving'}
+              title={saveState === 'error' ? 'Save failed' : 'Saving…'}
             >
               <span className="stream-save-status-dot" aria-hidden="true" />
-              <span className="stream-save-status-label">{SAVE_LABEL[saveState]}</span>
+              <span className="stream-save-status-label">
+                {saveState === 'error' ? 'Save failed' : 'Saving…'}
+              </span>
             </span>
           )}
           <button
@@ -1634,7 +1650,10 @@ export function RichStreamEditor({
       )}
 
       <div className="stream-body">
-        <div className="stream-content">
+        <div
+          className="stream-content"
+          onScroll={(event) => setHeaderScrolled(event.currentTarget.scrollTop > 0)}
+        >
           <div
             ref={editorShellRef}
             className={`document-editor-shell ${xray ? 'richtext-xray' : ''}`}
@@ -1642,7 +1661,7 @@ export function RichStreamEditor({
             <div ref={host} />
             {aiRunning && (
               <div
-                className="document-ai-status-pill"
+                className="document-ai-status"
                 role="status"
                 aria-live="polite"
               >

--- a/Web/src/components/StreamEditor.tsx
+++ b/Web/src/components/StreamEditor.tsx
@@ -816,7 +816,7 @@ export function StreamEditor({
       effects: setPendingAppend.of(false),
       annotations: Transaction.addToHistory.of(false),
     });
-    // Don't stomp the pill if an in-editor AI request is also running.
+    // Don't stomp the status if an in-editor AI request is also running.
     if (!aiRequestRef.current) hideAiFeedback();
   }, [hideAiFeedback]);
 
@@ -2992,18 +2992,20 @@ export function StreamEditor({
           </h1>
         )}
         <div className="stream-header-actions">
-          <span
-            className={`stream-save-status stream-save-status--${saveState}`}
-            role="status"
-            aria-live="polite"
-            aria-label={saveState === 'saving' ? 'Saving' : saveState === 'error' ? 'Save failed' : 'Saved'}
-            title={saveState === 'saving' ? 'Saving…' : saveState === 'error' ? 'Save failed' : 'Saved'}
-          >
-            <span className="stream-save-status-dot" aria-hidden="true" />
-            <span className="stream-save-status-label">
-              {saveState === 'saving' ? 'Saving…' : saveState === 'error' ? 'Save failed' : 'Saved'}
+          {saveState !== 'saved' && (
+            <span
+              className={`stream-save-status stream-save-status--${saveState}`}
+              role="status"
+              aria-live="polite"
+              aria-label={saveState === 'saving' ? 'Saving' : 'Save failed'}
+              title={saveState === 'saving' ? 'Saving…' : 'Save failed'}
+            >
+              <span className="stream-save-status-dot" aria-hidden="true" />
+              <span className="stream-save-status-label">
+                {saveState === 'saving' ? 'Saving…' : 'Save failed'}
+              </span>
             </span>
-          </span>
+          )}
           <button
             onClick={() => setIsProvenanceXrayVisible((value) => !value)}
             className={`stream-xray-button ${isProvenanceXrayVisible ? 'stream-xray-button--active' : ''}`}
@@ -3021,7 +3023,7 @@ export function StreamEditor({
             type="button"
             aria-label={`Sources, ${sources.length} ${sources.length === 1 ? 'source' : 'sources'}`}
           >
-            Sources · {sources.length}
+            {sources.length > 0 ? `Sources · ${sources.length}` : 'Sources'}
           </button>
           <details
             ref={streamOverflowMenuRef}
@@ -3532,7 +3534,7 @@ export function StreamEditor({
             />
             {aiFeedback.visible && (
               <div
-                className={`document-ai-status-pill document-ai-status-pill--${aiFeedback.kind}`}
+                className={`document-ai-status document-ai-status--${aiFeedback.kind}`}
                 role="status"
                 aria-live="polite"
               >

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -74,9 +74,9 @@
   margin-top: 0;
 }
 
-.richtext-editor .ProseMirror h1 { font-size: 24px; line-height: 32px; }
-.richtext-editor .ProseMirror h2 { font-size: 19px; line-height: 28px; }
-.richtext-editor .ProseMirror h3 { font-size: 17px; line-height: 28px; }
+.richtext-editor .ProseMirror h1 { font-size: var(--editor-heading-1); line-height: 1.3333333333; }
+.richtext-editor .ProseMirror h2 { font-size: var(--editor-heading-2); line-height: 1.4736842105; }
+.richtext-editor .ProseMirror h3 { font-size: var(--editor-heading-3); line-height: 1.6470588235; }
 .richtext-editor .ProseMirror h4,
 .richtext-editor .ProseMirror h5,
 .richtext-editor .ProseMirror h6 { font-size: 1em; }

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -28,10 +28,10 @@
 }
 
 .richtext-editor .ProseMirror {
-  max-width: 68ch;
+  max-width: 64ch;
   min-height: inherit;
   margin: 0 auto;
-  padding: clamp(var(--space-6), 4.6vw, var(--space-8)) clamp(var(--space-5), 4.6vw, var(--space-8))
+  padding: 96px clamp(var(--space-5), 4.6vw, var(--space-8))
     clamp(220px, 30vh, 360px);
   outline: none;
   color: var(--color-text);
@@ -68,16 +68,15 @@
   margin: var(--space-6) 0 var(--space-3);
   color: var(--text);
   font-weight: 600;
-  line-height: var(--line-height-tight);
 }
 
 .richtext-editor .ProseMirror > :first-child {
   margin-top: 0;
 }
 
-.richtext-editor .ProseMirror h1 { font-size: 1.6em; }
-.richtext-editor .ProseMirror h2 { font-size: 1.35em; }
-.richtext-editor .ProseMirror h3 { font-size: 1.15em; }
+.richtext-editor .ProseMirror h1 { font-size: 24px; line-height: 32px; }
+.richtext-editor .ProseMirror h2 { font-size: 19px; line-height: 28px; }
+.richtext-editor .ProseMirror h3 { font-size: 17px; line-height: 28px; }
 .richtext-editor .ProseMirror h4,
 .richtext-editor .ProseMirror h5,
 .richtext-editor .ProseMirror h6 { font-size: 1em; }

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -76,13 +76,15 @@
   --type-ui-title: 17px;
   --type-ui-display: 28px;
   --type-ui-line-height: 16px;
+  --type-list-preview: 14px;
+  --type-list-preview-line-height: 20px;
   --conversation-body: 15px;
   --conversation-line-height: 24px;
   --editor-body: 17px;
-  --editor-heading-1: 24px;
-  --editor-heading-2: 19px;
-  --editor-heading-3: 17px;
-  --editor-line-height: 28px;
+  --editor-heading-1: 1.4117647059em;
+  --editor-heading-2: 1.1176470588em;
+  --editor-heading-3: 1em;
+  --editor-line-height: 1.65;
 
   /* Compatibility aliases for existing component CSS */
   --color-bg: var(--bg);
@@ -207,9 +209,6 @@ body {
 }
 
 .stream-list-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -297,7 +296,7 @@ body {
 }
 
 .stream-item:hover {
-  background: var(--color-surface);
+  background: var(--surface-hover);
 }
 
 .stream-item:active {
@@ -334,8 +333,8 @@ body {
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: var(--type-list-preview);
+  line-height: var(--type-list-preview-line-height);
   color: var(--text-muted);
 }
 
@@ -856,7 +855,6 @@ body {
 }
 
 .stream-content {
-  --stream-end-scroll-space: clamp(120px, 24vh, 260px);
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
@@ -1319,21 +1317,21 @@ body {
 
 .document-editor-codemirror .cm-md-heading-1 {
   font-size: var(--editor-heading-1);
-  line-height: 32px;
+  line-height: 1.3333333333;
   font-weight: 600;
   letter-spacing: -0.015em;
 }
 
 .document-editor-codemirror .cm-md-heading-2 {
   font-size: var(--editor-heading-2);
-  line-height: 28px;
+  line-height: 1.4736842105;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .document-editor-codemirror .cm-md-heading-3 {
   font-size: var(--editor-heading-3);
-  line-height: 28px;
+  line-height: 1.6470588235;
   font-weight: 600;
 }
 
@@ -1523,7 +1521,6 @@ body {
   min-width: 120px;
   border-radius: var(--radius);
   border: 1px solid var(--border);
-  box-shadow: var(--control-shadow);
 }
 
 .document-editor-codemirror .cm-md-image-resize-handle {

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -61,8 +61,8 @@
   --space-7: 40px;
   --space-8: 64px;
 
-  /* One shared surface radius and overlay shadow */
-  --radius: 8px;
+  /* Controls are 6px; chips use the 4px small radius. */
+  --radius: 6px;
   --radius-small: 4px;
   --overlay-shadow: 0 16px 44px rgba(31, 31, 29, 0.16);
   --overlay-backdrop: blur(10px);
@@ -70,16 +70,19 @@
   --duration-base: 200ms;
 
   /* Type scale */
-  --type-ui-caption: 11px;
+  --type-ui-caption: 12px;
   --type-ui-small: 13px;
   --type-ui: 15px;
   --type-ui-title: 17px;
   --type-ui-display: 28px;
-  --editor-body: 16px;
-  --editor-heading-1: 1.6em;
-  --editor-heading-2: 1.35em;
-  --editor-heading-3: 1.15em;
-  --editor-line-height: 1.55;
+  --type-ui-line-height: 16px;
+  --conversation-body: 15px;
+  --conversation-line-height: 24px;
+  --editor-body: 17px;
+  --editor-heading-1: 24px;
+  --editor-heading-2: 19px;
+  --editor-heading-3: 17px;
+  --editor-line-height: 28px;
 
   /* Compatibility aliases for existing component CSS */
   --color-bg: var(--bg);
@@ -204,10 +207,20 @@ body {
 }
 
 .stream-list-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: var(--spacing-xl);
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--duration-fast) ease;
+}
+
+.stream-list-header--scrolled {
+  border-bottom-color: var(--border-subtle);
 }
 
 .stream-list-header h1 {
@@ -223,20 +236,21 @@ body {
 }
 
 .stream-list-header button {
-  background: var(--color-text);
-  color: var(--color-bg);
+  background: transparent;
+  color: var(--text-muted);
   border: none;
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: var(--font-size-sm);
+  font-size: var(--type-ui-small);
+  line-height: var(--type-ui-line-height);
   font-weight: 500;
   transition: all var(--duration-base) ease;
 }
 
 .stream-list-header button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--control-shadow);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .stream-list-header .settings-button {
@@ -247,15 +261,18 @@ body {
 
 .stream-list-header .settings-button:hover {
   color: var(--color-text);
+  background: var(--surface-hover);
+}
+
+.stream-list-header .primary-button,
+.stream-list-header .primary-button:hover {
+  color: var(--accent);
   background: transparent;
-  box-shadow: none;
-  transform: none;
 }
 
 .stream-list-content {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
 }
 
 .stream-item {
@@ -265,14 +282,18 @@ body {
   gap: var(--spacing-xs);
   background: transparent;
   border: none;
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
+  border-radius: 0;
+  padding: var(--spacing-md) var(--spacing-sm);
   cursor: pointer;
   text-align: left;
   width: 100%;
   color: inherit;
   font: inherit;
-  transition: all var(--duration-base) ease;
+  transition: background-color var(--duration-fast) ease;
+}
+
+.stream-item + .stream-item {
+  border-top: 1px solid var(--border-subtle);
 }
 
 .stream-item:hover {
@@ -313,13 +334,15 @@ body {
   display: -webkit-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--text-muted);
 }
 
 .stream-meta {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-tertiary);
+  font-size: var(--type-ui-caption);
+  line-height: var(--type-ui-line-height);
+  color: var(--text-faint);
 }
 
 /* Empty and Loading States */
@@ -385,8 +408,8 @@ body {
 
 /* Primary button */
 .primary-button {
-  background: var(--color-text);
-  color: var(--color-bg);
+  background: var(--accent);
+  color: var(--on-accent);
   border: none;
   padding: var(--spacing-sm) var(--spacing-lg);
   border-radius: var(--radius-md);
@@ -397,12 +420,11 @@ body {
 }
 
 .primary-button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--control-shadow);
+  background: var(--accent-hover);
 }
 
 .primary-button:active {
-  transform: translateY(0);
+  background: var(--accent);
 }
 
 /* ==================== Stream Editor ==================== */
@@ -420,14 +442,19 @@ body {
   gap: var(--spacing-sm);
   flex: 0 0 auto;
   padding: max(var(--spacing-md), var(--window-chrome-safe-top)) var(--spacing-xl) var(--spacing-md) max(var(--spacing-xl), var(--window-chrome-safe-left));
-  background: var(--color-bg);
-  /* No border - let content flow */
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--duration-fast) ease;
+}
+
+.stream-header--scrolled {
+  border-bottom-color: var(--border-subtle);
 }
 
 .stream-header h1 {
   font-size: var(--font-size-md);
+  line-height: var(--type-ui-line-height);
   font-weight: 500;
-  line-height: var(--line-height-tight);
   color: var(--color-text);
   flex: 1 1 auto;
   min-width: 0;
@@ -449,7 +476,7 @@ body {
 }
 
 .stream-title-editable:hover {
-  background: var(--color-surface);
+  color: var(--text);
 }
 
 .stream-title-input {
@@ -486,11 +513,12 @@ body {
   align-items: center;
   justify-content: center;
   background: transparent;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
+  border: 0;
+  color: var(--text-muted);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
+  line-height: var(--type-ui-line-height);
   cursor: pointer;
   white-space: nowrap;
   transition: all var(--duration-fast) ease;
@@ -516,9 +544,8 @@ body {
 .stream-sources-button:hover,
 .stream-xray-button:hover,
 .stream-xray-button--active {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--accent-soft);
+  color: var(--text);
+  background: transparent;
 }
 
 .stream-overflow-menu {
@@ -715,7 +742,7 @@ body {
 .ai-prompt-source-scope {
   margin-right: auto;
   background: transparent;
-  border: 1px solid var(--border-subtle);
+  border: 0;
   color: var(--text-muted);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
@@ -726,15 +753,14 @@ body {
 }
 
 .ai-prompt-source-scope:hover {
-  border-color: var(--color-border);
   background: var(--surface-hover);
-  color: var(--color-text-secondary);
+  color: var(--text);
 }
 
 .ai-prompt-cancel {
   background: transparent;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
+  border: 0;
+  color: var(--text-muted);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -742,8 +768,8 @@ body {
 }
 
 .ai-prompt-cancel:hover {
-  border-color: var(--color-text-tertiary);
-  color: var(--color-text);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .ai-prompt-send {
@@ -770,8 +796,8 @@ body {
 
 .delete-confirm-cancel {
   background: transparent;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
+  border: 0;
+  color: var(--text-muted);
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -781,8 +807,8 @@ body {
 }
 
 .delete-confirm-cancel:hover {
-  background: var(--color-bg-secondary);
-  border-color: var(--color-text-tertiary);
+  background: var(--surface-hover);
+  color: var(--text);
 }
 
 .delete-confirm-delete {
@@ -834,7 +860,7 @@ body {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: var(--spacing-md) clamp(20px, 5.8vw, 88px) calc(var(--spacing-xxl) + var(--stream-end-scroll-space));
+  padding: 0;
 }
 
 .stream-footer {
@@ -849,7 +875,7 @@ body {
   display: inline-flex;
   align-items: center;
   background: transparent;
-  border: 1px solid transparent;
+  border: 0;
   color: var(--color-text-tertiary);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
@@ -860,13 +886,12 @@ body {
 }
 
 .stream-footer-toggle:hover {
-  border-color: var(--color-border);
-  color: var(--color-text-secondary);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .stream-footer-toggle--active,
 .stream-footer-toggle--active:hover {
-  border-color: var(--color-accent);
   color: var(--color-accent);
   background: var(--accent-soft);
 }
@@ -877,6 +902,8 @@ body {
   color: var(--color-text-tertiary);
   min-width: 0;
   text-align: right;
+  line-height: var(--type-ui-line-height);
+  transition: opacity 800ms ease;
 }
 
 .stream-save-status-dot {
@@ -885,6 +912,10 @@ body {
 
 .stream-save-status--saving {
   color: var(--color-text-secondary);
+}
+
+.stream-save-status--settled {
+  opacity: 0;
 }
 
 .stream-save-status--error {
@@ -1169,13 +1200,13 @@ body {
 .document-editor-codemirror .cm-scroller {
   font-family: var(--editor-font-family);
   min-height: inherit;
-  padding: clamp(var(--space-6), 4.6vw, var(--space-8)) clamp(var(--space-5), 4.6vw, var(--space-8)) clamp(220px, 30vh, 360px);
+  padding: 96px clamp(var(--space-5), 4.6vw, var(--space-8)) clamp(220px, 30vh, 360px);
   overflow-x: hidden;
   overflow-y: visible;
 }
 
 .document-editor-codemirror .cm-content {
-  max-width: 68ch;
+  max-width: 64ch;
   min-height: inherit;
   margin: 0 auto;
   caret-color: var(--text);
@@ -1288,18 +1319,21 @@ body {
 
 .document-editor-codemirror .cm-md-heading-1 {
   font-size: var(--editor-heading-1);
-  font-weight: 650;
+  line-height: 32px;
+  font-weight: 600;
   letter-spacing: -0.015em;
 }
 
 .document-editor-codemirror .cm-md-heading-2 {
   font-size: var(--editor-heading-2);
+  line-height: 28px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .document-editor-codemirror .cm-md-heading-3 {
   font-size: var(--editor-heading-3);
+  line-height: 28px;
   font-weight: 600;
 }
 
@@ -1329,7 +1363,6 @@ body {
 
 .document-editor-codemirror .cm-codeblock-line {
   background: var(--surface);
-  box-shadow: inset 0 0 0 1px var(--border-subtle);
 }
 
 .document-editor-codemirror .cm-arrived {
@@ -1370,7 +1403,7 @@ body {
   }
 }
 
-.document-ai-status-pill {
+.document-ai-status {
   position: fixed;
   left: var(--space-5);
   bottom: var(--space-5);
@@ -1392,7 +1425,7 @@ body {
   animation: ai-status-enter var(--duration-fast) ease-out;
 }
 
-.document-ai-status-pill--error {
+.document-ai-status--error {
   color: var(--danger);
   border-color: var(--danger-border);
   background: var(--surface-raised);
@@ -1407,7 +1440,7 @@ body {
   animation: ai-status-pulse 0.9s ease-in-out infinite;
 }
 
-.document-ai-status-pill--error .document-ai-status-dot {
+.document-ai-status--error .document-ai-status-dot {
   animation: none;
 }
 
@@ -1681,6 +1714,10 @@ body {
   pointer-events: auto;
 }
 
+.cm-margin-note-card {
+  box-shadow: none;
+}
+
 .cm-margin-note-popover {
   width: min(260px, calc(100vw - var(--space-6)));
 }
@@ -1856,8 +1893,8 @@ body {
   margin: var(--spacing-md) var(--spacing-lg) 0;
   align-self: flex-start;
   background: transparent;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
+  border: 0;
+  color: var(--text-muted);
   padding: var(--spacing-xs) var(--spacing-md);
   border-radius: var(--radius);
   cursor: pointer;
@@ -1866,9 +1903,8 @@ body {
 }
 
 .sources-modal-add:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--accent-soft);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .sources-modal-list {
@@ -1985,7 +2021,7 @@ body {
   gap: var(--spacing-sm);
   min-height: var(--space-4);
   font-size: var(--font-size-xs);
-  line-height: var(--line-height-tight);
+  line-height: var(--type-ui-line-height);
   color: var(--text-muted);
 }
 
@@ -2008,7 +2044,7 @@ body {
 }
 
 .sources-modal-private-toggle {
-  border: 1px solid var(--color-border);
+  border: 0;
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
@@ -2021,21 +2057,19 @@ body {
 
 .sources-modal-private-toggle:hover,
 .sources-modal-private-toggle:focus-visible {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .sources-modal-private-toggle--active {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--on-accent);
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .sources-modal-private-toggle--active:hover,
 .sources-modal-private-toggle--active:focus-visible {
-  background: var(--color-accent-hover);
-  color: var(--on-accent);
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .sources-modal-remove {
@@ -2125,8 +2159,6 @@ body {
   font-size: var(--font-size-xs);
   font-weight: 500;
   color: var(--color-text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
   padding: var(--spacing-sm) var(--spacing-lg);
 }
 
@@ -2267,19 +2299,18 @@ body {
 .search-modal-go-button {
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-text);
-  color: var(--color-bg);
+  background: var(--accent);
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: box-shadow var(--duration-fast) ease, transform var(--duration-fast) ease;
+  transition: background-color var(--duration-fast) ease;
 }
 
 .search-modal-go-button:hover {
-  box-shadow: var(--control-shadow);
-  transform: translateY(-1px);
+  background: var(--accent-hover);
 }
 
 /* ==================== Exchange Overlay ==================== */
@@ -2306,8 +2337,6 @@ body {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 
 .exchange-block pre {
@@ -2376,8 +2405,8 @@ body {
 }
 
 .settings-close {
-  background: var(--color-text);
-  color: var(--color-bg);
+  background: transparent;
+  color: var(--text-muted);
   border: none;
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: var(--radius-md);
@@ -2388,8 +2417,8 @@ body {
 }
 
 .settings-close:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--control-shadow);
+  color: var(--text);
+  background: var(--surface-hover);
 }
 
 .settings-content {
@@ -2408,8 +2437,6 @@ body {
   font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
   margin: 0;
 }
 
@@ -2450,7 +2477,7 @@ body {
 .settings-toggle-visibility,
 .settings-save-key {
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--color-border);
+  border: 0;
   border-radius: var(--radius-md);
   background: var(--color-bg);
   color: var(--color-text-secondary);
@@ -2461,41 +2488,22 @@ body {
 
 .settings-toggle-visibility:hover,
 .settings-save-key:hover:not(:disabled) {
-  border-color: var(--color-text-tertiary);
   color: var(--color-text);
+  background: var(--surface-hover);
 }
 
 .settings-save-key {
-  background: var(--color-text);
-  color: var(--color-bg);
-  border-color: var(--color-text);
+  background: var(--accent);
+  color: var(--on-accent);
 }
 
 .settings-save-key:hover:not(:disabled) {
-  background: var(--color-text);
-  border-color: var(--color-text);
-  transform: translateY(-1px);
+  background: var(--accent-hover);
 }
 
 .settings-save-key:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-}
-
-.settings-delete-key {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--danger-border);
-  border-radius: var(--radius-md);
-  background: var(--danger-soft);
-  color: var(--color-error);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  transition: all var(--duration-fast) ease;
-}
-
-.settings-delete-key:hover {
-  background: var(--danger-hover);
-  border-color: var(--color-error);
 }
 
 .settings-hint {
@@ -2556,7 +2564,7 @@ body {
 
 .settings-disconnect-btn {
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--color-border);
+  border: 0;
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--color-text-secondary);
@@ -2567,7 +2575,6 @@ body {
 }
 
 .settings-disconnect-btn:hover {
-  border-color: var(--color-error);
   color: var(--color-error);
   background: var(--danger-soft);
 }
@@ -2813,19 +2820,18 @@ body {
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: transparent;
+  border: 0;
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-fast) ease;
 }
 
 .settings-editor-font-btn:hover {
-  border-color: var(--color-text-tertiary);
+  background: var(--surface-hover);
 }
 
 .settings-editor-font-btn--active {
-  border-color: var(--color-accent);
   background: var(--color-accent-soft);
 }
 
@@ -2880,9 +2886,8 @@ body {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  border: none;
+  border: 1px solid var(--border);
   background: var(--color-accent);
-  box-shadow: 0 0 0 1px var(--border);
 }
 
 .settings-editor-slider::-moz-range-track {
@@ -2894,10 +2899,9 @@ body {
 .settings-editor-slider::-moz-range-thumb {
   width: 14px;
   height: 14px;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: 50%;
   background: var(--color-accent);
-  box-shadow: 0 0 0 1px var(--border);
 }
 
 .settings-editor-preview {
@@ -2927,8 +2931,8 @@ body {
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: transparent;
+  border: 0;
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: var(--font-size-sm);
@@ -2937,18 +2941,17 @@ body {
 }
 
 .settings-appearance-btn:hover {
-  border-color: var(--color-text-tertiary);
+  background: var(--surface-hover);
   color: var(--color-text);
 }
 
 .settings-appearance-btn--active {
-  border-color: var(--color-accent);
   background: var(--color-accent-soft);
   color: var(--color-accent);
 }
 
 .settings-appearance-btn--active:hover {
-  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 /* Model selection buttons */
@@ -2964,15 +2967,15 @@ body {
   align-items: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-md);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: transparent;
+  border: 0;
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-fast) ease;
 }
 
 .settings-model-btn:hover:not(:disabled) {
-  border-color: var(--color-text-tertiary);
+  background: var(--surface-hover);
 }
 
 .settings-model-btn:disabled {
@@ -2981,12 +2984,11 @@ body {
 }
 
 .settings-model-btn--active {
-  border-color: var(--color-accent);
   background: var(--color-accent-soft);
 }
 
 .settings-model-btn--active:hover {
-  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .settings-model-name {
@@ -3023,7 +3025,7 @@ body {
 .settings-feedback-type button {
   flex: 1;
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--color-border);
+  border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-secondary);
@@ -3033,13 +3035,12 @@ body {
 }
 
 .settings-feedback-type button:hover {
-  border-color: var(--color-accent);
   color: var(--color-text);
+  background: var(--surface-hover);
 }
 
 .settings-feedback-type button.active {
   background: var(--color-accent-soft);
-  border-color: var(--color-accent);
   color: var(--color-accent);
 }
 
@@ -3129,20 +3130,18 @@ body {
 
 .settings-feedback-submit {
   padding: var(--spacing-sm) var(--spacing-lg);
-  background: var(--color-text);
-  color: var(--color-bg);
+  background: var(--accent);
+  color: var(--on-accent);
   border: none;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: opacity var(--duration-fast) ease, box-shadow var(--duration-fast) ease, transform var(--duration-fast) ease;
+  transition: opacity var(--duration-fast) ease, background-color var(--duration-fast) ease;
 }
 
 .settings-feedback-submit:hover:not(:disabled) {
-  opacity: 0.9;
-  box-shadow: var(--control-shadow);
-  transform: translateY(-1px);
+  background: var(--accent-hover);
 }
 
 .settings-feedback-submit:disabled {
@@ -3165,9 +3164,9 @@ body {
 
 .settings-support-bundle-btn {
   padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--text-muted);
+  border: 0;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   cursor: pointer;
@@ -3176,7 +3175,7 @@ body {
 
 .settings-support-bundle-btn:hover {
   background: var(--color-surface-hover);
-  border-color: var(--color-accent);
+  color: var(--text);
 }
 
 @media (max-width: 480px) {
@@ -3292,9 +3291,6 @@ body {
     --overlay-shadow: 0 16px 44px rgba(0, 0, 0, 0.32);
   }
 
-  .settings-appearance-btn {
-    background: var(--color-surface);
-  }
 }
 
 /* ==================== AI Activity ==================== */
@@ -3356,7 +3352,7 @@ body {
   flex: 1;
   min-width: 0;
   flex-direction: column;
-  line-height: var(--line-height-tight);
+  line-height: var(--type-ui-line-height);
 }
 
 .ai-activity-label {
@@ -3410,7 +3406,7 @@ body {
 
 /* ==================== Toasts ==================== */
 
-/* Toasts share the document-ai-status-pill idiom: quiet pill, kind-colored dot. */
+/* Toasts share the floating status idiom: quiet copy with a kind-colored dot. */
 .toast-stack {
   position: fixed;
   left: 50%;

--- a/Web/src/utils/editorTypography.ts
+++ b/Web/src/utils/editorTypography.ts
@@ -10,8 +10,8 @@ export interface EditorTypographySettings {
 
 export const DEFAULT_EDITOR_TYPOGRAPHY: EditorTypographySettings = {
   editorFont: 'systemSans',
-  editorFontSize: 16,
-  editorLineSpacing: 1.55,
+  editorFontSize: 17,
+  editorLineSpacing: 1.65,
 };
 
 export function editorFontStack(font: EditorFont): string {


### PR DESCRIPTION
Phase C1 of `docs/CONVERSATIONS_PLAN.md` §6 — typography-first chrome: body 17/28 at 64ch, em-scaled headings, transparent headers with scroll-hairline, transient Saving…, typographic stream-list rows, two button tiers (bordered pills deleted globally), shadows confined to floating overlays, dark parity via existing tokens.

Includes review fix round (`5dba044`): de-stickied list header, font-size-scalable headings, hover/line-height token corrections, dead CSS removal.

**Gates (independent):** typecheck ✓ · 556/556 web tests ✓ · prod build ✓ · contract checker ✓ · no Swift/bridge changes.
**Review (Opus): pass-with-notes** — all notes fixed or explicitly accepted (>7d relative-time buckets kept; dormant legacy CodeMirror path left untouched, slated for deletion).
**Visual pass pending:** Niko eyeballs light+dark on merge review (Codex cannot screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)