### PR TITLE
C2: conversation anchors (v30 + position-mapped sidecar ranges)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: add durable conversation anchors and passive gutter markers (phase C2)
 - editor: adopt the inline-conversation design language (phase C1)
 - editor: replace the thread drawer prototype with inline conversations (phase C0: drawer removed)
 - Quick Window now names the save destination and chat persistence in its footer, confirms saves during dismissal, and closes without discarding a draft.

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -65,6 +65,21 @@ enum StreamCodec {
         }
     }
 
+    static func encodeConversationAnchors(_ anchors: [ConversationAnchor]) -> [[String: Any]] {
+        let formatter = ISO8601DateFormatter()
+        return anchors.map { anchor in
+            [
+                "threadId": anchor.threadId.uuidString,
+                "anchorStart": anchor.anchorStart.map { $0 as Any } ?? NSNull(),
+                "anchorEnd": anchor.anchorEnd.map { $0 as Any } ?? NSNull(),
+                "anchorText": anchor.anchorText,
+                "detached": anchor.detached,
+                "ephemeral": anchor.ephemeral,
+                "updatedAt": formatter.string(from: anchor.updatedAt)
+            ]
+        }
+    }
+
     static func encodeMarginNotes(_ notes: [MarginNote]) -> [[String: Any]] {
         let formatter = ISO8601DateFormatter()
         return notes.map { note in

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -99,6 +99,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     "sourceScope": AnyCodable(stream.sourceScope.rawValue),
                     "scrollOffset": AnyCodable(document.scrollOffset),
                     "spans": AnyCodable(StreamCodec.encodeSpans([])),
+                    "conversationAnchors": AnyCodable([]),
                     "pendingAppends": AnyCodable(StreamCodec.encodePendingAppends([])),
                     "appendInbox": AnyCodable(StreamCodec.encodeAppendInbox([])),
                     "marginNotes": AnyCodable([])
@@ -168,15 +169,19 @@ final class StreamMessageHandler: BridgeMessageHandler {
                 return
             }
             let canonicalDocument: (json: String, version: Int)?
+            let anchorUpdates: [ConversationAnchorUpdate]?
             if message.type == "saveRichStreamDocument" {
                 guard let docJSON = payload["docJSON"]?.value as? String,
-                      let docFormatVersion = payload["docFormatVersion"]?.intValue else {
+                      let docFormatVersion = payload["docFormatVersion"]?.intValue,
+                      let conversationAnchors = decodeConversationAnchors(payload["conversationAnchors"]?.value) else {
                     await bridgeService.respondWithError(to: callbackId, error: "Invalid saveRichStreamDocument payload")
                     return
                 }
                 canonicalDocument = (docJSON, docFormatVersion)
+                anchorUpdates = conversationAnchors
             } else {
                 canonicalDocument = nil
+                anchorUpdates = nil
             }
             do {
                 let revision: Int
@@ -188,6 +193,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                         markdown: markdown,
                         baseRevision: baseRevision,
                         spans: spans,
+                        conversationAnchors: anchorUpdates ?? [],
                         resolvedPendingThrough: payload["resolvedPendingThrough"]?.intValue,
                         consumedInboxThrough: payload["consumedInboxThrough"]?.intValue
                     )
@@ -216,6 +222,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
                     "markdown": AnyCodable(conflict.markdown),
                     "revision": AnyCodable(conflict.revision),
                     "spans": AnyCodable(StreamCodec.encodeSpans(conflict.spans)),
+                    "conversationAnchors": AnyCodable(StreamCodec.encodeConversationAnchors(conflict.conversationAnchors)),
                     "pendingAppends": AnyCodable(pendingAppends),
                     "appendInbox": AnyCodable(appendInbox)
                 ]
@@ -339,6 +346,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
         let snapshot = try persistence.loadEditorSnapshot(streamId: id)
         let document = snapshot.document
         let spans = snapshot.spans
+        let conversationAnchors = snapshot.conversationAnchors
         let pendingAppends = snapshot.pendingAppends
         let appendInbox = snapshot.appendInbox
         let marginNotes = try persistence.loadMarginNotes(streamId: id)
@@ -348,6 +356,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
             "sourceScope": AnyCodable(stream.sourceScope.rawValue),
             "scrollOffset": AnyCodable(document.scrollOffset),
             "spans": AnyCodable(StreamCodec.encodeSpans(spans)),
+            "conversationAnchors": AnyCodable(StreamCodec.encodeConversationAnchors(conversationAnchors)),
             "marginNotes": AnyCodable(StreamCodec.encodeMarginNotes(marginNotes)),
             "pendingAppends": AnyCodable(StreamCodec.encodePendingAppends(pendingAppends)),
             "appendInbox": AnyCodable(StreamCodec.encodeAppendInbox(appendInbox))
@@ -402,6 +411,25 @@ final class StreamMessageHandler: BridgeMessageHandler {
             DebugLog.log("[StreamMessageHandler] Dropped \(dropped) malformed provenance span(s)")
         }
         return spans
+    }
+
+    private func decodeConversationAnchors(_ value: Any?) -> [ConversationAnchorUpdate]? {
+        guard let items = value as? [[String: Any]] else { return nil }
+        var anchors: [ConversationAnchorUpdate] = []
+        for item in items {
+            guard let rawThreadId = item["threadId"] as? String,
+                  let threadId = UUID(uuidString: rawThreadId),
+                  let anchorStart = intValue(item["anchorStart"]),
+                  let anchorEnd = intValue(item["anchorEnd"]),
+                  let detached = item["detached"] as? Bool else { return nil }
+            anchors.append(ConversationAnchorUpdate(
+                threadId: threadId,
+                anchorStart: anchorStart,
+                anchorEnd: anchorEnd,
+                detached: detached
+            ))
+        }
+        return anchors
     }
 
     private func intValue(_ value: Any?) -> Int? {

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -36,6 +36,7 @@ final class ThreadMessageHandler: BridgeMessageHandler {
         }
         switch message.type {
         case "listConversations":
+            // ponytail: no caller until C3 wires the conversation surface.
             guard let streamId = decodeUUID(message.payload, key: "streamId") else {
                 respondWithError(callbackId, "Invalid listConversations payload")
                 return

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 final class ThreadMessageHandler: BridgeMessageHandler {
-    let handledTypes: Set<String> = ["saveStreamThread"]
+    let handledTypes: Set<String> = ["listConversations", "saveStreamThread"]
 
     private let persistence: PersistenceService
     private let sendToWeb: (BridgeMessage) -> Void
@@ -34,45 +34,64 @@ final class ThreadMessageHandler: BridgeMessageHandler {
             sendBridgeError(message.type, "Missing callbackId for \(message.type)")
             return
         }
-        guard message.type == "saveStreamThread",
-              let payload = message.payload,
-              let streamId = decodeUUID(payload, key: "streamId"),
-              let threadId = decodeUUID(payload, key: "threadId"),
-              let title = payload["title"]?.value as? String,
-              let baseRevision = payload["baseRevision"]?.intValue,
-              baseRevision >= 0 else {
-            respondWithError(callbackId, "Invalid saveStreamThread payload")
-            return
-        }
+        switch message.type {
+        case "listConversations":
+            guard let streamId = decodeUUID(message.payload, key: "streamId") else {
+                respondWithError(callbackId, "Invalid listConversations payload")
+                return
+            }
+            do {
+                respond(callbackId, [
+                    "conversations": AnyCodable(StreamCodec.encodeConversationAnchors(
+                        try persistence.loadConversationAnchors(streamId: streamId)
+                    ))
+                ])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
 
-        do {
-            let thread = try persistence.saveStreamThread(
-                threadId: threadId,
-                streamId: streamId,
-                title: title,
-                baseRevision: baseRevision
-            )
-            respond(callbackId, [
-                "conflict": AnyCodable(false),
-                "thread": AnyCodable(StreamCodec.encodeThread(
-                    thread,
-                    source: nil,
-                    highlight: nil,
-                    exchanges: nil
-                ))
-            ])
-        } catch let conflict as StreamThreadRevisionConflict {
-            respond(callbackId, [
-                "conflict": AnyCodable(true),
-                "thread": AnyCodable(StreamCodec.encodeThread(
-                    conflict.current,
-                    source: nil,
-                    highlight: nil,
-                    exchanges: nil
-                ))
-            ])
-        } catch {
-            respondWithError(callbackId, error.localizedDescription)
+        case "saveStreamThread":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let threadId = decodeUUID(payload, key: "threadId"),
+                  let title = payload["title"]?.value as? String,
+                  let baseRevision = payload["baseRevision"]?.intValue,
+                  baseRevision >= 0 else {
+                respondWithError(callbackId, "Invalid saveStreamThread payload")
+                return
+            }
+            do {
+                let thread = try persistence.saveStreamThread(
+                    threadId: threadId,
+                    streamId: streamId,
+                    title: title,
+                    baseRevision: baseRevision
+                )
+                respond(callbackId, [
+                    "conflict": AnyCodable(false),
+                    "thread": AnyCodable(StreamCodec.encodeThread(
+                        thread,
+                        source: nil,
+                        highlight: nil,
+                        exchanges: nil
+                    ))
+                ])
+            } catch let conflict as StreamThreadRevisionConflict {
+                respond(callbackId, [
+                    "conflict": AnyCodable(true),
+                    "thread": AnyCodable(StreamCodec.encodeThread(
+                        conflict.current,
+                        source: nil,
+                        highlight: nil,
+                        exchanges: nil
+                    ))
+                ])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
+        default:
+            sendBridgeError(message.type, "Unsupported thread message")
         }
     }
 

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -290,6 +290,7 @@ final class WebViewManager: NSObject {
                 "sourceScope": AnyCodable(reloadedStream.sourceScope.rawValue),
                 "scrollOffset": AnyCodable(document.scrollOffset),
                 "spans": AnyCodable(StreamCodec.encodeSpans(snapshot.spans)),
+                "conversationAnchors": AnyCodable(StreamCodec.encodeConversationAnchors(snapshot.conversationAnchors)),
                 "pendingAppends": AnyCodable(StreamCodec.encodePendingAppends(snapshot.pendingAppends)),
                 "appendInbox": AnyCodable(StreamCodec.encodeAppendInbox(snapshot.appendInbox)),
                 "marginNotes": AnyCodable(StreamCodec.encodeMarginNotes(marginNotes))

--- a/Sources/Ticker/Models/StreamThread.swift
+++ b/Sources/Ticker/Models/StreamThread.swift
@@ -49,6 +49,10 @@ struct StreamThread: Codable, Equatable, Identifiable {
     let anchorSpanId: String?
     let sourceId: UUID?
     let highlightId: UUID?
+    let anchorStart: Int?
+    let anchorEnd: Int?
+    let detached: Bool
+    let ephemeral: Bool
     let revision: Int
     let createdAt: Date
     let updatedAt: Date
@@ -66,6 +70,10 @@ struct StreamThread: Codable, Equatable, Identifiable {
         anchorSpanId: String? = nil,
         sourceId: UUID? = nil,
         highlightId: UUID? = nil,
+        anchorStart: Int? = nil,
+        anchorEnd: Int? = nil,
+        detached: Bool = false,
+        ephemeral: Bool = false,
         revision: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -80,10 +88,31 @@ struct StreamThread: Codable, Equatable, Identifiable {
         self.anchorSpanId = anchorSpanId
         self.sourceId = sourceId
         self.highlightId = highlightId
+        self.anchorStart = anchorStart
+        self.anchorEnd = anchorEnd
+        self.detached = detached
+        self.ephemeral = ephemeral
         self.revision = revision
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
+}
+
+struct ConversationAnchor: Codable, Equatable {
+    let threadId: UUID
+    let anchorStart: Int?
+    let anchorEnd: Int?
+    let anchorText: String
+    let detached: Bool
+    let ephemeral: Bool
+    let updatedAt: Date
+}
+
+struct ConversationAnchorUpdate: Codable, Equatable {
+    let threadId: UUID
+    let anchorStart: Int
+    let anchorEnd: Int
+    let detached: Bool
 }
 
 struct StreamThreadRevisionConflict: Error {

--- a/Sources/Ticker/Models/StreamThread.swift
+++ b/Sources/Ticker/Models/StreamThread.swift
@@ -49,6 +49,7 @@ struct StreamThread: Codable, Equatable, Identifiable {
     let anchorSpanId: String?
     let sourceId: UUID?
     let highlightId: UUID?
+    // ProseMirror doc positions (opaque to Swift).
     let anchorStart: Int?
     let anchorEnd: Int?
     let detached: Bool
@@ -100,6 +101,7 @@ struct StreamThread: Codable, Equatable, Identifiable {
 
 struct ConversationAnchor: Codable, Equatable {
     let threadId: UUID
+    // ProseMirror doc positions (opaque to Swift).
     let anchorStart: Int?
     let anchorEnd: Int?
     let anchorText: String
@@ -110,6 +112,7 @@ struct ConversationAnchor: Codable, Equatable {
 
 struct ConversationAnchorUpdate: Codable, Equatable {
     let threadId: UUID
+    // ProseMirror doc positions (opaque to Swift).
     let anchorStart: Int
     let anchorEnd: Int
     let detached: Bool

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -1242,6 +1242,7 @@ final class PersistenceService {
         )
     }
 
+    // ponytail: nil/partial anchor updates preserve omitted rows; delete this legacy-save landmine with StreamEditor.
     @discardableResult
     private func saveStreamDocument(
         streamId: UUID,
@@ -2119,8 +2120,10 @@ final class PersistenceService {
                     streamId.uuidString
                 ]
             )
-            guard db.changesCount == 1 else {
-                throw StreamThreadPersistenceError.threadNotFound
+            if db.changesCount != 1 {
+                DebugLog.log(
+                    "[Persistence] Skipped missing conversation anchor \(anchor.threadId) for stream \(streamId)"
+                )
             }
         }
     }

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -46,6 +46,7 @@ struct StreamDocumentRevisionConflict: Error {
     let markdown: String
     let revision: Int
     let spans: [ProvenanceSpan]
+    let conversationAnchors: [ConversationAnchor]
     let pendingAppends: [PendingStreamAppend]
     let appendInbox: [StreamAppendInboxEntry]
 }
@@ -721,6 +722,16 @@ final class PersistenceService {
             """)
         }
 
+        migrator.registerMigration("v30_conversation_anchors") { db in
+            try db.execute(sql: """
+                ALTER TABLE stream_threads ADD COLUMN anchor_start INTEGER;
+                ALTER TABLE stream_threads ADD COLUMN anchor_end   INTEGER;
+                ALTER TABLE stream_threads ADD COLUMN detached     INTEGER NOT NULL DEFAULT 0;
+                ALTER TABLE stream_threads ADD COLUMN ephemeral    INTEGER NOT NULL DEFAULT 0;
+                UPDATE stream_threads SET detached = 1;
+            """)
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -1208,6 +1219,7 @@ final class PersistenceService {
         markdown: String,
         baseRevision: Int,
         spans: [ProvenanceSpan],
+        conversationAnchors: [ConversationAnchorUpdate] = [],
         resolvedPendingThrough: Int? = nil,
         consumedInboxThrough: Int? = nil
     ) throws -> Int {
@@ -1221,6 +1233,7 @@ final class PersistenceService {
             markdown: markdown,
             baseRevision: baseRevision,
             spans: Optional(spans),
+            conversationAnchors: conversationAnchors,
             resolvedPendingThrough: resolvedPendingThrough,
             consumedInboxThrough: consumedInboxThrough,
             canonicalDocument: (docJSON, docFormatVersion)
@@ -1233,6 +1246,7 @@ final class PersistenceService {
         markdown: String,
         baseRevision: Int,
         spans: [ProvenanceSpan]?,
+        conversationAnchors: [ConversationAnchorUpdate]? = nil,
         resolvedPendingThrough: Int? = nil,
         consumedInboxThrough: Int? = nil,
         canonicalDocument: (json: String, version: Int)? = nil
@@ -1257,6 +1271,7 @@ final class PersistenceService {
                         markdown: currentMarkdown,
                         revision: currentRevision,
                         spans: try fetchSpans(streamId: streamId, db: db),
+                        conversationAnchors: try fetchConversationAnchors(streamId: streamId, db: db),
                         pendingAppends: try fetchPendingAppends(streamId: streamId, db: db),
                         appendInbox: try fetchAppendInbox(streamId: streamId, db: db)
                     )
@@ -1322,6 +1337,13 @@ final class PersistenceService {
                     )
                     try deleteOrphanExchanges(streamId: streamId, db: db)
                 }
+                if let conversationAnchors {
+                    try updateConversationAnchors(
+                        streamId: streamId,
+                        anchors: conversationAnchors,
+                        db: db
+                    )
+                }
 
                 return newRevision
             }
@@ -1334,6 +1356,7 @@ final class PersistenceService {
                     markdown: "",
                     revision: 0,
                     spans: [],
+                    conversationAnchors: [],
                     pendingAppends: try fetchPendingAppends(streamId: streamId, db: db),
                     appendInbox: try fetchAppendInbox(streamId: streamId, db: db)
                 )
@@ -1394,6 +1417,13 @@ final class PersistenceService {
                     db: db
                 )
                 try deleteOrphanExchanges(streamId: streamId, db: db)
+            }
+            if let conversationAnchors {
+                try updateConversationAnchors(
+                    streamId: streamId,
+                    anchors: conversationAnchors,
+                    db: db
+                )
             }
 
             return newRevision
@@ -1630,8 +1660,9 @@ final class PersistenceService {
                     INSERT INTO stream_threads
                         (thread_id, stream_id, title, working_text, doc_json, doc_format_version,
                          anchor_text, anchor_span_id, source_id, highlight_id,
+                         anchor_start, anchor_end, detached, ephemeral,
                          revision, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 arguments: [
                     thread.threadId.uuidString,
@@ -1644,6 +1675,10 @@ final class PersistenceService {
                     thread.anchorSpanId,
                     thread.sourceId?.uuidString,
                     thread.highlightId?.uuidString,
+                    thread.anchorStart,
+                    thread.anchorEnd,
+                    thread.detached,
+                    thread.ephemeral,
                     thread.revision,
                     thread.createdAt.timeIntervalSince1970,
                     thread.updatedAt.timeIntervalSince1970
@@ -1669,7 +1704,7 @@ final class PersistenceService {
                 sql: """
                     SELECT thread_id, stream_id, title, working_text, anchor_text, anchor_span_id,
                            source_id, highlight_id, revision, created_at, updated_at,
-                           doc_json, doc_format_version
+                           doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral
                     FROM stream_threads
                     WHERE stream_id = ?
                     ORDER BY updated_at DESC, thread_id
@@ -1682,6 +1717,12 @@ final class PersistenceService {
     func loadStreamThread(threadId: UUID, streamId: UUID) throws -> StreamThread? {
         try dbQueue.read { db in
             try fetchStreamThread(threadId: threadId, streamId: streamId, db: db)
+        }
+    }
+
+    func loadConversationAnchors(streamId: UUID) throws -> [ConversationAnchor] {
+        try dbQueue.read { db in
+            try fetchConversationAnchors(streamId: streamId, db: db)
         }
     }
 
@@ -2015,12 +2056,71 @@ final class PersistenceService {
             sql: """
                 SELECT thread_id, stream_id, title, working_text, anchor_text, anchor_span_id,
                        source_id, highlight_id, revision, created_at, updated_at,
-                       doc_json, doc_format_version
+                       doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral
                 FROM stream_threads
                 WHERE thread_id = ? AND stream_id = ?
             """,
             arguments: [threadId.uuidString, streamId.uuidString]
         ).flatMap(Self.decodeStreamThread)
+    }
+
+    private func fetchConversationAnchors(streamId: UUID, db: Database) throws -> [ConversationAnchor] {
+        try Row.fetchAll(
+            db,
+            sql: """
+                SELECT thread_id, anchor_start, anchor_end, anchor_text,
+                       detached, ephemeral, updated_at
+                FROM stream_threads
+                WHERE stream_id = ?
+                ORDER BY updated_at DESC, thread_id
+            """,
+            arguments: [streamId.uuidString]
+        ).compactMap { row in
+            guard let threadId = UUID(uuidString: row["thread_id"]) else { return nil }
+            return ConversationAnchor(
+                threadId: threadId,
+                anchorStart: row["anchor_start"],
+                anchorEnd: row["anchor_end"],
+                anchorText: row["anchor_text"],
+                detached: row["detached"],
+                ephemeral: row["ephemeral"],
+                updatedAt: Date(timeIntervalSince1970: row["updated_at"])
+            )
+        }
+    }
+
+    private func updateConversationAnchors(
+        streamId: UUID,
+        anchors: [ConversationAnchorUpdate],
+        db: Database
+    ) throws {
+        guard Set(anchors.map(\.threadId)).count == anchors.count else {
+            throw StreamThreadPersistenceError.invalidAnchor
+        }
+        for anchor in anchors {
+            guard anchor.anchorStart >= 0,
+                  anchor.anchorEnd >= anchor.anchorStart,
+                  anchor.detached || anchor.anchorEnd > anchor.anchorStart else {
+                throw StreamThreadPersistenceError.invalidAnchor
+            }
+            try db.execute(
+                sql: """
+                    UPDATE stream_threads
+                    SET anchor_start = ?, anchor_end = ?, detached = ?
+                    WHERE thread_id = ? AND stream_id = ?
+                """,
+                arguments: [
+                    anchor.anchorStart,
+                    anchor.anchorEnd,
+                    anchor.detached,
+                    anchor.threadId.uuidString,
+                    streamId.uuidString
+                ]
+            )
+            guard db.changesCount == 1 else {
+                throw StreamThreadPersistenceError.threadNotFound
+            }
+        }
     }
 
     private static func decodeStreamThread(_ row: Row) -> StreamThread? {
@@ -2041,6 +2141,10 @@ final class PersistenceService {
             anchorSpanId: row["anchor_span_id"],
             sourceId: sourceIdRaw.flatMap(UUID.init(uuidString:)),
             highlightId: highlightIdRaw.flatMap(UUID.init(uuidString:)),
+            anchorStart: row["anchor_start"],
+            anchorEnd: row["anchor_end"],
+            detached: row["detached"],
+            ephemeral: row["ephemeral"],
             revision: row["revision"],
             createdAt: Date(timeIntervalSince1970: row["created_at"]),
             updatedAt: Date(timeIntervalSince1970: row["updated_at"])

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -35,6 +35,7 @@ enum ExternalAppendResult {
 struct EditorSnapshot {
     let document: StreamDocument
     let spans: [ProvenanceSpan]
+    let conversationAnchors: [ConversationAnchor]
     let pendingAppends: [PendingStreamAppend]
     let appendInbox: [StreamAppendInboxEntry]
 }
@@ -1113,6 +1114,7 @@ final class PersistenceService {
             EditorSnapshot(
                 document: try loadOrCreateStreamDocument(streamId: streamId, db: db),
                 spans: try fetchSpans(streamId: streamId, db: db),
+                conversationAnchors: try fetchConversationAnchors(streamId: streamId, db: db),
                 pendingAppends: try fetchPendingAppends(streamId: streamId, db: db),
                 appendInbox: try fetchAppendInbox(streamId: streamId, db: db)
             )

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1808,7 +1808,7 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
-    func test_v29MigrationCreatesSidenoteDocumentAndAnchorSchema() throws {
+    func test_v30MigrationCreatesConversationAnchorColumns() throws {
         try withTempPersistenceServiceAndURL { _, dbURL, _ in
             let dbQueue = try DatabaseQueue(path: dbURL.path)
             let columns = try dbQueue.read { db in
@@ -1837,7 +1837,7 @@ final class StreamDocumentTests: XCTestCase {
                 [
                     "thread_id", "stream_id", "title", "working_text", "anchor_text",
                     "anchor_span_id", "source_id", "highlight_id", "revision", "created_at", "updated_at",
-                    "doc_json", "doc_format_version"
+                    "doc_json", "doc_format_version", "anchor_start", "anchor_end", "detached", "ephemeral"
                 ]
             )
             XCTAssertEqual(
@@ -1853,6 +1853,97 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertTrue(indexes.contains("idx_stream_thread_anchors_span"))
             XCTAssertEqual(threadForeignKey?["table"] as String?, "stream_threads")
             XCTAssertEqual(threadForeignKey?["on_delete"] as String?, "SET NULL")
+        }
+    }
+
+    func test_v30MigrationDetachesPrototypeThreadRows() throws {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempDir) }
+        let dbURL = tempDir.appendingPathComponent("ticker.db")
+        var service: PersistenceService? = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+        let stream = Stream(title: "Prototype migration")
+        try service?.saveStream(stream)
+        let thread = StreamThread(streamId: stream.id, anchorText: "Prototype anchor")
+        try service?.createStreamThread(thread)
+        service = nil
+
+        var fixtureDB: DatabaseQueue? = try DatabaseQueue(path: dbURL.path)
+        try fixtureDB?.write { db in
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN ephemeral")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN detached")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_end")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_start")
+            try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v30_conversation_anchors'")
+        }
+        fixtureDB = nil
+
+        service = try PersistenceService(databaseURL: dbURL, fileManager: fileManager)
+        let migrated = try XCTUnwrap(service?.loadConversationAnchors(streamId: stream.id).first)
+        XCTAssertEqual(migrated.threadId, thread.threadId)
+        XCTAssertNil(migrated.anchorStart)
+        XCTAssertNil(migrated.anchorEnd)
+        XCTAssertTrue(migrated.detached)
+        XCTAssertFalse(migrated.ephemeral)
+    }
+
+    func test_conversationAnchorsRoundTripAtomicallyWithDocumentSaveUsingUTF16Offsets() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Anchor save")
+            try service.saveStream(stream)
+            let initial = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "🙂",
+                anchorStart: 1,
+                anchorEnd: 3,
+                ephemeral: true
+            )
+            try service.createStreamThread(thread)
+            let update = ConversationAnchorUpdate(
+                threadId: thread.threadId,
+                anchorStart: 1,
+                anchorEnd: 3,
+                detached: false
+            )
+
+            let revision = try service.saveStreamDocument(
+                streamId: stream.id,
+                docJSON: #"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a🙂b"}]}]}"#,
+                docFormatVersion: 1,
+                markdown: "a🙂b",
+                baseRevision: initial.revision,
+                spans: [],
+                conversationAnchors: [update]
+            )
+
+            let loaded = try XCTUnwrap(service.loadConversationAnchors(streamId: stream.id).first)
+            XCTAssertEqual(loaded.anchorStart, 1)
+            XCTAssertEqual(loaded.anchorEnd, 3)
+            XCTAssertEqual(UTF16Offsets.substring("a🙂b", start: 1, end: 3), "🙂")
+            XCTAssertFalse(loaded.detached)
+            XCTAssertTrue(loaded.ephemeral)
+
+            XCTAssertThrowsError(try service.saveStreamDocument(
+                streamId: stream.id,
+                docJSON: initial.docJSON,
+                docFormatVersion: initial.docFormatVersion,
+                markdown: "stale",
+                baseRevision: initial.revision,
+                spans: [],
+                conversationAnchors: [ConversationAnchorUpdate(
+                    threadId: thread.threadId,
+                    anchorStart: 0,
+                    anchorEnd: 0,
+                    detached: true
+                )]
+            )) { error in
+                let conflict = error as? StreamDocumentRevisionConflict
+                XCTAssertEqual(conflict?.revision, revision)
+                XCTAssertEqual(conflict?.conversationAnchors.first?.anchorStart, 1)
+            }
+            XCTAssertEqual(try service.loadConversationAnchors(streamId: stream.id).first?.anchorStart, 1)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1888,7 +1888,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertFalse(migrated.ephemeral)
     }
 
-    func test_conversationAnchorsRoundTripAtomicallyWithDocumentSaveUsingUTF16Offsets() throws {
+    func test_conversationAnchorProseMirrorPositionsRoundTripWithDocumentAndSkipMissingThread() throws {
         try withTempPersistenceService { service in
             let stream = Stream(title: "Anchor save")
             try service.saveStream(stream)
@@ -1901,29 +1901,42 @@ final class StreamDocumentTests: XCTestCase {
                 ephemeral: true
             )
             try service.createStreamThread(thread)
+            // These are ProseMirror positions; Swift must only round-trip them.
             let update = ConversationAnchorUpdate(
                 threadId: thread.threadId,
-                anchorStart: 1,
-                anchorEnd: 3,
+                anchorStart: 2,
+                anchorEnd: 4,
                 detached: false
             )
+            let missing = ConversationAnchorUpdate(
+                threadId: UUID(),
+                anchorStart: 8,
+                anchorEnd: 13,
+                detached: false
+            )
+            let docJSON = #"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a🙂b"}]}]}"#
 
             let revision = try service.saveStreamDocument(
                 streamId: stream.id,
-                docJSON: #"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a🙂b"}]}]}"#,
+                docJSON: docJSON,
                 docFormatVersion: 1,
                 markdown: "a🙂b",
                 baseRevision: initial.revision,
                 spans: [],
-                conversationAnchors: [update]
+                conversationAnchors: [missing, update]
             )
 
-            let loaded = try XCTUnwrap(service.loadConversationAnchors(streamId: stream.id).first)
-            XCTAssertEqual(loaded.anchorStart, 1)
-            XCTAssertEqual(loaded.anchorEnd, 3)
-            XCTAssertEqual(UTF16Offsets.substring("a🙂b", start: 1, end: 3), "🙂")
+            let anchors = try service.loadConversationAnchors(streamId: stream.id)
+            let loaded = try XCTUnwrap(anchors.first)
+            XCTAssertEqual(anchors.count, 1)
+            XCTAssertEqual(loaded.anchorStart, 2)
+            XCTAssertEqual(loaded.anchorEnd, 4)
             XCTAssertFalse(loaded.detached)
             XCTAssertTrue(loaded.ephemeral)
+            let document = try service.loadOrCreateStreamDocument(streamId: stream.id)
+            XCTAssertEqual(document.docJSON, docJSON)
+            XCTAssertEqual(document.markdown, "a🙂b")
+            XCTAssertEqual(document.revision, revision)
 
             XCTAssertThrowsError(try service.saveStreamDocument(
                 streamId: stream.id,
@@ -1941,9 +1954,9 @@ final class StreamDocumentTests: XCTestCase {
             )) { error in
                 let conflict = error as? StreamDocumentRevisionConflict
                 XCTAssertEqual(conflict?.revision, revision)
-                XCTAssertEqual(conflict?.conversationAnchors.first?.anchorStart, 1)
+                XCTAssertEqual(conflict?.conversationAnchors.first?.anchorStart, 2)
             }
-            XCTAssertEqual(try service.loadConversationAnchors(streamId: stream.id).first?.anchorStart, 1)
+            XCTAssertEqual(try service.loadConversationAnchors(streamId: stream.id).first?.anchorStart, 2)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2327,7 +2327,10 @@ final class StreamDocumentTests: XCTestCase {
                 title: "Original",
                 workingText: "Frozen draft",
                 docJSON: docJSON,
-                docFormatVersion: 1
+                docFormatVersion: 1,
+                anchorStart: 2,
+                anchorEnd: 6,
+                ephemeral: true
             )
             try service.createStreamThread(thread)
 
@@ -2342,7 +2345,27 @@ final class StreamDocumentTests: XCTestCase {
                     ]))
                 }
             )
-            XCTAssertEqual(handler.handledTypes, ["saveStreamThread"])
+            XCTAssertEqual(handler.handledTypes, ["listConversations", "saveStreamThread"])
+
+            await handler.handle(BridgeMessage(
+                type: "listConversations",
+                payload: ["streamId": AnyCodable(stream.id.uuidString)],
+                callbackId: "list"
+            ))
+            let listResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "list" }
+            )
+            let conversations = try XCTUnwrap(
+                listResponse.payload?["conversations"]?.value as? [[String: Any]]
+            )
+            XCTAssertEqual(conversations.count, 1)
+            XCTAssertEqual(conversations[0]["threadId"] as? String, thread.threadId.uuidString)
+            XCTAssertEqual(conversations[0]["anchorStart"] as? Int, 2)
+            XCTAssertEqual(conversations[0]["anchorEnd"] as? Int, 6)
+            XCTAssertEqual(conversations[0]["anchorText"] as? String, thread.anchorText)
+            XCTAssertEqual(conversations[0]["detached"] as? Bool, false)
+            XCTAssertEqual(conversations[0]["ephemeral"] as? Bool, true)
+            XCTAssertNotNil(conversations[0]["updatedAt"] as? String)
 
             await handler.handle(BridgeMessage(
                 type: "saveStreamThread",
@@ -5120,6 +5143,13 @@ final class StreamDocumentTests: XCTestCase {
             let other = Stream(title: "Other inbox")
             try service.saveStream(stream)
             try service.saveStream(other)
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "First",
+                anchorStart: 1,
+                anchorEnd: 6
+            )
+            try service.createStreamThread(thread)
 
             let dbQueue = try DatabaseQueue(path: dbURL.path)
             try dbQueue.write { db in
@@ -5142,6 +5172,7 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(snapshot.appendInbox.map(\.fragment), ["First", "Third"])
             XCTAssertEqual(snapshot.appendInbox.last?.rawSpansJSON, #"[{"spanId":"span-3"}]"#)
             XCTAssertEqual(snapshot.appendInbox.last?.createdAt, Date(timeIntervalSince1970: 1002))
+            XCTAssertEqual(snapshot.conversationAnchors.map(\.threadId), [thread.threadId])
 
             let wire = StreamCodec.encodeAppendInbox(snapshot.appendInbox)
             XCTAssertEqual(wire.map { $0["seq"]?.intValue }, [1, 3])

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -300,6 +300,9 @@ export function App() {
             ...payloadStream,
             sourceScope,
             spans: deserializeProvenanceSpans(message.payload?.spans),
+            conversationAnchors: (Array.isArray(message.payload?.conversationAnchors)
+              ? message.payload.conversationAnchors
+              : []) as Stream['conversationAnchors'],
             // Appends made while no editor was open; the editor converts their
             // provenance out of fragment coordinates the first time it opens.
             pendingAppends: (Array.isArray(message.payload?.pendingAppends)

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -32,6 +32,7 @@ import {
   type PDFSectionActionRequest,
 } from './StreamEditor';
 import { createRichTextEditor, type RichTextEditor } from '../richtext/editor';
+import { refreshConversationViewport } from '../richtext/conversationAnchors';
 import {
   aiWritingRange,
   insertImage,
@@ -415,6 +416,7 @@ export function RichStreamEditor({
   const onUpdate = useCallback(() => {
     redraw((n) => n + 1);
     updateSelectionMenu();
+    if (editorRef.current) refreshConversationViewport(editorRef.current.view);
   }, [updateSelectionMenu]);
 
   useLayoutEffect(() => {
@@ -577,6 +579,7 @@ export function RichStreamEditor({
     });
     const saveScrollPosition = () => {
       updateSelectionMenu();
+      refreshConversationViewport(created.view);
       window.clearTimeout(scrollSaveTimer);
       scrollSaveTimer = window.setTimeout(() => {
         scrollSaveTimer = undefined;
@@ -585,6 +588,7 @@ export function RichStreamEditor({
     };
     scroller.scrollTop = Math.max(0, stream.document?.scrollOffset ?? 0);
     scroller.addEventListener('scroll', saveScrollPosition, { passive: true });
+    refreshConversationViewport(created.view);
 
     return () => {
       scroller.removeEventListener('scroll', saveScrollPosition);

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -32,7 +32,7 @@ import {
   type PDFSectionActionRequest,
 } from './StreamEditor';
 import { createRichTextEditor, type RichTextEditor } from '../richtext/editor';
-import { refreshConversationViewport } from '../richtext/conversationAnchors';
+import { conversationAnchorFromJSON, refreshConversationViewport } from '../richtext/conversationAnchors';
 import {
   aiWritingRange,
   insertImage,
@@ -533,6 +533,7 @@ export function RichStreamEditor({
       editor: created,
       revision: stream.document?.revision ?? 0,
       spans: (stream.spans ?? []).map(spanFromJSON),
+      conversationAnchors: (stream.conversationAnchors ?? []).map(conversationAnchorFromJSON),
       pendingAppends: decodePendingAppends(stream.pendingAppends),
       inboxAppends: stream.appendInbox ?? [],
       transport: {
@@ -546,6 +547,7 @@ export function RichStreamEditor({
           markdown,
           baseRevision,
           spans,
+          conversationAnchors,
           resolvedPendingThrough,
           consumedInboxThrough,
         }) => bridge.sendAsync<{ revision: number }>(
@@ -557,6 +559,7 @@ export function RichStreamEditor({
             markdown,
             baseRevision,
             spans,
+            conversationAnchors,
             resolvedPendingThrough,
             consumedInboxThrough,
           },
@@ -1147,6 +1150,7 @@ export function RichStreamEditor({
         markdown: String(conflict?.markdown ?? ''),
         revision: Number(conflict?.revision),
         spans: conflict?.spans?.map(spanFromJSON),
+        conversationAnchors: conflict?.conversationAnchors?.map(conversationAnchorFromJSON),
         pendingAppends: decodePendingAppends(
           Array.isArray(conflict?.pendingAppends) ? conflict.pendingAppends : [],
         ),
@@ -1202,6 +1206,7 @@ export function RichStreamEditor({
       markdown: document.markdown,
       revision: document.revision,
       spans: (stream.spans ?? []).map(spanFromJSON),
+      conversationAnchors: (stream.conversationAnchors ?? []).map(conversationAnchorFromJSON),
       // The reloaded document brings its own rows. Without them the session could
       // never let the store forget another one, and a row that outlives the
       // revision it was recorded at can never be replayed.
@@ -1212,6 +1217,7 @@ export function RichStreamEditor({
     cancelDocumentAI,
     stream.appendInbox,
     stream.document,
+    stream.conversationAnchors,
     stream.pendingAppends,
     stream.spans,
   ]);

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest';
+import { undo } from 'prosemirror-history';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRichTextEditor, type RichTextEditor } from './editor';
 import { parseMarkdown } from './markdown';
 import {
@@ -11,18 +12,20 @@ import {
   conversationRenderPosition,
   fullBlockConversationAnchor,
   hasConversationAnchorTextDrifted,
+  refreshConversationViewport,
   setConversationAnchors,
   setConversationVisibleRanges,
 } from './conversationAnchors';
 
 let editor: RichTextEditor | null = null;
 
-function open(markdown: string): RichTextEditor {
+function open(markdown: string, onUpdate?: () => void): RichTextEditor {
   const parent = document.createElement('div');
   document.body.appendChild(parent);
   editor = createRichTextEditor({
     parent,
     docJSON: JSON.stringify(parseMarkdown(markdown).toJSON()),
+    onUpdate,
   });
   return editor;
 }
@@ -50,7 +53,7 @@ afterEach(() => {
 });
 
 describe('conversation anchor lifecycle', () => {
-  it('rule 1: starts as the full UTF-16 block and renders after its last intersecting block', () => {
+  it('rule 1: starts as the full block in ProseMirror positions and renders after it', () => {
     const ed = open('A🙂B');
     const anchor = recordFullBlock(ed, '🙂');
 
@@ -69,6 +72,27 @@ describe('conversation anchor lifecycle', () => {
     expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('Alpha \nbeta');
     expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.content.size);
     expect(anchor.detached).toBe(false);
+  });
+
+  it('does not grow across a split at the trailing edge or move its glyph', () => {
+    const ed = open('ABC');
+    const original = recordFullBlock(ed, 'ABC');
+    ed.view.dispatch(ed.view.state.tr.split(original.to));
+
+    const [anchor] = conversationAnchors(ed.view.state);
+    expect(anchor).toEqual(original);
+    expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.child(0).nodeSize);
+    expect(conversationMarkerBlockPositions(ed.view.state.doc, [anchor])).toEqual(new Set([0]));
+  });
+
+  it('extends across plain text inserted at the trailing edge', () => {
+    const ed = open('ABC');
+    const original = recordFullBlock(ed, 'ABC');
+    ed.view.dispatch(ed.view.state.tr.insertText('D', original.to));
+
+    const [anchor] = conversationAnchors(ed.view.state);
+    expect(anchor.to).toBe(original.to + 1);
+    expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('ABCD');
   });
 
   it('rule 3: a merge keeps the range in the merged block', () => {
@@ -98,14 +122,25 @@ describe('conversation anchor lifecycle', () => {
     expect(conversationRenderPosition(ed.view.state.doc, conversationAnchors(ed.view.state)[0])).toBe(null);
   });
 
-  it('rule 5: stores at most 200 characters and detects changed anchor text', () => {
-    const ed = open(`${'a'.repeat(205)} end`);
-    const anchor = recordFullBlock(ed, 'end');
+  it('reattaches a detached anchor when undo restores its range', () => {
+    const ed = open('Delete me');
+    const original = recordFullBlock(ed, 'Delete');
+    ed.view.dispatch(ed.view.state.tr.delete(original.from, original.to));
+    expect(conversationAnchors(ed.view.state)[0].detached).toBe(true);
+
+    expect(undo(ed.view.state, (tr) => ed.view.dispatch(tr))).toBe(true);
+    expect(conversationAnchors(ed.view.state)).toEqual([original]);
+  });
+
+  it('rule 5: stores at most 200 UTF-16 code units and detects changed anchor text', () => {
+    const ed = open(`${'🙂'.repeat(101)}tail`);
+    const anchor = recordFullBlock(ed, 'tail');
     const stored = conversationAnchorTextForStorage(ed.view.state.doc, anchor);
-    expect([...stored]).toHaveLength(200);
+    expect(stored).toHaveLength(200);
+    expect([...stored]).toHaveLength(100);
     expect(hasConversationAnchorTextDrifted(ed.view.state.doc, anchor, stored)).toBe(false);
 
-    ed.view.dispatch(ed.view.state.tr.insertText('changed', anchor.from + 100, anchor.from + 105));
+    ed.view.dispatch(ed.view.state.tr.insertText('changed', anchor.from + 100, anchor.from + 102));
     expect(hasConversationAnchorTextDrifted(
       ed.view.state.doc,
       conversationAnchors(ed.view.state)[0],
@@ -148,4 +183,45 @@ it('renders one passive right glyph class and the current-block left line class'
   const block = ed.view.dom.querySelector('p');
   expect(block?.classList.contains('conversation-block-active')).toBe(true);
   expect(block?.classList.contains('conversation-block-anchored')).toBe(true);
+});
+
+it('coalesces viewport and hover work per animation frame and skips unchanged targets', () => {
+  const callbacks: FrameRequestCallback[] = [];
+  let nextFrame = 0;
+  const requestAnimationFrame = window.requestAnimationFrame;
+  window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+    callbacks.push(callback);
+    nextFrame += 1;
+    return nextFrame;
+  });
+
+  try {
+    const onUpdate = vi.fn();
+    const ed = open('Visible block', onUpdate);
+    const dispatch = vi.spyOn(ed.view, 'dispatch');
+    refreshConversationViewport(ed.view);
+    refreshConversationViewport(ed.view);
+    expect(callbacks).toHaveLength(1);
+    callbacks.shift()!(0);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    refreshConversationViewport(ed.view);
+    refreshConversationViewport(ed.view);
+    callbacks.shift()!(0);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(ed.view, 'posAtCoords').mockReturnValue({ pos: 1, inside: 0 });
+    ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 1, clientY: 1 }));
+    ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 2, clientY: 2 }));
+    expect(callbacks).toHaveLength(1);
+    callbacks.shift()!(0);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    ed.view.dom.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 3, clientY: 3 }));
+    callbacks.shift()!(0);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  } finally {
+    window.requestAnimationFrame = requestAnimationFrame;
+  }
 });

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRichTextEditor, type RichTextEditor } from './editor';
+import { parseMarkdown } from './markdown';
+import {
+  conversationAnchorText,
+  conversationAnchorTextForStorage,
+  conversationAnchors,
+  conversationDecorationTargets,
+  conversationRenderPosition,
+  fullBlockConversationAnchor,
+  hasConversationAnchorTextDrifted,
+  setConversationAnchors,
+} from './conversationAnchors';
+
+let editor: RichTextEditor | null = null;
+
+function open(markdown: string): RichTextEditor {
+  const parent = document.createElement('div');
+  document.body.appendChild(parent);
+  editor = createRichTextEditor({
+    parent,
+    docJSON: JSON.stringify(parseMarkdown(markdown).toJSON()),
+  });
+  return editor;
+}
+
+function find(ed: RichTextEditor, text: string): { from: number; to: number } {
+  let from = -1;
+  ed.view.state.doc.descendants((node, pos) => {
+    if (from < 0 && node.isText && node.text?.includes(text)) from = pos + node.text.indexOf(text);
+  });
+  if (from < 0) throw new Error(`no ${JSON.stringify(text)}`);
+  return { from, to: from + text.length };
+}
+
+function recordFullBlock(ed: RichTextEditor, text: string) {
+  const anchor = fullBlockConversationAnchor(ed.view.state.doc, find(ed, text).from, 'thread-1');
+  if (!anchor) throw new Error('expected a non-empty block anchor');
+  ed.view.dispatch(setConversationAnchors(ed.view.state.tr, [anchor]));
+  return anchor;
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  document.body.innerHTML = '';
+});
+
+describe('conversation anchor lifecycle', () => {
+  it('rule 1: starts as the full UTF-16 block and renders after its last intersecting block', () => {
+    const ed = open('A🙂B');
+    const anchor = recordFullBlock(ed, '🙂');
+
+    expect(anchor.from).toBe(1);
+    expect(anchor.to - anchor.from).toBe(4);
+    expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('A🙂B');
+    expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.content.size);
+  });
+
+  it('rule 2: a split spans both halves and renders after the second', () => {
+    const ed = open('Alpha beta');
+    recordFullBlock(ed, 'Alpha');
+    ed.view.dispatch(ed.view.state.tr.split(find(ed, 'beta').from));
+
+    const [anchor] = conversationAnchors(ed.view.state);
+    expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('Alpha \nbeta');
+    expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.content.size);
+    expect(anchor.detached).toBe(false);
+  });
+
+  it('rule 3: a merge keeps the range in the merged block', () => {
+    const ed = open('Alpha beta');
+    recordFullBlock(ed, 'Alpha');
+    ed.view.dispatch(ed.view.state.tr.split(find(ed, 'beta').from));
+    const secondBlock = ed.view.state.doc.resolve(find(ed, 'beta').from).before(1);
+    ed.view.dispatch(ed.view.state.tr.join(secondBlock));
+
+    const [anchor] = conversationAnchors(ed.view.state);
+    expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('Alpha beta');
+    expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.content.size);
+    expect(anchor.detached).toBe(false);
+  });
+
+  it('rule 4: deleting the range to empty detaches it without deleting it', () => {
+    const ed = open('Delete me');
+    const original = recordFullBlock(ed, 'Delete');
+    ed.view.dispatch(ed.view.state.tr.delete(original.from, original.to));
+
+    expect(conversationAnchors(ed.view.state)).toEqual([{
+      threadId: 'thread-1',
+      from: 1,
+      to: 1,
+      detached: true,
+    }]);
+    expect(conversationRenderPosition(ed.view.state.doc, conversationAnchors(ed.view.state)[0])).toBe(null);
+  });
+
+  it('rule 5: stores at most 200 characters and detects changed anchor text', () => {
+    const ed = open(`${'a'.repeat(205)} end`);
+    const anchor = recordFullBlock(ed, 'end');
+    const stored = conversationAnchorTextForStorage(ed.view.state.doc, anchor);
+    expect([...stored]).toHaveLength(200);
+    expect(hasConversationAnchorTextDrifted(ed.view.state.doc, anchor, stored)).toBe(false);
+
+    ed.view.dispatch(ed.view.state.tr.insertText('changed', anchor.from + 100, anchor.from + 105));
+    expect(hasConversationAnchorTextDrifted(
+      ed.view.state.doc,
+      conversationAnchors(ed.view.state)[0],
+      stored,
+    )).toBe(true);
+  });
+});
+
+it('bounds decoration traversal to the supplied visible ranges and collapses overlaps', () => {
+  const ed = open('First\n\nMiddle\n\nLast');
+  const first = fullBlockConversationAnchor(ed.view.state.doc, find(ed, 'First').from, 'first')!;
+  const last = fullBlockConversationAnchor(ed.view.state.doc, find(ed, 'Last').from, 'last')!;
+  const duplicate = { ...last, threadId: 'also-last' };
+
+  const firstTargets = conversationDecorationTargets(
+    ed.view.state.doc,
+    [first, last, duplicate],
+    [{ from: first.from, to: first.to }],
+    null,
+  );
+  expect(firstTargets).toHaveLength(1);
+  expect(firstTargets[0]).toMatchObject({ right: true, contentFrom: first.from, contentTo: first.to });
+
+  const lastTargets = conversationDecorationTargets(
+    ed.view.state.doc,
+    [first, last, duplicate],
+    [{ from: last.from, to: last.to }],
+    null,
+  );
+  expect(lastTargets).toHaveLength(1);
+  expect(lastTargets[0].right).toBe(true);
+});

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -7,10 +7,12 @@ import {
   conversationAnchorTextForStorage,
   conversationAnchors,
   conversationDecorationTargets,
+  conversationMarkerBlockPositions,
   conversationRenderPosition,
   fullBlockConversationAnchor,
   hasConversationAnchorTextDrifted,
   setConversationAnchors,
+  setConversationVisibleRanges,
 } from './conversationAnchors';
 
 let editor: RichTextEditor | null = null;
@@ -120,7 +122,7 @@ it('bounds decoration traversal to the supplied visible ranges and collapses ove
 
   const firstTargets = conversationDecorationTargets(
     ed.view.state.doc,
-    [first, last, duplicate],
+    conversationMarkerBlockPositions(ed.view.state.doc, [first, last, duplicate]),
     [{ from: first.from, to: first.to }],
     null,
   );
@@ -129,10 +131,21 @@ it('bounds decoration traversal to the supplied visible ranges and collapses ove
 
   const lastTargets = conversationDecorationTargets(
     ed.view.state.doc,
-    [first, last, duplicate],
+    conversationMarkerBlockPositions(ed.view.state.doc, [first, last, duplicate]),
     [{ from: last.from, to: last.to }],
     null,
   );
   expect(lastTargets).toHaveLength(1);
   expect(lastTargets[0].right).toBe(true);
+});
+
+it('renders one passive right glyph class and the current-block left line class', () => {
+  const ed = open('Visible block');
+  const anchor = fullBlockConversationAnchor(ed.view.state.doc, 1, 'one')!;
+  ed.view.dispatch(setConversationAnchors(ed.view.state.tr, [anchor, { ...anchor, threadId: 'two' }]));
+  ed.view.dispatch(setConversationVisibleRanges(ed.view.state.tr, [{ from: anchor.from, to: anchor.to }]));
+
+  const block = ed.view.dom.querySelector('p');
+  expect(block?.classList.contains('conversation-block-active')).toBe(true);
+  expect(block?.classList.contains('conversation-block-anchored')).toBe(true);
 });

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -1,0 +1,292 @@
+import type { Node as ProseNode } from 'prosemirror-model';
+import { Plugin, PluginKey, type EditorState, type Transaction } from 'prosemirror-state';
+import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
+
+export interface ConversationAnchor {
+  threadId: string;
+  from: number;
+  to: number;
+  detached: boolean;
+}
+
+export interface ConversationAnchorJSON {
+  threadId: string;
+  anchorStart: number | null;
+  anchorEnd: number | null;
+  anchorText: string;
+  detached: boolean;
+  ephemeral: boolean;
+  updatedAt: string;
+}
+
+export interface ConversationAnchorUpdateJSON {
+  threadId: string;
+  anchorStart: number;
+  anchorEnd: number;
+  detached: boolean;
+}
+
+interface BlockRange {
+  from: number;
+  to: number;
+  contentFrom: number;
+  contentTo: number;
+}
+
+interface VisibleRange {
+  from: number;
+  to: number;
+}
+
+interface ConversationAnchorState {
+  anchors: ConversationAnchor[];
+  visibleRanges: VisibleRange[];
+  hoveredBlockFrom: number | null;
+}
+
+type AnchorMessage =
+  | { kind: 'set'; anchors: ConversationAnchor[] }
+  | { kind: 'visible'; ranges: VisibleRange[] }
+  | { kind: 'hover'; blockFrom: number | null };
+
+const conversationAnchorKey = new PluginKey<ConversationAnchorState>('tickerConversationAnchors');
+
+export const setConversationAnchors = (
+  tr: Transaction,
+  anchors: ConversationAnchor[],
+): Transaction => tr.setMeta(conversationAnchorKey, { kind: 'set', anchors });
+
+export const setConversationVisibleRanges = (
+  tr: Transaction,
+  ranges: VisibleRange[],
+): Transaction => tr.setMeta(conversationAnchorKey, { kind: 'visible', ranges });
+
+export function refreshConversationViewport(view: EditorView): void {
+  const field = conversationAnchorKey.getState(view.state);
+  if (!field) return;
+  const editorRect = view.dom.getBoundingClientRect();
+  const viewportRect = view.dom.closest('.stream-content')?.getBoundingClientRect();
+  const top = Math.max(editorRect.top, viewportRect?.top ?? 0);
+  const bottom = Math.min(editorRect.bottom, viewportRect?.bottom ?? window.innerHeight);
+  const fallback = textBlockAt(view.state.doc, view.state.selection.head);
+  let from = editorRect.top >= top ? 0 : fallback?.from ?? 0;
+  let to = editorRect.bottom <= bottom ? view.state.doc.content.size : fallback?.to ?? from;
+  try {
+    const left = editorRect.left + editorRect.width / 2;
+    from = editorRect.top >= top ? 0 : view.posAtCoords({ left, top: top + 1 })?.pos ?? from;
+    to = editorRect.bottom <= bottom
+      ? view.state.doc.content.size
+      : view.posAtCoords({ left, top: Math.max(top + 1, bottom - 1) })?.pos ?? to;
+  } catch {
+    // jsdom and a pre-layout WebView have no caret geometry; the cursor block is bounded and safe.
+  }
+  const next = [{ from: Math.min(from, to), to: Math.max(from, to) }];
+  const current = field.visibleRanges;
+  if (current.length === 1 && current[0].from === next[0].from && current[0].to === next[0].to) return;
+  view.dispatch(setConversationVisibleRanges(view.state.tr, next));
+}
+
+export function conversationAnchors(state: EditorState): ConversationAnchor[] {
+  return conversationAnchorKey.getState(state)?.anchors ?? [];
+}
+
+/** Create the initial anchor from the complete text content of the current block. */
+export function fullBlockConversationAnchor(
+  doc: ProseNode,
+  pos: number,
+  threadId: string,
+): ConversationAnchor | null {
+  const block = textBlockAt(doc, pos);
+  if (!block || block.contentFrom === block.contentTo) return null;
+  return { threadId, from: block.contentFrom, to: block.contentTo, detached: false };
+}
+
+/** The document position immediately after the anchor's last intersecting block. */
+export function conversationRenderPosition(
+  doc: ProseNode,
+  anchor: ConversationAnchor,
+): number | null {
+  if (anchor.detached || anchor.from >= anchor.to) return null;
+  return textBlockAt(doc, anchor.to - 1)?.to ?? null;
+}
+
+export function conversationAnchorText(doc: ProseNode, anchor: ConversationAnchor): string {
+  return anchor.detached ? '' : doc.textBetween(anchor.from, anchor.to, '\n', '\n');
+}
+
+export function conversationAnchorTextForStorage(doc: ProseNode, anchor: ConversationAnchor): string {
+  return [...conversationAnchorText(doc, anchor)].slice(0, 200).join('');
+}
+
+export function hasConversationAnchorTextDrifted(
+  doc: ProseNode,
+  anchor: ConversationAnchor,
+  originalText: string,
+): boolean {
+  return anchor.detached || !conversationAnchorText(doc, anchor).includes(originalText);
+}
+
+export function conversationAnchorFromJSON(json: ConversationAnchorJSON): ConversationAnchor {
+  const from = Number.isInteger(json.anchorStart) ? json.anchorStart as number : 0;
+  const to = Number.isInteger(json.anchorEnd) ? json.anchorEnd as number : from;
+  return {
+    threadId: json.threadId,
+    from,
+    to,
+    detached: json.detached || from < 0 || to <= from,
+  };
+}
+
+export function conversationAnchorToJSON(anchor: ConversationAnchor): ConversationAnchorUpdateJSON {
+  return {
+    threadId: anchor.threadId,
+    anchorStart: anchor.from,
+    anchorEnd: anchor.to,
+    detached: anchor.detached,
+  };
+}
+
+function textBlockAt(doc: ProseNode, rawPos: number): BlockRange | null {
+  const pos = Math.max(0, Math.min(rawPos, doc.content.size));
+  const $pos = doc.resolve(pos);
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    const node = $pos.node(depth);
+    if (!node.isTextblock) continue;
+    const from = $pos.before(depth);
+    return {
+      from,
+      to: from + node.nodeSize,
+      contentFrom: $pos.start(depth),
+      contentTo: $pos.end(depth),
+    };
+  }
+  return null;
+}
+
+function mapAnchor(anchor: ConversationAnchor, tr: Transaction): ConversationAnchor {
+  if (!tr.docChanged || anchor.detached) return anchor;
+  let { from, to } = anchor;
+  for (const step of tr.steps) {
+    const map = step.getMap();
+    from = map.map(from, -1);
+    to = map.map(to, 1);
+  }
+  return { ...anchor, from, to, detached: to <= from };
+}
+
+function validAnchors(anchors: ConversationAnchor[], doc: ProseNode): ConversationAnchor[] {
+  return anchors.filter((anchor) => anchor.detached || (
+    anchor.from >= 0 && anchor.to <= doc.content.size && anchor.from < anchor.to
+  ));
+}
+
+function mapRange(range: VisibleRange, tr: Transaction): VisibleRange {
+  return {
+    from: tr.mapping.map(range.from, -1),
+    to: tr.mapping.map(range.to, 1),
+  };
+}
+
+export interface ConversationDecorationTarget extends BlockRange {
+  left: boolean;
+  right: boolean;
+}
+
+/** Only walks visible document ranges; anchor endpoints are resolved directly. */
+export function conversationDecorationTargets(
+  doc: ProseNode,
+  anchors: ConversationAnchor[],
+  visibleRanges: VisibleRange[],
+  activeBlockFrom: number | null,
+): ConversationDecorationTarget[] {
+  const visibleBlocks = new Map<number, ConversationDecorationTarget>();
+  for (const range of visibleRanges) {
+    const from = Math.max(0, Math.min(range.from, doc.content.size));
+    const to = Math.max(from, Math.min(range.to, doc.content.size));
+    if (from === to) continue;
+    doc.nodesBetween(from, to, (node, pos) => {
+      if (!node.isTextblock) return true;
+      visibleBlocks.set(pos, {
+        from: pos,
+        to: pos + node.nodeSize,
+        contentFrom: pos + 1,
+        contentTo: pos + node.nodeSize - 1,
+        left: pos === activeBlockFrom,
+        right: false,
+      });
+      return false;
+    });
+  }
+
+  for (const anchor of anchors) {
+    const marker = conversationRenderPosition(doc, anchor);
+    if (marker === null) continue;
+    const block = textBlockAt(doc, marker - 1);
+    const target = block && visibleBlocks.get(block.from);
+    if (target) target.right = true;
+  }
+  return [...visibleBlocks.values()].filter((target) => target.left || target.right);
+}
+
+export function conversationAnchorField(): Plugin<ConversationAnchorState> {
+  return new Plugin<ConversationAnchorState>({
+    key: conversationAnchorKey,
+    state: {
+      init: () => ({ anchors: [], visibleRanges: [], hoveredBlockFrom: null }),
+      apply(tr, current, _old, next) {
+        const mapped: ConversationAnchorState = {
+          anchors: current.anchors.map((anchor) => mapAnchor(anchor, tr)),
+          visibleRanges: tr.docChanged
+            ? current.visibleRanges.map((range) => mapRange(range, tr))
+            : current.visibleRanges,
+          hoveredBlockFrom: current.hoveredBlockFrom === null
+            ? null
+            : tr.mapping.map(current.hoveredBlockFrom, -1),
+        };
+        const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
+        if (!meta) return mapped;
+        if (meta.kind === 'set') return { ...mapped, anchors: validAnchors(meta.anchors, next.doc) };
+        if (meta.kind === 'visible') return { ...mapped, visibleRanges: meta.ranges };
+        return { ...mapped, hoveredBlockFrom: meta.blockFrom };
+      },
+    },
+    props: {
+      decorations(state) {
+        const field = conversationAnchorKey.getState(state);
+        if (!field) return null;
+        const cursorBlock = textBlockAt(state.doc, state.selection.head)?.from ?? null;
+        const targets = conversationDecorationTargets(
+          state.doc,
+          field.anchors,
+          field.visibleRanges,
+          field.hoveredBlockFrom ?? cursorBlock,
+        );
+        return DecorationSet.create(state.doc, targets.map((target) => Decoration.node(
+          target.from,
+          target.to,
+          { class: [target.left && 'conversation-block-active', target.right && 'conversation-block-anchored'].filter(Boolean).join(' ') },
+        )));
+      },
+      handleDOMEvents: {
+        mousemove(view, event) {
+          const found = view.posAtCoords({ left: event.clientX, top: event.clientY });
+          const blockFrom = found ? textBlockAt(view.state.doc, found.pos)?.from ?? null : null;
+          if (blockFrom !== conversationAnchorKey.getState(view.state)?.hoveredBlockFrom) {
+            view.dispatch(view.state.tr.setMeta(conversationAnchorKey, { kind: 'hover', blockFrom }));
+          }
+          return false;
+        },
+        mouseleave(view) {
+          if (conversationAnchorKey.getState(view.state)?.hoveredBlockFrom !== null) {
+            view.dispatch(view.state.tr.setMeta(conversationAnchorKey, { kind: 'hover', blockFrom: null }));
+          }
+          return false;
+        },
+        click() {
+          // ponytail: visual no-op for C2; C3 replaces this with open/create routing.
+          return false;
+        },
+      },
+    },
+  });
+}

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -42,6 +42,23 @@ type AnchorMessage =
   | { kind: 'hover'; blockFrom: number | null };
 
 const conversationAnchorKey = new PluginKey<ConversationAnchorState>('tickerConversationAnchors');
+const pendingViewportRefreshes = new WeakSet<EditorView>();
+
+const requestFrame = (callback: FrameRequestCallback): number => (
+  typeof window.requestAnimationFrame === 'function'
+    ? window.requestAnimationFrame(callback)
+    : window.setTimeout(() => callback(performance.now()), 16)
+);
+
+const cancelFrame = (handle: number): void => {
+  if (typeof window.cancelAnimationFrame === 'function') window.cancelAnimationFrame(handle);
+  else window.clearTimeout(handle);
+};
+
+export function isConversationDecorationTransaction(tr: Transaction): boolean {
+  const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
+  return !tr.docChanged && !tr.selectionSet && (meta?.kind === 'visible' || meta?.kind === 'hover');
+}
 
 export const setConversationAnchors = (
   tr: Transaction,
@@ -54,6 +71,19 @@ export const setConversationVisibleRanges = (
 ): Transaction => tr.setMeta(conversationAnchorKey, { kind: 'visible', ranges });
 
 export function refreshConversationViewport(view: EditorView): void {
+  if (pendingViewportRefreshes.has(view)) return;
+  pendingViewportRefreshes.add(view);
+  requestFrame(() => {
+    try {
+      applyConversationViewport(view);
+    } finally {
+      pendingViewportRefreshes.delete(view);
+    }
+  });
+}
+
+function applyConversationViewport(view: EditorView): void {
+  if (view.isDestroyed) return;
   const field = conversationAnchorKey.getState(view.state);
   if (!field) return;
   const editorRect = view.dom.getBoundingClientRect();
@@ -98,16 +128,16 @@ export function conversationRenderPosition(
   doc: ProseNode,
   anchor: ConversationAnchor,
 ): number | null {
-  if (anchor.detached || anchor.from >= anchor.to) return null;
+  if (anchor.from >= anchor.to) return null;
   return textBlockAt(doc, anchor.to - 1)?.to ?? null;
 }
 
 export function conversationAnchorText(doc: ProseNode, anchor: ConversationAnchor): string {
-  return anchor.detached ? '' : doc.textBetween(anchor.from, anchor.to, '\n', '\n');
+  return anchor.from >= anchor.to ? '' : doc.textBetween(anchor.from, anchor.to, '\n', '\n');
 }
 
 export function conversationAnchorTextForStorage(doc: ProseNode, anchor: ConversationAnchor): string {
-  return [...conversationAnchorText(doc, anchor)].slice(0, 200).join('');
+  return conversationAnchorText(doc, anchor).slice(0, 200);
 }
 
 export function hasConversationAnchorTextDrifted(
@@ -115,7 +145,7 @@ export function hasConversationAnchorTextDrifted(
   anchor: ConversationAnchor,
   originalText: string,
 ): boolean {
-  return anchor.detached || !conversationAnchorText(doc, anchor).includes(originalText);
+  return anchor.from >= anchor.to || !conversationAnchorText(doc, anchor).includes(originalText);
 }
 
 export function conversationAnchorFromJSON(json: ConversationAnchorJSON): ConversationAnchor {
@@ -129,7 +159,7 @@ export function conversationAnchorFromJSON(json: ConversationAnchorJSON): Conver
     threadId: json.threadId,
     from,
     to,
-    detached: json.detached || from < 0 || to <= from,
+    detached: to <= from,
   };
 }
 
@@ -138,7 +168,7 @@ export function conversationAnchorToJSON(anchor: ConversationAnchor): Conversati
     threadId: anchor.threadId,
     anchorStart: anchor.from,
     anchorEnd: anchor.to,
-    detached: anchor.detached,
+    detached: anchor.from >= anchor.to,
   };
 }
 
@@ -160,22 +190,24 @@ function textBlockAt(doc: ProseNode, rawPos: number): BlockRange | null {
 }
 
 function mapAnchor(anchor: ConversationAnchor, tr: Transaction): ConversationAnchor {
-  if (!tr.docChanged || anchor.detached) return anchor;
+  if (!tr.docChanged) return anchor;
   let { from, to } = anchor;
   for (const step of tr.steps) {
     const map = step.getMap();
+    const json = step.toJSON() as { from?: number; to?: number; structure?: boolean };
+    const splitsAtTrailingEdge = json.structure === true && json.from === to && json.to === to;
     from = map.map(from, -1);
-    to = map.map(to, 1);
+    to = map.map(to, splitsAtTrailingEdge ? -1 : 1);
   }
-  return { ...anchor, from, to, detached: to <= from };
+  return { ...anchor, from, to, detached: from >= to };
 }
 
 function validAnchors(anchors: ConversationAnchor[], doc: ProseNode): ConversationAnchor[] {
   return anchors.filter((anchor) => (
     anchor.from >= 0
     && anchor.to <= doc.content.size
-    && (anchor.detached ? anchor.from <= anchor.to : anchor.from < anchor.to)
-  ));
+    && anchor.from <= anchor.to
+  )).map((anchor) => ({ ...anchor, detached: anchor.from >= anchor.to }));
 }
 
 function mapRange(range: VisibleRange, tr: Transaction): VisibleRange {
@@ -236,6 +268,26 @@ export function conversationDecorationTargets(
 }
 
 export function conversationAnchorField(): Plugin<ConversationAnchorState> {
+  let hoverFrame: number | null = null;
+  let pendingHover: { view: EditorView; left: number; top: number } | { view: EditorView } | null = null;
+  const queueHover = (view: EditorView, point?: { left: number; top: number }): void => {
+    pendingHover = point ? { view, ...point } : { view };
+    if (hoverFrame !== null) return;
+    hoverFrame = requestFrame(() => {
+      const pending = pendingHover;
+      pendingHover = null;
+      hoverFrame = null;
+      if (!pending) return;
+      const found = 'left' in pending
+        ? pending.view.posAtCoords({ left: pending.left, top: pending.top })
+        : null;
+      const blockFrom = found ? textBlockAt(pending.view.state.doc, found.pos)?.from ?? null : null;
+      if (blockFrom !== conversationAnchorKey.getState(pending.view.state)?.hoveredBlockFrom) {
+        pending.view.dispatch(pending.view.state.tr.setMeta(conversationAnchorKey, { kind: 'hover', blockFrom }));
+      }
+    });
+  };
+
   return new Plugin<ConversationAnchorState>({
     key: conversationAnchorKey,
     state: {
@@ -287,17 +339,11 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
       },
       handleDOMEvents: {
         mousemove(view, event) {
-          const found = view.posAtCoords({ left: event.clientX, top: event.clientY });
-          const blockFrom = found ? textBlockAt(view.state.doc, found.pos)?.from ?? null : null;
-          if (blockFrom !== conversationAnchorKey.getState(view.state)?.hoveredBlockFrom) {
-            view.dispatch(view.state.tr.setMeta(conversationAnchorKey, { kind: 'hover', blockFrom }));
-          }
+          queueHover(view, { left: event.clientX, top: event.clientY });
           return false;
         },
         mouseleave(view) {
-          if (conversationAnchorKey.getState(view.state)?.hoveredBlockFrom !== null) {
-            view.dispatch(view.state.tr.setMeta(conversationAnchorKey, { kind: 'hover', blockFrom: null }));
-          }
+          queueHover(view);
           return false;
         },
         click() {
@@ -306,5 +352,12 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
         },
       },
     },
+    view: () => ({
+      destroy() {
+        if (hoverFrame !== null) cancelFrame(hoverFrame);
+        hoverFrame = null;
+        pendingHover = null;
+      },
+    }),
   });
 }

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -1,22 +1,13 @@
 import type { Node as ProseNode } from 'prosemirror-model';
 import { Plugin, PluginKey, type EditorState, type Transaction } from 'prosemirror-state';
 import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
+import type { ConversationAnchorJSON } from '../types/models';
 
 export interface ConversationAnchor {
   threadId: string;
   from: number;
   to: number;
   detached: boolean;
-}
-
-export interface ConversationAnchorJSON {
-  threadId: string;
-  anchorStart: number | null;
-  anchorEnd: number | null;
-  anchorText: string;
-  detached: boolean;
-  ephemeral: boolean;
-  updatedAt: string;
 }
 
 export interface ConversationAnchorUpdateJSON {
@@ -40,6 +31,7 @@ interface VisibleRange {
 
 interface ConversationAnchorState {
   anchors: ConversationAnchor[];
+  markerBlockFrom: Set<number>;
   visibleRanges: VisibleRange[];
   hoveredBlockFrom: number | null;
 }
@@ -127,8 +119,12 @@ export function hasConversationAnchorTextDrifted(
 }
 
 export function conversationAnchorFromJSON(json: ConversationAnchorJSON): ConversationAnchor {
-  const from = Number.isInteger(json.anchorStart) ? json.anchorStart as number : 0;
-  const to = Number.isInteger(json.anchorEnd) ? json.anchorEnd as number : from;
+  const from = Number.isInteger(json.anchorStart) && (json.anchorStart as number) >= 0
+    ? json.anchorStart as number
+    : 0;
+  const to = Number.isInteger(json.anchorEnd) && (json.anchorEnd as number) >= from
+    ? json.anchorEnd as number
+    : from;
   return {
     threadId: json.threadId,
     from,
@@ -175,8 +171,10 @@ function mapAnchor(anchor: ConversationAnchor, tr: Transaction): ConversationAnc
 }
 
 function validAnchors(anchors: ConversationAnchor[], doc: ProseNode): ConversationAnchor[] {
-  return anchors.filter((anchor) => anchor.detached || (
-    anchor.from >= 0 && anchor.to <= doc.content.size && anchor.from < anchor.to
+  return anchors.filter((anchor) => (
+    anchor.from >= 0
+    && anchor.to <= doc.content.size
+    && (anchor.detached ? anchor.from <= anchor.to : anchor.from < anchor.to)
   ));
 }
 
@@ -192,10 +190,23 @@ export interface ConversationDecorationTarget extends BlockRange {
   right: boolean;
 }
 
+export function conversationMarkerBlockPositions(
+  doc: ProseNode,
+  anchors: ConversationAnchor[],
+): Set<number> {
+  const positions = new Set<number>();
+  for (const anchor of anchors) {
+    const marker = conversationRenderPosition(doc, anchor);
+    const block = marker === null ? null : textBlockAt(doc, marker - 1);
+    if (block) positions.add(block.from);
+  }
+  return positions;
+}
+
 /** Only walks visible document ranges; anchor endpoints are resolved directly. */
 export function conversationDecorationTargets(
   doc: ProseNode,
-  anchors: ConversationAnchor[],
+  markerBlockFrom: ReadonlySet<number>,
   visibleRanges: VisibleRange[],
   activeBlockFrom: number | null,
 ): ConversationDecorationTarget[] {
@@ -218,12 +229,8 @@ export function conversationDecorationTargets(
     });
   }
 
-  for (const anchor of anchors) {
-    const marker = conversationRenderPosition(doc, anchor);
-    if (marker === null) continue;
-    const block = textBlockAt(doc, marker - 1);
-    const target = block && visibleBlocks.get(block.from);
-    if (target) target.right = true;
+  for (const [pos, target] of visibleBlocks) {
+    if (markerBlockFrom.has(pos)) target.right = true;
   }
   return [...visibleBlocks.values()].filter((target) => target.left || target.right);
 }
@@ -232,10 +239,14 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
   return new Plugin<ConversationAnchorState>({
     key: conversationAnchorKey,
     state: {
-      init: () => ({ anchors: [], visibleRanges: [], hoveredBlockFrom: null }),
+      init: () => ({ anchors: [], markerBlockFrom: new Set(), visibleRanges: [], hoveredBlockFrom: null }),
       apply(tr, current, _old, next) {
+        const anchors = current.anchors.map((anchor) => mapAnchor(anchor, tr));
         const mapped: ConversationAnchorState = {
-          anchors: current.anchors.map((anchor) => mapAnchor(anchor, tr)),
+          anchors,
+          markerBlockFrom: tr.docChanged
+            ? conversationMarkerBlockPositions(next.doc, anchors)
+            : current.markerBlockFrom,
           visibleRanges: tr.docChanged
             ? current.visibleRanges.map((range) => mapRange(range, tr))
             : current.visibleRanges,
@@ -245,7 +256,14 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
         };
         const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
         if (!meta) return mapped;
-        if (meta.kind === 'set') return { ...mapped, anchors: validAnchors(meta.anchors, next.doc) };
+        if (meta.kind === 'set') {
+          const valid = validAnchors(meta.anchors, next.doc);
+          return {
+            ...mapped,
+            anchors: valid,
+            markerBlockFrom: conversationMarkerBlockPositions(next.doc, valid),
+          };
+        }
         if (meta.kind === 'visible') return { ...mapped, visibleRanges: meta.ranges };
         return { ...mapped, hoveredBlockFrom: meta.blockFrom };
       },
@@ -257,7 +275,7 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
         const cursorBlock = textBlockAt(state.doc, state.selection.head)?.from ?? null;
         const targets = conversationDecorationTargets(
           state.doc,
-          field.anchors,
+          field.markerBlockFrom,
           field.visibleRanges,
           field.hoveredBlockFrom ?? cursorBlock,
         );

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -59,6 +59,33 @@
   margin-bottom: 0;
 }
 
+.richtext-editor .ProseMirror .conversation-block-active,
+.richtext-editor .ProseMirror .conversation-block-anchored {
+  position: relative;
+}
+
+.richtext-editor .ProseMirror .conversation-block-active::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 -18px;
+  width: 2px;
+  background: var(--accent);
+  pointer-events: none;
+}
+
+.richtext-editor .ProseMirror .conversation-block-anchored::after {
+  content: '◆';
+  position: absolute;
+  top: 50%;
+  right: -24px;
+  color: var(--accent);
+  font-size: 8px;
+  line-height: 1;
+  opacity: 0.55;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
 .richtext-editor .ProseMirror h1,
 .richtext-editor .ProseMirror h2,
 .richtext-editor .ProseMirror h3,

--- a/Web/src/richtext/editor.ts
+++ b/Web/src/richtext/editor.ts
@@ -30,7 +30,7 @@ import {
 } from './commands';
 import { parseMarkdown, serializeMarkdown } from './markdown';
 import { aiWritingHighlight, setImageWidth } from './operations';
-import { conversationAnchorField } from './conversationAnchors';
+import { conversationAnchorField, isConversationDecorationTransaction } from './conversationAnchors';
 import { provenance } from './provenance';
 import { BREAK_ATTRIBUTES, MAX_IMAGE_WIDTH, MIN_IMAGE_WIDTH, tickerSchema } from './schema';
 
@@ -334,7 +334,7 @@ export function createRichTextEditor(options: RichTextEditorOptions): RichTextEd
       view.updateState(next);
       if (transaction.docChanged) onChange?.();
       onTransaction?.(transaction);
-      onUpdate?.();
+      if (!isConversationDecorationTransaction(transaction)) onUpdate?.();
     },
   });
 

--- a/Web/src/richtext/editor.ts
+++ b/Web/src/richtext/editor.ts
@@ -30,6 +30,7 @@ import {
 } from './commands';
 import { parseMarkdown, serializeMarkdown } from './markdown';
 import { aiWritingHighlight, setImageWidth } from './operations';
+import { conversationAnchorField } from './conversationAnchors';
 import { provenance } from './provenance';
 import { BREAK_ATTRIBUTES, MAX_IMAGE_WIDTH, MIN_IMAGE_WIDTH, tickerSchema } from './schema';
 
@@ -290,7 +291,7 @@ function stateFor(doc: ProseNode): EditorState {
   // Order matters: our keymap gets first refusal, then the stock bindings.
   return EditorState.create({
     doc,
-    plugins: [history(), tickerKeymap(), keymap(baseKeymap), aiWritingHighlight(), provenance()],
+    plugins: [history(), tickerKeymap(), keymap(baseKeymap), aiWritingHighlight(), provenance(), conversationAnchorField()],
   });
 }
 

--- a/Web/src/richtext/session.test.ts
+++ b/Web/src/richtext/session.test.ts
@@ -9,6 +9,12 @@ import { addProvenanceSpans, hashProvenanceText, provenanceSpans, spanFromJSON, 
 import { fnv1a } from '../utils/fnv1a';
 import type { PendingAppend } from './pendingAppends';
 import type { InboxAppend } from './inbox';
+import {
+  conversationAnchors,
+  fullBlockConversationAnchor,
+  type ConversationAnchor,
+  type ConversationAnchorUpdateJSON,
+} from './conversationAnchors';
 
 /**
  * These are the rules that corrupt a user's notes when they are wrong, so they are
@@ -33,6 +39,7 @@ interface Harness {
     markdown: string;
     baseRevision: number;
     spans: ProvenanceSpanJSON[];
+    conversationAnchors: ConversationAnchorUpdateJSON[];
     resolvedPendingThrough?: number;
     consumedInboxThrough?: number;
   }>;
@@ -48,6 +55,7 @@ function open(
   spans: ProvenanceSpan[] = [],
   pendingAppends: PendingAppend[] = [],
   inboxAppends: InboxAppend[] = [],
+  anchors: ConversationAnchor[] = [],
 ): Harness {
   const parent = document.createElement('div');
   document.body.appendChild(parent);
@@ -67,6 +75,7 @@ function open(
         markdown: request.markdown,
         baseRevision: request.baseRevision,
         spans: request.spans,
+        conversationAnchors: request.conversationAnchors,
         resolvedPendingThrough: request.resolvedPendingThrough,
         consumedInboxThrough: request.consumedInboxThrough,
       });
@@ -98,6 +107,7 @@ function open(
     transport,
     revision,
     spans,
+    conversationAnchors: anchors,
     pendingAppends,
     inboxAppends,
     autosaveDelay: 5,
@@ -122,6 +132,12 @@ afterEach(() => {
 });
 
 const type = (ed: RichTextEditor, text: string) => ed.view.dispatch(ed.view.state.tr.insertText(text, 1));
+
+const fullBlockAnchor = (ed: RichTextEditor, threadId = 'thread-1') => {
+  const anchor = fullBlockConversationAnchor(ed.view.state.doc, 1, threadId);
+  if (!anchor) throw new Error('expected a non-empty block anchor');
+  return anchor;
+};
 
 /**
  * What the host ACTUALLY sends. Every producer records offsets into the
@@ -189,6 +205,20 @@ describe('the durable append inbox', () => {
     await h.session.saveNow();
     expect(h.saves).toHaveLength(1);
     expect(h.saves[0].consumedInboxThrough).toBe(9);
+  });
+
+  it('maps existing conversation anchors while reducing opening inbox rows', async () => {
+    const anchor = { threadId: 'thread-1', from: 1, to: 6, detached: false };
+    const h = open('Base.', 7, [], [], [inboxAppend(3, 'Later.')], [anchor]);
+
+    expect(conversationAnchors(h.ed.view.state)).toEqual([anchor]);
+    await h.session.saveNow();
+    expect(h.saves[0].conversationAnchors[0]).toMatchObject({
+      threadId: 'thread-1',
+      anchorStart: 1,
+      anchorEnd: 6,
+      detached: false,
+    });
   });
 
   it('leaves the live document untouched when one row is malformed', () => {
@@ -393,6 +423,21 @@ describe('autosave', () => {
     await h.session.saveNow();
     expect(h.saves[h.saves.length - 1].markdown).toBe(h.ed.getMarkdownProjection());
   });
+
+  it('rule 4: persists a detached anchor on the next document save', async () => {
+    const h = open('Delete me');
+    const anchor = fullBlockAnchor(h.ed);
+    h.session.restoreConversationAnchors([anchor]);
+    h.ed.view.dispatch(h.ed.view.state.tr.delete(anchor.from, anchor.to));
+
+    await h.session.saveNow();
+    expect(h.saves[0].conversationAnchors).toEqual([{
+      threadId: 'thread-1',
+      anchorStart: 1,
+      anchorEnd: 1,
+      detached: true,
+    }]);
+  });
 });
 
 describe('an append from outside the editor', () => {
@@ -415,6 +460,21 @@ describe('an append from outside the editor', () => {
     expect(h.saves).toHaveLength(1);
     expect(h.saves[0].markdown).toBe('first\n\nappended');
     expect(h.saves[0].resolvedPendingThrough).toBe(4);
+  });
+
+  it('rule 6: maps and saves anchors through an external append transaction', async () => {
+    const h = open('A🙂B', 3);
+    const anchor = fullBlockAnchor(h.ed);
+    h.session.restoreConversationAnchors([anchor]);
+    h.session.documentAppended({ streamId: 'stream-1', fragment: 'later', revision: 4 });
+
+    await h.session.saveNow();
+    expect(h.saves[0].conversationAnchors).toEqual([{
+      threadId: 'thread-1',
+      anchorStart: 1,
+      anchorEnd: 5,
+      detached: false,
+    }]);
   });
 
   it('reloads instead of patching when a revision is MISSING', () => {

--- a/Web/src/richtext/session.ts
+++ b/Web/src/richtext/session.ts
@@ -4,6 +4,13 @@ import { reduceAppendInbox, type InboxAppend } from './inbox';
 import { parseMarkdown } from './markdown';
 import { placeFragmentSpan, planReplay, type PendingAppend } from './pendingAppends';
 import {
+  conversationAnchors,
+  conversationAnchorToJSON,
+  setConversationAnchors,
+  type ConversationAnchor,
+  type ConversationAnchorUpdateJSON,
+} from './conversationAnchors';
+import {
   addProvenanceSpans,
   hashProvenanceText,
   provenanceSpans,
@@ -41,6 +48,7 @@ export interface SessionTransport {
     markdown: string;
     baseRevision: number;
     spans: ProvenanceSpanJSON[];
+    conversationAnchors: ConversationAnchorUpdateJSON[];
     /**
      * The highest append revision whose provenance this editor has converted. The
      * store forgets only those rows; without it, it keeps every one — an editor
@@ -62,6 +70,7 @@ export interface SessionOptions {
   transport: SessionTransport;
   revision: number;
   spans?: ProvenanceSpan[];
+  conversationAnchors?: ConversationAnchor[];
   /** Appends recorded while no editor was open, still in fragment coordinates. */
   pendingAppends?: PendingAppend[];
   /** New append inbox rows, ordered by their database sequence. */
@@ -88,6 +97,8 @@ export class DocumentSession {
 
   /** The spans as last persisted, so metadata-only changes still count as dirty. */
   private lastSavedSpans = '';
+
+  private lastSavedConversationAnchors = '';
 
   private timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -132,6 +143,8 @@ export class DocumentSession {
     this.lastSavedMarkdown = options.editor.getMarkdownProjection();
     if (options.spans?.length) this.restoreSpans(options.spans);
     this.lastSavedSpans = this.spanFingerprint();
+    if (options.conversationAnchors?.length) this.restoreConversationAnchors(options.conversationAnchors);
+    this.lastSavedConversationAnchors = this.conversationAnchorFingerprint();
     this.adoptPendingAppends(options.pendingAppends ?? []);
     this.adoptInboxAppends(options.inboxAppends ?? []);
   }
@@ -272,7 +285,7 @@ export class DocumentSession {
   }
 
   /**
-   * Parse and place every queued append off-screen before replacing the live
+   * Parse and place every queued append off-screen before appending to the live
    * opening document. If one row is bad, consuming any earlier row would strand
    * the rest behind a canonical document they were never applied to.
    */
@@ -292,14 +305,13 @@ export class DocumentSession {
       return;
     }
 
-    editor.setDocumentJSON(JSON.stringify(reduced.doc.toJSON()));
-    // These were proved against the exact document just installed. Filtering them
-    // a second time could turn a future disagreement into silent history loss
-    // while the same save consumes the only rows that could recover it.
-    editor.view.dispatch(setProvenanceSpans(
-      editor.view.state.tr,
-      [...existing, ...reduced.spans],
-    ));
+    const { view } = editor;
+    const insertedAt = view.state.doc.content.size;
+    const appended = reduced.doc.content.cut(insertedAt);
+    view.dispatch(addProvenanceSpans(
+      view.state.tr.replace(insertedAt, insertedAt, new Slice(appended, 0, 0)),
+      reduced.spans,
+    ).setMeta('addToHistory', false));
     this.inboxConsumedThrough = reduced.consumedThrough;
     this.inboxSeenThrough = reduced.consumedThrough ?? 0;
     // The stored fingerprints stay at the base document: this combined document
@@ -359,9 +371,14 @@ export class DocumentSession {
     return JSON.stringify(provenanceSpans(this.options.editor.view.state).map(spanToJSON));
   }
 
+  private conversationAnchorFingerprint(): string {
+    return JSON.stringify(conversationAnchors(this.options.editor.view.state).map(conversationAnchorToJSON));
+  }
+
   private isDirty(): boolean {
     return this.options.editor.getDocumentJSON() !== this.lastSavedDocument
-      || this.spanFingerprint() !== this.lastSavedSpans;
+      || this.spanFingerprint() !== this.lastSavedSpans
+      || this.conversationAnchorFingerprint() !== this.lastSavedConversationAnchors;
   }
 
   /**
@@ -420,6 +437,8 @@ export class DocumentSession {
     const baseRevision = this.revision;
     const spans = this.spansForSave();
     const fingerprint = this.spanFingerprint();
+    const anchors = conversationAnchors(editor.view.state);
+    const anchorFingerprint = this.conversationAnchorFingerprint();
     const generation = this.generation;
     const consumedInboxThrough = this.inboxConsumedThrough ?? undefined;
 
@@ -436,6 +455,7 @@ export class DocumentSession {
         markdown,
         baseRevision,
         spans: spans.map(spanToJSON),
+        conversationAnchors: anchors.map(conversationAnchorToJSON),
         resolvedPendingThrough,
         consumedInboxThrough,
       });
@@ -472,6 +492,7 @@ export class DocumentSession {
       this.lastSavedDocument = docJSON;
       this.lastSavedMarkdown = markdown;
       this.lastSavedSpans = fingerprint;
+      this.lastSavedConversationAnchors = anchorFingerprint;
       // Only settle if nothing changed while the write was in flight.
       this.setState(this.isDirty() ? 'saving' : 'saved');
     } catch (error) {
@@ -563,6 +584,7 @@ export class DocumentSession {
     markdown: string;
     revision: number;
     spans?: ProvenanceSpan[];
+    conversationAnchors?: ConversationAnchor[];
     pendingAppends?: PendingAppend[];
     inboxAppends?: InboxAppend[];
   }): void {
@@ -663,6 +685,7 @@ export class DocumentSession {
     markdown: string;
     revision: number;
     spans?: ProvenanceSpan[];
+    conversationAnchors?: ConversationAnchor[];
     pendingAppends?: PendingAppend[];
     inboxAppends?: InboxAppend[];
   }): void {
@@ -677,6 +700,7 @@ export class DocumentSession {
     markdown: string;
     revision: number;
     spans?: ProvenanceSpan[];
+    conversationAnchors?: ConversationAnchor[];
   }): boolean {
     if (payload.docFormatVersion !== DOCUMENT_FORMAT_VERSION || typeof payload.docJSON !== 'string') {
       this.refuseHostDocument('missingCanonicalDocument');
@@ -693,9 +717,11 @@ export class DocumentSession {
     this.generation += 1;
     this.revision = payload.revision;
     this.restoreSpans(payload.spans ?? []);
+    this.restoreConversationAnchors(payload.conversationAnchors ?? []);
     this.lastSavedDocument = this.options.editor.getDocumentJSON();
     this.lastSavedMarkdown = payload.markdown;
     this.lastSavedSpans = this.spanFingerprint();
+    this.lastSavedConversationAnchors = this.conversationAnchorFingerprint();
     // The document it had proven things about is gone; a caller that knows the new
     // document's rows says so by calling adoptPendingAppends after this.
     this.pendingSafeThrough = null;
@@ -726,6 +752,12 @@ export class DocumentSession {
       && hashProvenanceText(view.state.doc, span) === span.textHash
     ));
     view.dispatch(setProvenanceSpans(view.state.tr, valid));
+  }
+
+  restoreConversationAnchors(anchors: ConversationAnchor[]): void {
+    const { view } = this.options.editor;
+    view.dispatch(setConversationAnchors(view.state.tr, anchors));
+    this.lastSavedConversationAnchors = this.conversationAnchorFingerprint();
   }
 
   /**

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -1,6 +1,7 @@
 import { debugLog } from '../utils/debug';
 import type {
   AIExchangeJSON,
+  ConversationAnchorJSON,
   PendingAppendJSON,
   ProvenanceSpanJSON,
   StreamAppendInboxJSON,
@@ -70,6 +71,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadProxyAuth',
   'loadSettings',
   'loadStorageState',
+  'listConversations',
   'loadStream',
   'loadStreams',
   'getExchange',
@@ -131,6 +133,7 @@ export interface StreamDocumentConflictPayload extends Record<string, unknown> {
   markdown: string;
   revision: number;
   spans: ProvenanceSpanJSON[];
+  conversationAnchors: ConversationAnchorJSON[];
   pendingAppends: PendingAppendJSON[];
   appendInbox: StreamAppendInboxJSON[];
 }
@@ -230,6 +233,10 @@ export const bridge: Bridge = {
 
 export function getExchange(requestId: string): Promise<{ exchange: AIExchangeJSON | null }> {
   return bridge.sendAsync('getExchange', { requestId });
+}
+
+export function listConversations(streamId: string): Promise<{ conversations: ConversationAnchorJSON[] }> {
+  return bridge.sendAsync('listConversations', { streamId });
 }
 
 export function updateMarginNote(payload: UpdateMarginNotePayload): void {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -235,6 +235,7 @@ export function getExchange(requestId: string): Promise<{ exchange: AIExchangeJS
   return bridge.sendAsync('getExchange', { requestId });
 }
 
+// ponytail: no caller until C3 wires the conversation surface.
 export function listConversations(streamId: string): Promise<{ conversations: ConversationAnchorJSON[] }> {
   return bridge.sendAsync('listConversations', { streamId });
 }

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -6,6 +6,7 @@ export interface Stream {
   sources: SourceReference[];
   document: StreamDocument;
   spans: ProvenanceSpanJSON[];
+  conversationAnchors?: ConversationAnchorJSON[];
   pendingAppends?: PendingAppendJSON[];
   appendInbox?: StreamAppendInboxJSON[];
   marginNotes: MarginNoteJSON[];
@@ -58,6 +59,16 @@ export interface ProvenanceSpanJSON {
   meta: string;
   textHash: string;
   createdAt: string;
+}
+
+export interface ConversationAnchorJSON {
+  threadId: string;
+  anchorStart: number | null;
+  anchorEnd: number | null;
+  anchorText: string;
+  detached: boolean;
+  ephemeral: boolean;
+  updatedAt: string;
 }
 
 export interface MarginNoteJSON {

--- a/docs/CONVERSATIONS_PLAN.md
+++ b/docs/CONVERSATIONS_PLAN.md
@@ -64,7 +64,7 @@ sidecar data.
 
 ### Anchor lifecycle rules (verbatim; encode in tests)
 
-1. A conversation anchors to a contiguous UTF-16 range in the canonical document, initially the full
+1. A conversation anchors to a contiguous range of ProseMirror document positions, initially the full
    text of one block. The range maps through every transaction (same mapping discipline as provenance
    spans). The conversation renders after the **last block intersecting the range**.
 2. Block split inside the range: the range now spans both halves; render rule (1) keeps the
@@ -124,7 +124,7 @@ composer empty) collapses. Streaming renders progressively into the last AI turn
 
 ```sql
 -- v30_conversation_anchors
-ALTER TABLE stream_threads ADD COLUMN anchor_start INTEGER;   -- UTF-16 offset in canonical doc
+ALTER TABLE stream_threads ADD COLUMN anchor_start INTEGER;   -- ProseMirror doc position (opaque to Swift)
 ALTER TABLE stream_threads ADD COLUMN anchor_end   INTEGER;
 ALTER TABLE stream_threads ADD COLUMN detached     INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE stream_threads ADD COLUMN ephemeral    INTEGER NOT NULL DEFAULT 0;  -- /chat, D9

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -122,11 +122,11 @@
         "requiredPayloadKeys": ["streamId", "appendInbox", "isNewStream", "source"]
       },
       "streamDocumentConflict": {
-        "requiredPayloadKeys": ["streamId", "markdown", "revision", "spans", "pendingAppends", "appendInbox"],
+        "requiredPayloadKeys": ["streamId", "markdown", "revision", "spans", "conversationAnchors", "pendingAppends", "appendInbox"],
         "optionalPayloadKeys": ["docJSON", "docFormatVersion"]
       },
       "streamLoaded": {
-        "requiredPayloadKeys": ["stream", "spans", "marginNotes", "appendInbox"],
+        "requiredPayloadKeys": ["stream", "spans", "conversationAnchors", "marginNotes", "appendInbox"],
         "optionalPayloadKeys": ["scrollOffset", "sourceScope", "requestId", "pendingAppends"]
       },
       "streamLoadFailed": {
@@ -200,6 +200,10 @@
       "loadStorageState": {
         "requiredPayloadKeys": []
       },
+      "listConversations": {
+        "requiredPayloadKeys": ["streamId"],
+        "requiredCallbackId": true
+      },
       "loadStream": {
         "requiredPayloadKeys": ["id"],
         "optionalPayloadKeys": ["requestId"]
@@ -256,7 +260,7 @@
         ]
       },
       "saveRichStreamDocument": {
-        "requiredPayloadKeys": ["streamId", "docJSON", "docFormatVersion", "markdown", "baseRevision", "spans"],
+        "requiredPayloadKeys": ["streamId", "docJSON", "docFormatVersion", "markdown", "baseRevision", "spans", "conversationAnchors"],
         "optionalPayloadKeys": ["resolvedPendingThrough", "consumedInboxThrough"],
         "requiredCallbackId": true
       },


### PR DESCRIPTION
Phase C2 of `docs/CONVERSATIONS_PLAN.md` — the anchor foundation: v30 migration (anchor_start/end as opaque ProseMirror positions, detached, ephemeral; prototype rows detached), `ConversationAnchorField` mapping ranges through edits with the provenance-span discipline, anchors persisted atomically inside the document-save transaction, `listConversations` bridge message, passive gutter glyphs + hover line bounded by visible ranges.

Lifecycle rules 1–6 each encoded as named tests (split/merge/delete/undo-reattach/drift/append mapping).

**Review (Opus): pass-with-notes → fix round `346100f`:** trailing-edge splits no longer grow the anchor; detachment is derived so ⌘Z re-attaches; stale anchor rows can no longer fail document autosave (skip+log); rAF-coalesced viewport/hover dispatch; UTF-16 test invariant corrected to opaque-PM-position semantics. Accepted+annotated: partial-update anchor semantics on the legacy save path; `listConversations` has no caller until C3.

**Gates (independent):** build-dev ✓ · swift-test ✓ · typecheck ✓ · 570/570 web tests ✓ · prod build ✓ · contract checker ✓.
**User smoke note:** drag-select across paragraphs (hover dispatch path) — check for selection jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)