### PR TITLE
C3: inline conversation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: open block-anchored conversations inline with streaming replies (phase C3)
 - editor: add durable conversation anchors and passive gutter markers (phase C2)
 - editor: adopt the inline-conversation design language (phase C1)
 - editor: replace the thread drawer prototype with inline conversations (phase C0: drawer removed)

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -136,6 +136,8 @@ enum StreamCodec {
             "title": thread.title,
             "workingText": thread.workingText,
             "anchorText": thread.anchorText,
+            "detached": thread.detached,
+            "ephemeral": thread.ephemeral,
             "revision": thread.revision,
             "createdAt": formatter.string(from: thread.createdAt),
             "updatedAt": formatter.string(from: thread.updatedAt)
@@ -143,6 +145,10 @@ enum StreamCodec {
         if let docJSON = thread.docJSON, let docFormatVersion = thread.docFormatVersion {
             payload["docJSON"] = docJSON
             payload["docFormatVersion"] = docFormatVersion
+        }
+        if let anchorStart = thread.anchorStart, let anchorEnd = thread.anchorEnd {
+            payload["anchorStart"] = anchorStart
+            payload["anchorEnd"] = anchorEnd
         }
         payload["anchors"] = anchors
         if let exchanges {

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -5,6 +5,7 @@ final class ThreadMessageHandler: BridgeMessageHandler {
     let handledTypes: Set<String> = [
         "listConversations",
         "createStreamThread",
+        "deleteStreamThread",
         "loadStreamThread",
         "saveStreamThread"
     ]
@@ -41,7 +42,6 @@ final class ThreadMessageHandler: BridgeMessageHandler {
         }
         switch message.type {
         case "listConversations":
-            // ponytail: no caller until C3 wires the conversation surface.
             guard let streamId = decodeUUID(message.payload, key: "streamId") else {
                 respondWithError(callbackId, "Invalid listConversations payload")
                 return
@@ -100,6 +100,25 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 }
                 respond(callbackId, [
                     "thread": AnyCodable(try encodeThread(thread))
+                ])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
+        case "deleteStreamThread":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let threadId = decodeUUID(payload, key: "threadId") else {
+                respondWithError(callbackId, "Invalid deleteStreamThread payload")
+                return
+            }
+            do {
+                let highlightIds = try persistence.deleteStreamThread(
+                    threadId: threadId,
+                    streamId: streamId
+                )
+                respond(callbackId, [
+                    "highlightIds": AnyCodable(highlightIds.map(\.uuidString))
                 ])
             } catch {
                 respondWithError(callbackId, error.localizedDescription)

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -2,7 +2,12 @@ import Foundation
 
 @MainActor
 final class ThreadMessageHandler: BridgeMessageHandler {
-    let handledTypes: Set<String> = ["listConversations", "saveStreamThread"]
+    let handledTypes: Set<String> = [
+        "listConversations",
+        "createStreamThread",
+        "loadStreamThread",
+        "saveStreamThread"
+    ]
 
     private let persistence: PersistenceService
     private let sendToWeb: (BridgeMessage) -> Void
@@ -51,6 +56,55 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 respondWithError(callbackId, error.localizedDescription)
             }
 
+        case "createStreamThread":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let title = payload["title"]?.value as? String,
+                  let anchorText = payload["anchorText"]?.value as? String,
+                  !anchorText.isEmpty,
+                  let anchorStart = payload["anchorStart"]?.intValue,
+                  let anchorEnd = payload["anchorEnd"]?.intValue,
+                  anchorStart >= 0,
+                  anchorEnd > anchorStart else {
+                respondWithError(callbackId, "Invalid createStreamThread payload")
+                return
+            }
+            do {
+                let thread = try persistence.createStreamThread(StreamThread(
+                    streamId: streamId,
+                    title: title,
+                    anchorText: anchorText,
+                    anchorStart: anchorStart,
+                    anchorEnd: anchorEnd
+                ))
+                respond(callbackId, [
+                    "thread": AnyCodable(try encodeThread(thread))
+                ])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
+        case "loadStreamThread":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let threadId = decodeUUID(payload, key: "threadId") else {
+                respondWithError(callbackId, "Invalid loadStreamThread payload")
+                return
+            }
+            do {
+                guard let thread = try persistence.loadStreamThread(
+                    threadId: threadId,
+                    streamId: streamId
+                ) else {
+                    throw StreamThreadPersistenceError.threadNotFound
+                }
+                respond(callbackId, [
+                    "thread": AnyCodable(try encodeThread(thread))
+                ])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
         case "saveStreamThread":
             guard let payload = message.payload,
                   let streamId = decodeUUID(payload, key: "streamId"),
@@ -70,23 +124,17 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 )
                 respond(callbackId, [
                     "conflict": AnyCodable(false),
-                    "thread": AnyCodable(StreamCodec.encodeThread(
-                        thread,
-                        source: nil,
-                        highlight: nil,
-                        exchanges: nil
-                    ))
+                    "thread": AnyCodable(try encodeThread(thread))
                 ])
             } catch let conflict as StreamThreadRevisionConflict {
-                respond(callbackId, [
-                    "conflict": AnyCodable(true),
-                    "thread": AnyCodable(StreamCodec.encodeThread(
-                        conflict.current,
-                        source: nil,
-                        highlight: nil,
-                        exchanges: nil
-                    ))
-                ])
+                do {
+                    respond(callbackId, [
+                        "conflict": AnyCodable(true),
+                        "thread": AnyCodable(try encodeThread(conflict.current))
+                    ])
+                } catch {
+                    respondWithError(callbackId, error.localizedDescription)
+                }
             } catch {
                 respondWithError(callbackId, error.localizedDescription)
             }
@@ -94,6 +142,38 @@ final class ThreadMessageHandler: BridgeMessageHandler {
         default:
             sendBridgeError(message.type, "Unsupported thread message")
         }
+    }
+
+    private func encodeThread(_ thread: StreamThread) throws -> [String: Any] {
+        let source = try thread.sourceId.flatMap { try persistence.loadSource(id: $0) }
+        let highlight = try source.flatMap { source in
+            try thread.highlightId.flatMap {
+                try persistence.loadPDFHighlight(id: $0, sourceId: source.id)
+            }
+        }
+        let exchanges = try persistence.loadThreadExchanges(
+            threadId: thread.threadId,
+            streamId: thread.streamId
+        )
+        let anchors = try persistence.loadStreamThreadAnchors(
+            threadId: thread.threadId,
+            streamId: thread.streamId
+        ).map { anchor in
+            let anchorSource = try anchor.sourceId.flatMap { try persistence.loadSource(id: $0) }
+            let anchorHighlight = try anchorSource.flatMap { source in
+                try anchor.highlightId.flatMap {
+                    try persistence.loadPDFHighlight(id: $0, sourceId: source.id)
+                }
+            }
+            return StreamCodec.encodeThreadAnchor(anchor, source: anchorSource, highlight: anchorHighlight)
+        }
+        return StreamCodec.encodeThread(
+            thread,
+            source: source,
+            highlight: highlight,
+            exchanges: exchanges,
+            anchors: anchors
+        )
     }
 
     private func respond(_ callbackId: String, _ payload: [String: AnyCodable]) {

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2328,7 +2328,7 @@ final class StreamDocumentTests: XCTestCase {
     }
 
     @MainActor
-    func test_threadBridgeSavesTitleWithRevisionCheck() async throws {
+    func test_threadBridgeCreatesLoadsAndSavesConversations() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Bridge conversations")
             let otherStream = Stream(title: "Other bridge stream")
@@ -2358,7 +2358,12 @@ final class StreamDocumentTests: XCTestCase {
                     ]))
                 }
             )
-            XCTAssertEqual(handler.handledTypes, ["listConversations", "saveStreamThread"])
+            XCTAssertEqual(handler.handledTypes, [
+                "listConversations",
+                "createStreamThread",
+                "loadStreamThread",
+                "saveStreamThread"
+            ])
 
             await handler.handle(BridgeMessage(
                 type: "listConversations",
@@ -2381,6 +2386,51 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertNotNil(conversations[0]["updatedAt"] as? String)
 
             await handler.handle(BridgeMessage(
+                type: "createStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "title": AnyCodable("Does this hold?"),
+                    "anchorStart": AnyCodable(1),
+                    "anchorEnd": AnyCodable(12),
+                    "anchorText": AnyCodable("Power budget")
+                ],
+                callbackId: "create"
+            ))
+            let createResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "create" }
+            )
+            let createdPayload = try XCTUnwrap(createResponse.payload?["thread"]?.value as? [String: Any])
+            let createdThreadId = try XCTUnwrap(UUID(uuidString: createdPayload["threadId"] as? String ?? ""))
+            XCTAssertEqual(createdPayload["anchorStart"] as? Int, 1)
+            XCTAssertEqual(createdPayload["anchorEnd"] as? Int, 12)
+            XCTAssertEqual(createdPayload["anchorText"] as? String, "Power budget")
+            XCTAssertEqual((createdPayload["exchanges"] as? [[String: Any]])?.count, 0)
+
+            try service.saveExchange(AIExchange(
+                requestId: "conversation-turn",
+                streamId: stream.id,
+                threadId: createdThreadId,
+                verb: "thread",
+                userInput: "Does this hold?",
+                responseRaw: "Yes."
+            ))
+            await handler.handle(BridgeMessage(
+                type: "loadStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "threadId": AnyCodable(createdThreadId.uuidString)
+                ],
+                callbackId: "load"
+            ))
+            let loadResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "load" }
+            )
+            let loadedPayload = try XCTUnwrap(loadResponse.payload?["thread"]?.value as? [String: Any])
+            let exchanges = try XCTUnwrap(loadedPayload["exchanges"] as? [[String: Any]])
+            XCTAssertEqual(exchanges.map { $0["requestId"] as? String }, ["conversation-turn"])
+            XCTAssertEqual(exchanges.first?["responseRaw"] as? String, "Yes.")
+
+            await handler.handle(BridgeMessage(
                 type: "saveStreamThread",
                 payload: [
                     "streamId": AnyCodable(stream.id.uuidString),
@@ -2399,6 +2449,8 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(savedPayload["workingText"] as? String, thread.workingText)
             XCTAssertEqual(savedPayload["docJSON"] as? String, docJSON)
             XCTAssertEqual(savedPayload["revision"] as? Int, 1)
+            XCTAssertNotNil(savedPayload["anchors"] as? [[String: Any]])
+            XCTAssertNotNil(savedPayload["exchanges"] as? [[String: Any]])
 
             await handler.handle(BridgeMessage(
                 type: "saveStreamThread",
@@ -2417,6 +2469,8 @@ final class StreamDocumentTests: XCTestCase {
             let conflictPayload = try XCTUnwrap(conflictResponse.payload?["thread"]?.value as? [String: Any])
             XCTAssertEqual(conflictPayload["title"] as? String, "Power budget")
             XCTAssertEqual(conflictPayload["workingText"] as? String, thread.workingText)
+            XCTAssertNotNil(conflictPayload["anchors"] as? [[String: Any]])
+            XCTAssertNotNil(conflictPayload["exchanges"] as? [[String: Any]])
 
             await handler.handle(BridgeMessage(
                 type: "saveStreamThread",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2361,6 +2361,7 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(handler.handledTypes, [
                 "listConversations",
                 "createStreamThread",
+                "deleteStreamThread",
                 "loadStreamThread",
                 "saveStreamThread"
             ])
@@ -2429,6 +2430,20 @@ final class StreamDocumentTests: XCTestCase {
             let exchanges = try XCTUnwrap(loadedPayload["exchanges"] as? [[String: Any]])
             XCTAssertEqual(exchanges.map { $0["requestId"] as? String }, ["conversation-turn"])
             XCTAssertEqual(exchanges.first?["responseRaw"] as? String, "Yes.")
+
+            await handler.handle(BridgeMessage(
+                type: "deleteStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "threadId": AnyCodable(createdThreadId.uuidString)
+                ],
+                callbackId: "delete"
+            ))
+            let deleteResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "delete" }
+            )
+            XCTAssertEqual(deleteResponse.payload?["highlightIds"]?.value as? [String], [])
+            XCTAssertNil(try service.loadStreamThread(threadId: createdThreadId, streamId: stream.id))
 
             await handler.handle(BridgeMessage(
                 type: "saveStreamThread",

--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -20,6 +20,7 @@ import { DocumentIcon, KeyIcon, Spinner, XIcon } from './components/icons';
 import { useToastStore } from './store/toastStore';
 import { debugError, debugLog } from './utils/debug';
 import { deserializeProvenanceSpans } from './utils/provenanceSpans';
+import { formatRelativeTime } from './utils/relativeTime';
 import {
   editorFontStack,
   normalizeEditorTypography,
@@ -644,22 +645,6 @@ interface StreamListViewProps {
   onCreate: () => void;
   onSettings: () => void;
   onRetry: () => void;
-}
-
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 30) return `${diffDays}d ago`;
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
-  return `${Math.floor(diffDays / 365)}y ago`;
 }
 
 function StreamListView({ streams, isLoading, error, onSelect, onCreate, onSettings, onRetry }: StreamListViewProps) {

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -1,19 +1,8 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { memo, useEffect, useRef, type KeyboardEvent } from 'react';
 import { bridge, loadStreamThread } from '../types/bridge';
 import type { AIExchangeJSON, SourceScope, StreamThreadJSON } from '../types/models';
 
-interface ConversationSurfaceProps {
-  streamId: string;
-  sourceScope: SourceScope;
-  threadId?: string;
-  anchorText: string;
-  focusComposer: boolean;
-  createThread: (query: string) => Promise<StreamThreadJSON>;
-  hasDrifted: (anchorText: string) => boolean;
-  onCollapse: () => void;
-}
-
-interface ActiveTurn {
+export interface ConversationActiveTurn {
   requestId: string;
   userInput: string;
   response: string;
@@ -21,9 +10,49 @@ interface ActiveTurn {
   error?: string;
 }
 
+export interface ConversationLiveState {
+  thread: StreamThreadJSON | null;
+  exchanges: AIExchangeJSON[];
+  composer: string;
+  active: ConversationActiveTurn | null;
+  loading: boolean;
+  loadError: boolean;
+  creating: boolean;
+  closing: boolean;
+  error: string | null;
+}
+
+export const initialConversationLiveState = (threadId?: string): ConversationLiveState => ({
+  thread: null,
+  exchanges: [],
+  composer: '',
+  active: null,
+  loading: Boolean(threadId),
+  loadError: false,
+  creating: false,
+  closing: false,
+  error: null,
+});
+
+type ConversationLiveStateUpdater = (current: ConversationLiveState) => ConversationLiveState;
+
+interface ConversationSurfaceProps {
+  conversationKey: string;
+  streamId: string;
+  sourceScope: SourceScope;
+  threadId?: string;
+  anchorText: string;
+  focusComposer: boolean;
+  state: ConversationLiveState;
+  updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
+  createThread: (query: string) => Promise<StreamThreadJSON>;
+  hasDrifted: (anchorText: string) => boolean;
+  onCollapse: () => void;
+}
+
 const copy = (text: string) => void navigator.clipboard?.writeText(text);
 
-function Turn({ who, text }: { who: 'You' | 'AI'; text: string }) {
+const Turn = memo(function Turn({ who, text }: { who: 'You' | 'AI'; text: string }) {
   return (
     <div className={`conversation-turn conversation-turn--${who === 'You' ? 'you' : 'ai'}`}>
       <span className="conversation-turn-label">{who}</span>
@@ -31,45 +60,51 @@ function Turn({ who, text }: { who: 'You' | 'AI'; text: string }) {
       <button type="button" className="conversation-turn-copy" onClick={() => copy(text)}>Copy</button>
     </div>
   );
-}
+});
 
 export function ConversationSurface({
+  conversationKey,
   streamId,
   sourceScope,
   threadId,
   anchorText,
   focusComposer,
+  state,
+  updateState,
   createThread,
   hasDrifted,
   onCollapse,
 }: ConversationSurfaceProps) {
   const composerRef = useRef<HTMLTextAreaElement>(null);
-  const collapseTimer = useRef<number>();
-  const [thread, setThread] = useState<StreamThreadJSON | null>(null);
-  const [exchanges, setExchanges] = useState<AIExchangeJSON[]>([]);
-  const [composer, setComposer] = useState('');
-  const [active, setActive] = useState<ActiveTurn | null>(null);
-  const [loading, setLoading] = useState(Boolean(threadId));
-  const [error, setError] = useState<string | null>(null);
-  const [closing, setClosing] = useState(false);
+  const stateRef = useRef(state);
+  const activeRequestId = useRef(state.active?.running ? state.active.requestId : null);
+  stateRef.current = state;
+  activeRequestId.current = state.active?.running ? state.active.requestId : null;
 
   useEffect(() => {
-    if (!threadId) return undefined;
+    if (!threadId || state.thread || !state.loading) return undefined;
     let live = true;
     void loadStreamThread(streamId, threadId)
       .then(({ thread: loaded }) => {
         if (!live) return;
-        setThread(loaded);
-        setExchanges(loaded.exchanges ?? []);
-        setLoading(false);
+        updateState(conversationKey, (current) => ({
+          ...current,
+          thread: loaded,
+          exchanges: loaded.exchanges ?? [],
+          loading: false,
+          loadError: false,
+        }));
       })
       .catch(() => {
         if (!live) return;
-        setError('This conversation could not be loaded.');
-        setLoading(false);
+        updateState(conversationKey, (current) => ({
+          ...current,
+          loading: false,
+          loadError: true,
+        }));
       });
     return () => { live = false; };
-  }, [streamId, threadId]);
+  }, [conversationKey, state.loading, state.thread, streamId, threadId, updateState]);
 
   useEffect(() => {
     if (!focusComposer) return;
@@ -78,60 +113,73 @@ export function ConversationSurface({
   }, [focusComposer]);
 
   useEffect(() => bridge.onMessage((message) => {
+    const requestId = activeRequestId.current;
     const payload = message.payload as Record<string, unknown> | undefined;
-    if (!active || payload?.requestId !== active.requestId) return;
+    if (!requestId || payload?.requestId !== requestId) return;
     if (message.type === 'documentAIChunk' && typeof payload.chunk === 'string') {
-      setActive((current) => current?.requestId === active.requestId
-        ? { ...current, response: current.response + payload.chunk }
+      updateState(conversationKey, (current) => current.active?.requestId === requestId
+        ? { ...current, active: { ...current.active, response: current.active.response + payload.chunk } }
         : current);
       return;
     }
     if (message.type === 'documentAIComplete') {
+      activeRequestId.current = null;
       const exchange = payload.exchange as AIExchangeJSON | undefined;
-      if (exchange?.requestId === active.requestId) setExchanges((current) => [...current, exchange]);
-      setActive(null);
+      updateState(conversationKey, (current) => ({
+        ...current,
+        exchanges: exchange?.requestId === requestId
+          ? [...current.exchanges, exchange]
+          : current.exchanges,
+        active: null,
+      }));
       return;
     }
     if (message.type === 'documentAIError') {
-      setActive((current) => current?.requestId === active.requestId
+      activeRequestId.current = null;
+      updateState(conversationKey, (current) => current.active?.requestId === requestId
         ? {
           ...current,
-          running: false,
-          error: payload.errorCode === 'cancelled'
-            ? 'Stopped.'
-            : typeof payload.error === 'string' ? payload.error : 'AI request failed.',
+          active: {
+            ...current.active,
+            running: false,
+            error: payload.errorCode === 'cancelled'
+              ? 'Stopped.'
+              : typeof payload.error === 'string' ? payload.error : 'AI request failed.',
+          },
         }
         : current);
     }
-  }), [active]);
-
-  useEffect(() => () => {
-    if (collapseTimer.current !== undefined) window.clearTimeout(collapseTimer.current);
-  }, []);
-
-  const collapse = () => {
-    if (closing) return;
-    setClosing(true);
-    collapseTimer.current = window.setTimeout(onCollapse, 150);
-  };
+  }), [conversationKey, updateState]);
 
   const send = async () => {
-    const query = composer.trim();
-    if (!query || active?.running) return;
-    setError(null);
-    let current = thread;
-    if (!current) {
+    const snapshot = stateRef.current;
+    const query = snapshot.composer.trim();
+    if (!query || snapshot.active?.running || snapshot.loading || snapshot.creating) return;
+    if (threadId && !snapshot.thread) return;
+    let current = snapshot.thread;
+    if (!current && !threadId) {
+      updateState(conversationKey, (value) => ({ ...value, creating: true, error: null }));
       try {
         current = await createThread(query);
-        setThread(current);
+        updateState(conversationKey, (value) => ({ ...value, thread: current!, creating: false }));
       } catch {
-        setError('This conversation could not be created.');
+        updateState(conversationKey, (value) => ({
+          ...value,
+          creating: false,
+          error: 'This conversation could not be created.',
+        }));
         return;
       }
     }
+    if (!current) return;
     const requestId = crypto.randomUUID();
-    setComposer('');
-    setActive({ requestId, userInput: query, response: '', running: true });
+    activeRequestId.current = requestId;
+    updateState(conversationKey, (value) => ({
+      ...value,
+      composer: '',
+      error: null,
+      active: { requestId, userInput: query, response: '', running: true },
+    }));
     bridge.send({
       type: 'thinkDocument',
       payload: {
@@ -150,59 +198,74 @@ export function ConversationSurface({
     if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
       event.preventDefault();
       void send();
-    } else if (event.key === 'Escape' && composer.length === 0) {
+    } else if (event.key === 'Escape' && state.composer.length === 0) {
       event.preventDefault();
-      collapse();
+      onCollapse();
     }
   };
 
-  const originalAnchorText = thread?.anchorText ?? anchorText;
+  const retryLoad = () => updateState(conversationKey, (current) => ({
+    ...current,
+    loading: true,
+    loadError: false,
+  }));
+  const originalAnchorText = state.thread?.anchorText ?? anchorText;
+  const sendDisabled = !state.composer.trim() || state.loading || state.creating
+    || Boolean(threadId && !state.thread);
   return (
-    <section className={`conversation-surface ${closing ? 'conversation-surface--closing' : ''}`}>
-      <button type="button" className="conversation-rail" aria-label="Collapse conversation" onClick={collapse} />
+    <section className={`conversation-surface ${state.closing ? 'conversation-surface--closing' : ''}`}>
+      <button type="button" className="conversation-rail" aria-label="Collapse conversation" onClick={onCollapse} />
       <div className="conversation-content">
         {hasDrifted(originalAnchorText) && (
           <p className="conversation-drift-note">The passage has changed since this conversation started.</p>
         )}
-        {loading && <p className="conversation-status">Loading conversation…</p>}
-        {exchanges.map((exchange) => (
+        {state.loading && <p className="conversation-status">Loading conversation…</p>}
+        {state.loadError && (
+          <p className="conversation-load-error">
+            This conversation could not be loaded. <button type="button" onClick={retryLoad}>Retry</button>
+          </p>
+        )}
+        {state.exchanges.map((exchange) => (
           <div className="conversation-exchange" key={exchange.requestId}>
             <Turn who="You" text={exchange.userInput} />
             <Turn who="AI" text={exchange.responseRaw} />
           </div>
         ))}
-        {active && (
+        {state.active && (
           <div className="conversation-exchange">
-            <Turn who="You" text={active.userInput} />
-            <Turn who="AI" text={active.response || active.error || 'Thinking…'} />
+            <Turn who="You" text={state.active.userInput} />
+            <Turn who="AI" text={state.active.response || state.active.error || 'Thinking…'} />
           </div>
         )}
-        {error && <p className="conversation-error" role="alert">{error}</p>}
+        {state.error && <p className="conversation-error" role="alert">{state.error}</p>}
         <div className="conversation-composer-row">
           <textarea
             ref={composerRef}
             className="conversation-composer"
-            value={composer}
-            onChange={(event) => setComposer(event.target.value)}
+            value={state.composer}
+            onChange={(event) => updateState(conversationKey, (current) => ({
+              ...current,
+              composer: event.target.value,
+            }))}
             onKeyDown={handleComposerKeyDown}
             placeholder="Ask — sees this block, the Stream, and sources"
             rows={2}
             aria-label="Conversation message"
           />
-          {active?.running ? (
+          {state.active?.running ? (
             <button
               type="button"
               className="conversation-stop"
               onClick={() => bridge.send({
                 type: 'cancelDocumentAI',
-                payload: { requestId: active.requestId },
+                payload: { requestId: state.active!.requestId },
               })}
             >
               Stop
             </button>
           ) : (
-            <button type="button" className="conversation-send" disabled={!composer.trim()} onClick={() => void send()}>
-              Send ⌘↵
+            <button type="button" className="conversation-send" disabled={sendDisabled} onClick={() => void send()}>
+              {state.creating ? 'Starting…' : 'Send ⌘↵'}
             </button>
           )}
         </div>

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { bridge, loadStreamThread } from '../types/bridge';
+import type { AIExchangeJSON, SourceScope, StreamThreadJSON } from '../types/models';
+
+interface ConversationSurfaceProps {
+  streamId: string;
+  sourceScope: SourceScope;
+  threadId?: string;
+  anchorText: string;
+  focusComposer: boolean;
+  createThread: (query: string) => Promise<StreamThreadJSON>;
+  hasDrifted: (anchorText: string) => boolean;
+  onCollapse: () => void;
+}
+
+interface ActiveTurn {
+  requestId: string;
+  userInput: string;
+  response: string;
+  running: boolean;
+  error?: string;
+}
+
+const copy = (text: string) => void navigator.clipboard?.writeText(text);
+
+function Turn({ who, text }: { who: 'You' | 'AI'; text: string }) {
+  return (
+    <div className={`conversation-turn conversation-turn--${who === 'You' ? 'you' : 'ai'}`}>
+      <span className="conversation-turn-label">{who}</span>
+      <div className="conversation-turn-text">{text}</div>
+      <button type="button" className="conversation-turn-copy" onClick={() => copy(text)}>Copy</button>
+    </div>
+  );
+}
+
+export function ConversationSurface({
+  streamId,
+  sourceScope,
+  threadId,
+  anchorText,
+  focusComposer,
+  createThread,
+  hasDrifted,
+  onCollapse,
+}: ConversationSurfaceProps) {
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  const collapseTimer = useRef<number>();
+  const [thread, setThread] = useState<StreamThreadJSON | null>(null);
+  const [exchanges, setExchanges] = useState<AIExchangeJSON[]>([]);
+  const [composer, setComposer] = useState('');
+  const [active, setActive] = useState<ActiveTurn | null>(null);
+  const [loading, setLoading] = useState(Boolean(threadId));
+  const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    if (!threadId) return undefined;
+    let live = true;
+    void loadStreamThread(streamId, threadId)
+      .then(({ thread: loaded }) => {
+        if (!live) return;
+        setThread(loaded);
+        setExchanges(loaded.exchanges ?? []);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!live) return;
+        setError('This conversation could not be loaded.');
+        setLoading(false);
+      });
+    return () => { live = false; };
+  }, [streamId, threadId]);
+
+  useEffect(() => {
+    if (!focusComposer) return;
+    const frame = window.requestAnimationFrame(() => composerRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusComposer]);
+
+  useEffect(() => bridge.onMessage((message) => {
+    const payload = message.payload as Record<string, unknown> | undefined;
+    if (!active || payload?.requestId !== active.requestId) return;
+    if (message.type === 'documentAIChunk' && typeof payload.chunk === 'string') {
+      setActive((current) => current?.requestId === active.requestId
+        ? { ...current, response: current.response + payload.chunk }
+        : current);
+      return;
+    }
+    if (message.type === 'documentAIComplete') {
+      const exchange = payload.exchange as AIExchangeJSON | undefined;
+      if (exchange?.requestId === active.requestId) setExchanges((current) => [...current, exchange]);
+      setActive(null);
+      return;
+    }
+    if (message.type === 'documentAIError') {
+      setActive((current) => current?.requestId === active.requestId
+        ? {
+          ...current,
+          running: false,
+          error: payload.errorCode === 'cancelled'
+            ? 'Stopped.'
+            : typeof payload.error === 'string' ? payload.error : 'AI request failed.',
+        }
+        : current);
+    }
+  }), [active]);
+
+  useEffect(() => () => {
+    if (collapseTimer.current !== undefined) window.clearTimeout(collapseTimer.current);
+  }, []);
+
+  const collapse = () => {
+    if (closing) return;
+    setClosing(true);
+    collapseTimer.current = window.setTimeout(onCollapse, 150);
+  };
+
+  const send = async () => {
+    const query = composer.trim();
+    if (!query || active?.running) return;
+    setError(null);
+    let current = thread;
+    if (!current) {
+      try {
+        current = await createThread(query);
+        setThread(current);
+      } catch {
+        setError('This conversation could not be created.');
+        return;
+      }
+    }
+    const requestId = crypto.randomUUID();
+    setComposer('');
+    setActive({ requestId, userInput: query, response: '', running: true });
+    bridge.send({
+      type: 'thinkDocument',
+      payload: {
+        requestId,
+        streamId,
+        threadId: current.threadId,
+        query,
+        imageURLs: [],
+        sourceScope,
+        verb: 'develop',
+      },
+    });
+  };
+
+  const handleComposerKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault();
+      void send();
+    } else if (event.key === 'Escape' && composer.length === 0) {
+      event.preventDefault();
+      collapse();
+    }
+  };
+
+  const originalAnchorText = thread?.anchorText ?? anchorText;
+  return (
+    <section className={`conversation-surface ${closing ? 'conversation-surface--closing' : ''}`}>
+      <button type="button" className="conversation-rail" aria-label="Collapse conversation" onClick={collapse} />
+      <div className="conversation-content">
+        {hasDrifted(originalAnchorText) && (
+          <p className="conversation-drift-note">The passage has changed since this conversation started.</p>
+        )}
+        {loading && <p className="conversation-status">Loading conversation…</p>}
+        {exchanges.map((exchange) => (
+          <div className="conversation-exchange" key={exchange.requestId}>
+            <Turn who="You" text={exchange.userInput} />
+            <Turn who="AI" text={exchange.responseRaw} />
+          </div>
+        ))}
+        {active && (
+          <div className="conversation-exchange">
+            <Turn who="You" text={active.userInput} />
+            <Turn who="AI" text={active.response || active.error || 'Thinking…'} />
+          </div>
+        )}
+        {error && <p className="conversation-error" role="alert">{error}</p>}
+        <div className="conversation-composer-row">
+          <textarea
+            ref={composerRef}
+            className="conversation-composer"
+            value={composer}
+            onChange={(event) => setComposer(event.target.value)}
+            onKeyDown={handleComposerKeyDown}
+            placeholder="Ask — sees this block, the Stream, and sources"
+            rows={2}
+            aria-label="Conversation message"
+          />
+          {active?.running ? (
+            <button
+              type="button"
+              className="conversation-stop"
+              onClick={() => bridge.send({
+                type: 'cancelDocumentAI',
+                payload: { requestId: active.requestId },
+              })}
+            >
+              Stop
+            </button>
+          ) : (
+            <button type="button" className="conversation-send" disabled={!composer.trim()} onClick={() => void send()}>
+              Send ⌘↵
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -449,8 +449,6 @@ describe('RichStreamEditor inline conversations', () => {
   it('collapses an unsent draft without creating a row or leaving a glyph', async () => {
     const composer = await openDraftConversation();
     await vi.waitFor(() => expect(document.activeElement).toBe(composer));
-    expect(composer.tabIndex).toBe(0);
-    expect((composer.closest('.conversation-widget-host') as HTMLElement).contentEditable).toBe('false');
     expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
 
     await act(async () => {
@@ -488,6 +486,7 @@ describe('RichStreamEditor inline conversations', () => {
       }
       return { revision: 2 };
     }) as typeof bridge.sendAsync);
+    const subscribe = vi.spyOn(bridge, 'onMessage');
     const composer = await openDraftConversation();
     await enterConversationMessage(composer, 'Does this hold?');
 
@@ -513,8 +512,10 @@ describe('RichStreamEditor inline conversations', () => {
     const requestId = String(sent.find((message) => message.type === 'thinkDocument')?.payload?.requestId);
     await act(async () => {
       bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: 'It streams.' } });
+      bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: ' Live.' } });
     });
-    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams.');
+    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams. Live.');
+    expect(subscribe).toHaveBeenCalledTimes(1);
     await act(async () => {
       (document.querySelector('.conversation-stop') as HTMLButtonElement).click();
       await Promise.resolve();
@@ -536,14 +537,14 @@ describe('RichStreamEditor inline conversations', () => {
             verb: 'thread',
             userInput: 'Does this hold?',
             sourceManifest: '[]',
-            responseRaw: 'It streams.',
+            responseRaw: 'It streams. Live.',
             createdAt,
           },
         },
       });
     });
     expect(document.querySelector('.conversation-stop')).toBe(null);
-    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams.');
+    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams. Live.');
 
     await vi.waitFor(() => {
       const save = vi.mocked(bridge.sendAsync).mock.calls
@@ -558,7 +559,12 @@ describe('RichStreamEditor inline conversations', () => {
     const anchored: Stream = {
       ...stream,
       id: 'conversation-stream',
-      document: { ...stream.document, streamId: 'conversation-stream' },
+      document: {
+        ...stream.document,
+        streamId: 'conversation-stream',
+        docJSON: docJSON('Original paragraph.\n\nFollowing paragraph.'),
+        markdown: 'Original paragraph.\n\nFollowing paragraph.',
+      },
       conversationAnchors: [{
         threadId: 'thread-existing',
         anchorStart: 1,
@@ -619,6 +625,274 @@ describe('RichStreamEditor inline conversations', () => {
     expect(scroller.scrollTop).toBe(37);
     expect(document.querySelectorAll('.conversation-widget-host')).toHaveLength(1);
     expect(document.activeElement).toBe(editor());
+
+    const tab = new KeyboardEvent('keydown', {
+      key: 'Tab', bubbles: true, cancelable: true,
+    });
+    await act(async () => { editor().dispatchEvent(tab); });
+    expect(tab.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(document.querySelector('.conversation-composer'));
+  });
+
+  it('keeps send disabled until a persisted conversation loads successfully', async () => {
+    const updatedAt = new Date().toISOString();
+    const anchored: Stream = {
+      ...stream,
+      id: 'loading-conversation-stream',
+      document: { ...stream.document, streamId: 'loading-conversation-stream' },
+      conversationAnchors: [{
+        threadId: 'thread-loading',
+        anchorStart: 1,
+        anchorEnd: 20,
+        anchorText: 'Original paragraph.',
+        detached: false,
+        ephemeral: false,
+        updatedAt,
+      }],
+    };
+    let rejectLoad: ((reason?: unknown) => void) | undefined;
+    let loadAttempts = 0;
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type) => {
+      if (type === 'loadStreamThread') {
+        loadAttempts += 1;
+        if (loadAttempts === 1) {
+          return new Promise((_resolve, reject) => { rejectLoad = reject; });
+        }
+        return {
+          thread: {
+            threadId: 'thread-loading',
+            streamId: anchored.id,
+            title: 'Existing conversation',
+            workingText: '',
+            anchorText: 'Original paragraph.',
+            anchorStart: 1,
+            anchorEnd: 20,
+            detached: false,
+            ephemeral: false,
+            revision: 0,
+            createdAt: updatedAt,
+            updatedAt,
+            exchanges: [],
+          },
+        };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    await renderStream(anchored);
+    const block = editor().querySelector('p') as HTMLParagraphElement;
+    await vi.waitFor(() => expect(block.classList.contains('conversation-block-anchored')).toBe(true));
+    vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+      left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+      toJSON: () => ({}),
+    });
+    await act(async () => {
+      block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
+      await Promise.resolve();
+    });
+    const composer = await vi.waitFor(() => document.querySelector('.conversation-composer') as HTMLTextAreaElement);
+    await enterConversationMessage(composer, 'Do not duplicate this.');
+    expect((document.querySelector('.conversation-send') as HTMLButtonElement).disabled).toBe(true);
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+    });
+    expect(sent.some((message) => message.type === 'thinkDocument')).toBe(false);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+
+    await act(async () => { rejectLoad?.(new Error('offline')); });
+    const retry = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-load-error button') as HTMLButtonElement | null;
+      expect(found?.textContent).toBe('Retry');
+      return found!;
+    });
+    expect((document.querySelector('.conversation-send') as HTMLButtonElement).disabled).toBe(true);
+    await act(async () => {
+      retry.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(loadAttempts).toBe(2);
+      expect((document.querySelector('.conversation-send') as HTMLButtonElement).disabled).toBe(false);
+    });
+    await act(async () => {
+      (document.querySelector('.conversation-composer') as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+  });
+
+  it('keeps a detached draft surface and its composer text at the document end', async () => {
+    let liveView: EditorView | null = null;
+    const updateState = EditorView.prototype.updateState;
+    vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+      this: EditorView,
+      state,
+    ) {
+      liveView = this;
+      return updateState.call(this, state);
+    });
+    await renderStream({
+      ...stream,
+      id: 'detaching-draft-stream',
+      document: { ...stream.document, streamId: 'detaching-draft-stream' },
+    });
+    const composer = await openDraftConversation();
+    await enterConversationMessage(composer, 'Keep this draft.');
+
+    await act(async () => {
+      liveView!.dispatch(liveView!.state.tr.delete(1, 20));
+      await Promise.resolve();
+    });
+
+    const moved = await vi.waitFor(() => document.querySelector('.conversation-composer') as HTMLTextAreaElement);
+    expect(moved.value).toBe('Keep this draft.');
+    expect(document.querySelector('.conversation-drift-note')?.textContent)
+      .toBe('The passage has changed since this conversation started.');
+    expect(editor().lastElementChild?.classList.contains('conversation-widget-host')).toBe(true);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+  });
+
+  it.each(['collapse', 'editor unmount'] as const)(
+    'cancels an in-flight conversation on %s',
+    async (exit) => {
+      const createdAt = new Date(0).toISOString();
+      vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+        if (type === 'createStreamThread') {
+          return {
+            thread: {
+              threadId: `thread-${exit}`,
+              streamId: stream.id,
+              title: String(payload?.title),
+              workingText: '',
+              anchorText: String(payload?.anchorText),
+              anchorStart: Number(payload?.anchorStart),
+              anchorEnd: Number(payload?.anchorEnd),
+              detached: false,
+              ephemeral: false,
+              revision: 0,
+              createdAt,
+              updatedAt: createdAt,
+              exchanges: [],
+            },
+          };
+        }
+        return { revision: 2 };
+      }) as typeof bridge.sendAsync);
+      const composer = await openDraftConversation();
+      await enterConversationMessage(composer, 'Keep or cancel?');
+      await act(async () => {
+        composer.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+        }));
+        await Promise.resolve();
+      });
+      const requestId = activeRequestId();
+
+      if (exit === 'collapse') {
+        await act(async () => {
+          (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
+          await new Promise((resolve) => window.setTimeout(resolve, 160));
+        });
+        expect(document.querySelector('.conversation-surface')).toBe(null);
+      } else {
+        await act(async () => {
+          root?.unmount();
+          await Promise.resolve();
+        });
+        root = null;
+      }
+      expect(sent).toContainEqual({
+        type: 'cancelDocumentAI',
+        payload: { requestId },
+      });
+    },
+  );
+
+  it('preserves composer and streamed text when a conflict reload remounts the portal', async () => {
+    const updatedAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') {
+        return {
+          thread: {
+            threadId: 'thread-reloaded',
+            streamId: stream.id,
+            title: String(payload?.title),
+            workingText: '',
+            anchorText: String(payload?.anchorText),
+            anchorStart: Number(payload?.anchorStart),
+            anchorEnd: Number(payload?.anchorEnd),
+            detached: false,
+            ephemeral: false,
+            revision: 0,
+            createdAt: updatedAt,
+            updatedAt,
+            exchanges: [],
+          },
+        };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const composer = await openDraftConversation();
+    await enterConversationMessage(composer, 'First question');
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    const requestId = activeRequestId();
+    await vi.waitFor(() => {
+      expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'saveRichStreamDocument')).toBe(true);
+    });
+    await act(async () => {
+      bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: 'Partial answer.' } });
+    });
+    await enterConversationMessage(
+      document.querySelector('.conversation-composer') as HTMLTextAreaElement,
+      'Follow-up draft',
+    );
+    const oldHost = document.querySelector('.conversation-widget-host');
+
+    await act(async () => {
+      bridge.receive({
+        type: 'streamDocumentConflict',
+        payload: {
+          streamId: stream.id,
+          docJSON: docJSON('Original paragraph.\n\nFrom elsewhere.'),
+          docFormatVersion: 1,
+          markdown: 'Original paragraph.\n\nFrom elsewhere.',
+          revision: 3,
+          spans: [],
+          conversationAnchors: [{
+            threadId: 'thread-reloaded',
+            anchorStart: 1,
+            anchorEnd: 20,
+            anchorText: 'Original paragraph.',
+            detached: false,
+            ephemeral: false,
+            updatedAt,
+          }],
+          pendingAppends: [],
+          appendInbox: [],
+        },
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      const newHost = document.querySelector('.conversation-widget-host');
+      expect(newHost).not.toBe(oldHost);
+      expect((newHost?.querySelector('.conversation-composer') as HTMLTextAreaElement).value)
+        .toBe('Follow-up draft');
+      expect(newHost?.querySelector('.conversation-turn--ai')?.textContent).toContain('Partial answer.');
+    });
+    expect(sent).not.toContainEqual({ type: 'cancelDocumentAI', payload: { requestId } });
   });
 
   it('lists, opens, and deletes a detached conversation from header overflow', async () => {
@@ -686,7 +960,6 @@ describe('RichStreamEditor inline conversations', () => {
     expect(document.querySelector('.conversation-drift-note')?.textContent)
       .toBe('The passage has changed since this conversation started.');
 
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await act(async () => {
       conversations.click();
       await Promise.resolve();
@@ -694,6 +967,12 @@ describe('RichStreamEditor inline conversations', () => {
     await vi.waitFor(() => expect(document.querySelector('.conversation-list-delete')).not.toBe(null));
     await act(async () => {
       (document.querySelector('.conversation-list-delete') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(document.querySelector('.conversation-delete-confirm-dialog')).not.toBe(null);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'deleteStreamThread')).toBe(false);
+    await act(async () => {
+      (document.querySelector('.conversation-delete-confirm-delete') as HTMLButtonElement).click();
       await Promise.resolve();
     });
     expect(vi.mocked(bridge.sendAsync).mock.calls).toContainEqual([

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -343,7 +343,7 @@ describe('RichStreamEditor chrome parity', () => {
     expect(document.querySelector('.stream-xray-button')?.textContent).toBe('');
     expect(document.querySelector('.stream-overflow-menu')).not.toBe(null);
     expect([...document.querySelectorAll('.stream-overflow-panel button')]
-      .map((button) => button.textContent?.trim())).toEqual(['Delete stream…']);
+      .map((button) => button.textContent?.trim())).toEqual(['Conversations', 'Delete stream…']);
     expect(document.querySelector('.delete-button')).toBe(null);
     expect(document.querySelector('.stream-format-bar')).toBe(null);
     expect(document.querySelector('.selection-action-menu')).toBe(null);
@@ -449,6 +449,8 @@ describe('RichStreamEditor inline conversations', () => {
   it('collapses an unsent draft without creating a row or leaving a glyph', async () => {
     const composer = await openDraftConversation();
     await vi.waitFor(() => expect(document.activeElement).toBe(composer));
+    expect(composer.tabIndex).toBe(0);
+    expect((composer.closest('.conversation-widget-host') as HTMLElement).contentEditable).toBe('false');
     expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
 
     await act(async () => {
@@ -513,6 +515,14 @@ describe('RichStreamEditor inline conversations', () => {
       bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: 'It streams.' } });
     });
     expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams.');
+    await act(async () => {
+      (document.querySelector('.conversation-stop') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(sent).toContainEqual({
+      type: 'cancelDocumentAI',
+      payload: { requestId },
+    });
 
     await act(async () => {
       bridge.receive({
@@ -599,6 +609,7 @@ describe('RichStreamEditor inline conversations', () => {
     });
     const scroller = document.querySelector('.stream-content') as HTMLElement;
     scroller.scrollTop = 37;
+    editor().focus();
     await act(async () => {
       block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
       await Promise.resolve();
@@ -607,6 +618,89 @@ describe('RichStreamEditor inline conversations', () => {
     await vi.waitFor(() => expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('Because.'));
     expect(scroller.scrollTop).toBe(37);
     expect(document.querySelectorAll('.conversation-widget-host')).toHaveLength(1);
+    expect(document.activeElement).toBe(editor());
+  });
+
+  it('lists, opens, and deletes a detached conversation from header overflow', async () => {
+    const updatedAt = new Date().toISOString();
+    const record = {
+      threadId: 'thread-detached',
+      anchorStart: null,
+      anchorEnd: null,
+      anchorText: 'Original passage',
+      detached: true,
+      ephemeral: false,
+      updatedAt,
+    };
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type) => {
+      if (type === 'listConversations') return { conversations: [record] };
+      if (type === 'loadStreamThread') {
+        return {
+          thread: {
+            threadId: record.threadId,
+            streamId: stream.id,
+            title: 'Detached question',
+            workingText: '',
+            anchorText: record.anchorText,
+            detached: true,
+            ephemeral: false,
+            revision: 0,
+            createdAt: updatedAt,
+            updatedAt,
+            exchanges: [{
+              requestId: 'detached-exchange',
+              streamId: stream.id,
+              threadId: record.threadId,
+              verb: 'thread',
+              userInput: 'Where did it go?',
+              sourceManifest: '[]',
+              responseRaw: 'The passage was removed.',
+              createdAt: updatedAt,
+            }],
+          },
+        };
+      }
+      if (type === 'deleteStreamThread') return { highlightIds: [] };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+
+    const conversations = document.querySelector('.stream-overflow-action') as HTMLButtonElement;
+    await act(async () => {
+      conversations.click();
+      await Promise.resolve();
+    });
+    const row = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-list-row');
+      expect(found?.textContent).toContain('Original passage');
+      expect(found?.textContent).toContain('detached');
+      return found!;
+    });
+    await act(async () => {
+      (row.querySelector('.conversation-list-open') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(document.querySelector('.conversation-turn--ai')?.textContent)
+        .toContain('The passage was removed.');
+    });
+    expect(document.querySelector('.conversation-drift-note')?.textContent)
+      .toBe('The passage has changed since this conversation started.');
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await act(async () => {
+      conversations.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-list-delete')).not.toBe(null));
+    await act(async () => {
+      (document.querySelector('.conversation-list-delete') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(bridge.sendAsync).mock.calls).toContainEqual([
+      'deleteStreamThread',
+      { streamId: stream.id, threadId: record.threadId },
+    ]);
+    expect(document.querySelector('.conversation-list-row')).toBe(null);
   });
 });
 

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -141,6 +141,33 @@ async function enterPrompt(value: string) {
   });
 }
 
+async function openDraftConversation(): Promise<HTMLTextAreaElement> {
+  const block = editor().querySelector('p') as HTMLParagraphElement;
+  await vi.waitFor(() => expect(block.classList.contains('conversation-block-active')).toBe(true));
+  vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+    left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+    toJSON: () => ({}),
+  });
+  await act(async () => {
+    block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 0 }));
+    await Promise.resolve();
+  });
+  const composer = await vi.waitFor(() => {
+    const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+    expect(found).not.toBe(null);
+    return found!;
+  });
+  return composer;
+}
+
+async function enterConversationMessage(input: HTMLTextAreaElement, value: string) {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
 function activeRequestId(): string {
   const messages = sent.filter((candidate) => candidate.type === 'thinkDocument');
   const message = messages[messages.length - 1];
@@ -415,6 +442,171 @@ describe('RichStreamEditor chrome parity', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('RichStreamEditor inline conversations', () => {
+  it('collapses an unsent draft without creating a row or leaving a glyph', async () => {
+    const composer = await openDraftConversation();
+    await vi.waitFor(() => expect(document.activeElement).toBe(composer));
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+    });
+
+    expect(document.querySelector('.conversation-surface')).toBe(null);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+    expect(editor().querySelector('p')?.classList.contains('conversation-block-anchored')).toBe(false);
+    await vi.waitFor(() => expect(document.activeElement).toBe(editor()));
+  });
+
+  it('creates on first send, streams the AI turn, and keeps the widget out of the document save', async () => {
+    const createdAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') {
+        return {
+          thread: {
+            threadId: 'thread-created',
+            streamId: stream.id,
+            title: String(payload?.title),
+            workingText: '',
+            anchorText: String(payload?.anchorText),
+            anchorStart: Number(payload?.anchorStart),
+            anchorEnd: Number(payload?.anchorEnd),
+            detached: false,
+            ephemeral: false,
+            revision: 0,
+            createdAt,
+            updatedAt: createdAt,
+            exchanges: [],
+          },
+        };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const composer = await openDraftConversation();
+    await enterConversationMessage(composer, 'Does this hold?');
+
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+
+    const createCall = vi.mocked(bridge.sendAsync).mock.calls
+      .find(([type]) => type === 'createStreamThread');
+    expect(createCall?.[1]).toMatchObject({
+      streamId: stream.id,
+      title: 'Does this hold?',
+      anchorText: 'Original paragraph.',
+    });
+    expect(Number(createCall?.[1]?.anchorEnd)).toBeGreaterThan(Number(createCall?.[1]?.anchorStart));
+    expect(editor().querySelector('p')?.classList.contains('conversation-block-anchored')).toBe(true);
+    expect(document.querySelector('.conversation-stop')).not.toBe(null);
+
+    const requestId = String(sent.find((message) => message.type === 'thinkDocument')?.payload?.requestId);
+    await act(async () => {
+      bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: 'It streams.' } });
+    });
+    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams.');
+
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: {
+            requestId,
+            streamId: stream.id,
+            threadId: 'thread-created',
+            verb: 'thread',
+            userInput: 'Does this hold?',
+            sourceManifest: '[]',
+            responseRaw: 'It streams.',
+            createdAt,
+          },
+        },
+      });
+    });
+    expect(document.querySelector('.conversation-stop')).toBe(null);
+    expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams.');
+
+    await vi.waitFor(() => {
+      const save = vi.mocked(bridge.sendAsync).mock.calls
+        .find(([type]) => type === 'saveRichStreamDocument');
+      expect(save?.[1]?.docJSON).not.toContain('Does this hold?');
+      expect(save?.[1]?.docJSON).not.toContain('It streams.');
+    });
+  });
+
+  it('opens a persisted glyph in place and restores its saved turns', async () => {
+    const updatedAt = new Date().toISOString();
+    const anchored: Stream = {
+      ...stream,
+      id: 'conversation-stream',
+      document: { ...stream.document, streamId: 'conversation-stream' },
+      conversationAnchors: [{
+        threadId: 'thread-existing',
+        anchorStart: 1,
+        anchorEnd: 20,
+        anchorText: 'Original paragraph.',
+        detached: false,
+        ephemeral: false,
+        updatedAt,
+      }],
+    };
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type) => {
+      if (type === 'loadStreamThread') {
+        return {
+          thread: {
+            threadId: 'thread-existing',
+            streamId: anchored.id,
+            title: 'Why?',
+            workingText: '',
+            anchorText: 'Original paragraph.',
+            anchorStart: 1,
+            anchorEnd: 20,
+            detached: false,
+            ephemeral: false,
+            revision: 0,
+            createdAt: updatedAt,
+            updatedAt,
+            exchanges: [{
+              requestId: 'exchange-1',
+              streamId: anchored.id,
+              threadId: 'thread-existing',
+              verb: 'thread',
+              userInput: 'Why?',
+              sourceManifest: '[]',
+              responseRaw: 'Because.',
+              createdAt: updatedAt,
+            }],
+          },
+        };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    await renderStream(anchored);
+    const block = editor().querySelector('p') as HTMLParagraphElement;
+    await vi.waitFor(() => expect(block.classList.contains('conversation-block-anchored')).toBe(true));
+    vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+      left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+      toJSON: () => ({}),
+    });
+    const scroller = document.querySelector('.stream-content') as HTMLElement;
+    scroller.scrollTop = 37;
+    await act(async () => {
+      block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('Because.'));
+    expect(scroller.scrollTop).toBe(37);
+    expect(document.querySelectorAll('.conversation-widget-host')).toHaveLength(1);
   });
 });
 

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -6,10 +6,12 @@ import {
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
+import { createPortal } from 'react-dom';
 import type { Slice } from 'prosemirror-model';
 import { TextSelection, type Command, type Transaction } from 'prosemirror-state';
 import {
   bridge,
+  createStreamThread,
   getExchange,
   type DocumentAIVerb,
   type SourceTitlePayload,
@@ -17,11 +19,14 @@ import {
 } from '../types/bridge';
 import type {
   AIExchangeJSON,
+  ConversationAnchorJSON,
   SourceReference,
   SourceScope,
   Stream,
   StreamAppendInboxJSON,
+  StreamThreadJSON,
 } from '../types/models';
+import { ConversationSurface } from './ConversationSurface';
 import { ExchangeOverlay, type ExchangeManifestEntry } from './ExchangeOverlay';
 import { EyeIcon, XIcon } from './icons';
 import { Modal } from './Modal';
@@ -32,7 +37,18 @@ import {
   type PDFSectionActionRequest,
 } from './StreamEditor';
 import { createRichTextEditor, type RichTextEditor } from '../richtext/editor';
-import { conversationAnchorFromJSON, refreshConversationViewport } from '../richtext/conversationAnchors';
+import {
+  conversationAnchorFromJSON,
+  conversationAnchorTextForStorage,
+  conversationAnchors,
+  conversationRenderPosition,
+  conversationSurface,
+  hasConversationAnchorTextDrifted,
+  refreshConversationViewport,
+  setConversationAnchors,
+  setConversationSurface,
+  type ConversationAnchor,
+} from '../richtext/conversationAnchors';
 import {
   aiWritingRange,
   insertImage,
@@ -147,6 +163,14 @@ interface SelectionMenuState {
   to: number;
 }
 
+interface ExpandedConversation {
+  key: string;
+  threadId?: string;
+  anchor?: ConversationAnchor;
+  anchorText: string;
+  focusComposer: boolean;
+}
+
 function documentAITarget(editor: RichTextEditor): { from: number; to: number; text: string } | null {
   const { doc, selection } = editor.view.state;
   const from = selection.empty ? selection.$head.start() : selection.from;
@@ -197,6 +221,7 @@ export function RichStreamEditor({
   // PDF jobs ever become a supported workflow.
   const pdfAIInFlightRef = useRef(false);
   const consumedPendingSourceRef = useRef<string | null>(null);
+  const conversationRecordsRef = useRef<ConversationAnchorJSON[]>(stream.conversationAnchors ?? []);
 
   const [editor, setEditor] = useState<RichTextEditor | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('saved');
@@ -227,7 +252,9 @@ export function RichStreamEditor({
     from: 0,
     to: 0,
   });
-  const [, redraw] = useState(0);
+  const [editorVersion, redraw] = useState(0);
+  const [expandedConversation, setExpandedConversation] = useState<ExpandedConversation | null>(null);
+  const [conversationWidgetTarget, setConversationWidgetTarget] = useState<HTMLElement | null>(null);
   const addToast = useToastStore((state) => state.addToast);
   const { sources, setSources } = useBridgeMessages({
     streamId: stream.id,
@@ -411,6 +438,54 @@ export function RichStreamEditor({
     setSelectionMenu({ visible: true, ...placement, from, to });
   }, [getSelectionMenuPlacement, hideSelectionMenu]);
 
+  const collapseConversation = useCallback(() => {
+    const currentEditor = editorRef.current;
+    const anchor = currentEditor && conversationSurface(currentEditor.view.state)?.anchor;
+    setExpandedConversation(null);
+    setConversationWidgetTarget(null);
+    if (!currentEditor || !anchor) return;
+    window.requestAnimationFrame(() => {
+      if (currentEditor.view.isDestroyed) return;
+      const pos = Math.max(0, Math.min(anchor.from, currentEditor.view.state.doc.content.size));
+      currentEditor.view.dispatch(currentEditor.view.state.tr.setSelection(
+        TextSelection.near(currentEditor.view.state.doc.resolve(pos)),
+      ));
+      currentEditor.view.focus();
+    });
+  }, []);
+
+  const openConversationFromGlyph = useCallback((threadId: string) => {
+    const view = editorRef.current?.view;
+    const anchor = view && conversationAnchors(view.state).find((candidate) => candidate.threadId === threadId);
+    if (!anchor) return;
+    const record = conversationRecordsRef.current.find((candidate) => candidate.threadId === threadId);
+    setExpandedConversation({
+      key: `thread:${threadId}`,
+      threadId,
+      anchorText: record?.anchorText ?? '',
+      focusComposer: false,
+    });
+  }, []);
+
+  const createConversationAtBlock = useCallback((anchor: ConversationAnchor) => {
+    const view = editorRef.current?.view;
+    if (!view) return;
+    const open = conversationSurface(view.state);
+    if (open && conversationRenderPosition(view.state.doc, open.anchor)
+      === conversationRenderPosition(view.state.doc, anchor)) {
+      collapseConversation();
+      return;
+    }
+    const key = `draft:${crypto.randomUUID()}`;
+    const draft = { ...anchor, threadId: key };
+    setExpandedConversation({
+      key,
+      anchor: draft,
+      anchorText: conversationAnchorTextForStorage(view.state.doc, draft),
+      focusComposer: true,
+    });
+  }, [collapseConversation]);
+
   // Which formatting buttons are lit depends on the SELECTION, so the menu has to
   // redraw on every transaction and not only on edits.
   const onUpdate = useCallback(() => {
@@ -521,6 +596,10 @@ export function RichStreamEditor({
         onTransaction,
         onUpdate,
         onOpenLink: openLink,
+        conversations: {
+          onCreate: createConversationAtBlock,
+          onOpen: openConversationFromGlyph,
+        },
       });
     } catch {
       addToast('This stream’s rich-text document could not be read.', 'error');
@@ -644,7 +723,100 @@ export function RichStreamEditor({
         });
       });
     };
-  }, [addToast, onTransaction, onUpdate, openLink, stream.id, updateSelectionMenu]);
+  }, [
+    addToast,
+    createConversationAtBlock,
+    onTransaction,
+    onUpdate,
+    openConversationFromGlyph,
+    openLink,
+    stream.id,
+    updateSelectionMenu,
+  ]);
+
+  useEffect(() => {
+    conversationRecordsRef.current = stream.conversationAnchors ?? [];
+  }, [stream.conversationAnchors]);
+
+  const createPersistedConversation = useCallback(async (query: string): Promise<StreamThreadJSON> => {
+    const currentEditor = editorRef.current;
+    const currentSurface = currentEditor && conversationSurface(currentEditor.view.state);
+    if (!currentEditor || !currentSurface) throw new Error('Conversation closed');
+    const anchorText = conversationAnchorTextForStorage(currentEditor.view.state.doc, currentSurface.anchor);
+    if (!anchorText) throw new Error('Anchor deleted');
+    const { thread } = await createStreamThread({
+      streamId: stream.id,
+      title: query.split(/\r?\n/, 1)[0],
+      anchorStart: currentSurface.anchor.from,
+      anchorEnd: currentSurface.anchor.to,
+      anchorText,
+    });
+
+    const liveEditor = editorRef.current;
+    if (!liveEditor || liveEditor.view.isDestroyed) return thread;
+    const liveSurface = conversationSurface(liveEditor.view.state);
+    const mapped = liveSurface?.key === currentSurface.key ? liveSurface.anchor : currentSurface.anchor;
+    const persisted = { ...mapped, threadId: thread.threadId, detached: mapped.from >= mapped.to };
+    const anchors = conversationAnchors(liveEditor.view.state)
+      .filter((anchor) => anchor.threadId !== thread.threadId);
+    liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [...anchors, persisted]));
+    if (liveSurface?.key === currentSurface.key) {
+      liveEditor.view.dispatch(setConversationSurface(liveEditor.view.state.tr, {
+        key: currentSurface.key,
+        anchor: persisted,
+      }));
+    }
+    conversationRecordsRef.current = [
+      ...conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId),
+      {
+        threadId: thread.threadId,
+        anchorStart: persisted.from,
+        anchorEnd: persisted.to,
+        anchorText,
+        detached: false,
+        ephemeral: false,
+        updatedAt: thread.updatedAt,
+      },
+    ];
+    sessionRef.current?.documentChanged();
+    return thread;
+  }, [stream.id]);
+
+  const conversationHasDrifted = useCallback((anchorText: string) => {
+    const currentEditor = editorRef.current;
+    const surface = currentEditor && conversationSurface(currentEditor.view.state);
+    return !currentEditor || !surface || hasConversationAnchorTextDrifted(
+      currentEditor.view.state.doc,
+      surface.anchor,
+      anchorText,
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!editor) return;
+    let surface = conversationSurface(editor.view.state);
+    if (!expandedConversation) {
+      if (surface) editor.view.dispatch(setConversationSurface(editor.view.state.tr, null));
+      if (conversationWidgetTarget) setConversationWidgetTarget(null);
+      return;
+    }
+    if (surface?.key !== expandedConversation.key) {
+      const anchor = expandedConversation.anchor ?? conversationAnchors(editor.view.state)
+        .find((candidate) => candidate.threadId === expandedConversation.threadId);
+      if (!anchor) {
+        setConversationWidgetTarget(null);
+        return;
+      }
+      editor.view.dispatch(setConversationSurface(editor.view.state.tr, {
+        key: expandedConversation.key,
+        anchor,
+      }));
+      surface = conversationSurface(editor.view.state);
+    }
+    const target = [...editor.view.dom.querySelectorAll<HTMLElement>('[data-conversation-widget]')]
+      .find((candidate) => candidate.dataset.conversationWidget === surface?.key) ?? null;
+    setConversationWidgetTarget((current) => current === target ? current : target);
+  }, [conversationWidgetTarget, editor, editorVersion, expandedConversation]);
 
   useEffect(() => {
     if (!editor) return undefined;
@@ -1539,6 +1711,21 @@ export function RichStreamEditor({
           onClose={() => setExchangeOverlay(null)}
           onOpenManifestEntry={openExchangeManifestEntry}
         />
+      )}
+
+      {conversationWidgetTarget && expandedConversation && createPortal(
+        <ConversationSurface
+          streamId={stream.id}
+          sourceScope={sourceScope}
+          threadId={expandedConversation.threadId}
+          anchorText={expandedConversation.anchorText}
+          focusComposer={expandedConversation.focusComposer}
+          createThread={createPersistedConversation}
+          hasDrifted={conversationHasDrifted}
+          onCollapse={collapseConversation}
+        />,
+        conversationWidgetTarget,
+        expandedConversation.key,
       )}
 
       {formats && selectionMenu.visible && (

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -28,7 +28,11 @@ import type {
   StreamAppendInboxJSON,
   StreamThreadJSON,
 } from '../types/models';
-import { ConversationSurface } from './ConversationSurface';
+import {
+  ConversationSurface,
+  initialConversationLiveState,
+  type ConversationLiveState,
+} from './ConversationSurface';
 import { ExchangeOverlay, type ExchangeManifestEntry } from './ExchangeOverlay';
 import { EyeIcon, XIcon } from './icons';
 import { Modal } from './Modal';
@@ -175,6 +179,8 @@ interface ExpandedConversation {
   focusComposer: boolean;
 }
 
+type ConversationLiveStateUpdater = (current: ConversationLiveState) => ConversationLiveState;
+
 function documentAITarget(editor: RichTextEditor): { from: number; to: number; text: string } | null {
   const { doc, selection } = editor.view.state;
   const from = selection.empty ? selection.$head.start() : selection.from;
@@ -226,6 +232,9 @@ export function RichStreamEditor({
   const pdfAIInFlightRef = useRef(false);
   const consumedPendingSourceRef = useRef<string | null>(null);
   const conversationRecordsRef = useRef<ConversationAnchorJSON[]>(stream.conversationAnchors ?? []);
+  const expandedConversationRef = useRef<ExpandedConversation | null>(null);
+  const conversationLiveStatesRef = useRef<Record<string, ConversationLiveState>>({});
+  const conversationCollapseTimerRef = useRef<number>();
 
   const [editor, setEditor] = useState<RichTextEditor | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('saved');
@@ -258,6 +267,7 @@ export function RichStreamEditor({
   });
   const [editorVersion, redraw] = useState(0);
   const [expandedConversation, setExpandedConversation] = useState<ExpandedConversation | null>(null);
+  const [conversationLiveStates, setConversationLiveStates] = useState<Record<string, ConversationLiveState>>({});
   const [conversationWidgetTarget, setConversationWidgetTarget] = useState<HTMLElement | null>(null);
   const [conversationRecords, setConversationRecords] = useState<ConversationAnchorJSON[]>(
     stream.conversationAnchors ?? [],
@@ -265,6 +275,7 @@ export function RichStreamEditor({
   const [showConversationList, setShowConversationList] = useState(false);
   const [conversationListLoading, setConversationListLoading] = useState(false);
   const [conversationListError, setConversationListError] = useState(false);
+  const [conversationPendingDelete, setConversationPendingDelete] = useState<ConversationAnchorJSON | null>(null);
   const addToast = useToastStore((state) => state.addToast);
   const { sources, setSources } = useBridgeMessages({
     streamId: stream.id,
@@ -448,34 +459,102 @@ export function RichStreamEditor({
     setSelectionMenu({ visible: true, ...placement, from, to });
   }, [getSelectionMenuPlacement, hideSelectionMenu]);
 
-  const collapseConversation = useCallback(() => {
-    const currentEditor = editorRef.current;
-    const anchor = currentEditor && conversationSurface(currentEditor.view.state)?.anchor;
-    setExpandedConversation(null);
-    setConversationWidgetTarget(null);
-    if (!currentEditor || !anchor) return;
-    window.requestAnimationFrame(() => {
-      if (currentEditor.view.isDestroyed) return;
-      const pos = Math.max(0, Math.min(anchor.from, currentEditor.view.state.doc.content.size));
-      currentEditor.view.dispatch(currentEditor.view.state.tr.setSelection(
-        TextSelection.near(currentEditor.view.state.doc.resolve(pos)),
-      ));
-      currentEditor.view.focus();
+  const updateConversationLiveState = useCallback((
+    key: string,
+    updater: ConversationLiveStateUpdater,
+  ) => {
+    setConversationLiveStates((current) => {
+      const value = updater(current[key] ?? initialConversationLiveState());
+      if (value === current[key]) return current;
+      const next = { ...current, [key]: value };
+      conversationLiveStatesRef.current = next;
+      return next;
     });
   }, []);
+
+  const ensureConversationLiveState = useCallback((key: string, threadId?: string) => {
+    setConversationLiveStates((current) => {
+      if (current[key]) return current;
+      const next = { ...current, [key]: initialConversationLiveState(threadId) };
+      conversationLiveStatesRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const cancelConversationRequest = useCallback((key: string, updateUI = true) => {
+    const current = conversationLiveStatesRef.current[key];
+    if (!current?.active?.running) return;
+    bridge.send({ type: 'cancelDocumentAI', payload: { requestId: current.active.requestId } });
+    const stopped = {
+      ...current,
+      active: { ...current.active, running: false, error: 'Stopped.' },
+    };
+    const next = { ...conversationLiveStatesRef.current, [key]: stopped };
+    conversationLiveStatesRef.current = next;
+    if (updateUI) setConversationLiveStates(next);
+  }, []);
+
+  const expandConversation = useCallback((next: ExpandedConversation) => {
+    const current = expandedConversationRef.current;
+    if (current?.key !== next.key) {
+      if (current) cancelConversationRequest(current.key);
+      ensureConversationLiveState(next.key, next.threadId);
+    }
+    if (conversationCollapseTimerRef.current !== undefined) {
+      window.clearTimeout(conversationCollapseTimerRef.current);
+      conversationCollapseTimerRef.current = undefined;
+    }
+    expandedConversationRef.current = next;
+    setExpandedConversation(next);
+  }, [cancelConversationRequest, ensureConversationLiveState]);
+
+  const collapseConversation = useCallback(() => {
+    const expanded = expandedConversationRef.current;
+    if (!expanded || conversationCollapseTimerRef.current !== undefined) return;
+    const currentEditor = editorRef.current;
+    const anchor = currentEditor && conversationSurface(currentEditor.view.state)?.anchor;
+    cancelConversationRequest(expanded.key);
+    updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: true }));
+    conversationCollapseTimerRef.current = window.setTimeout(() => {
+      conversationCollapseTimerRef.current = undefined;
+      if (expandedConversationRef.current?.key !== expanded.key) return;
+      expandedConversationRef.current = null;
+      setExpandedConversation(null);
+      setConversationWidgetTarget(null);
+      updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: false }));
+      if (!currentEditor || !anchor) return;
+      window.requestAnimationFrame(() => {
+        if (currentEditor.view.isDestroyed) return;
+        const pos = Math.max(0, Math.min(anchor.from, currentEditor.view.state.doc.content.size));
+        currentEditor.view.dispatch(currentEditor.view.state.tr.setSelection(
+          TextSelection.near(currentEditor.view.state.doc.resolve(pos)),
+        ));
+        currentEditor.view.focus();
+      });
+    }, 150);
+  }, [cancelConversationRequest, updateConversationLiveState]);
+
+  useEffect(() => () => {
+    if (conversationCollapseTimerRef.current !== undefined) {
+      window.clearTimeout(conversationCollapseTimerRef.current);
+    }
+    for (const key of Object.keys(conversationLiveStatesRef.current)) {
+      cancelConversationRequest(key, false);
+    }
+  }, [cancelConversationRequest]);
 
   const openConversationFromGlyph = useCallback((threadId: string) => {
     const view = editorRef.current?.view;
     const anchor = view && conversationAnchors(view.state).find((candidate) => candidate.threadId === threadId);
     if (!anchor) return;
     const record = conversationRecordsRef.current.find((candidate) => candidate.threadId === threadId);
-    setExpandedConversation({
+    expandConversation({
       key: `thread:${threadId}`,
       threadId,
       anchorText: record?.anchorText ?? '',
       focusComposer: false,
     });
-  }, []);
+  }, [expandConversation]);
 
   const createConversationAtBlock = useCallback((anchor: ConversationAnchor) => {
     const view = editorRef.current?.view;
@@ -483,18 +562,18 @@ export function RichStreamEditor({
     const open = conversationSurface(view.state);
     if (open && conversationRenderPosition(view.state.doc, open.anchor)
       === conversationRenderPosition(view.state.doc, anchor)) {
-      document.querySelector<HTMLButtonElement>('.conversation-rail')?.click();
+      collapseConversation();
       return;
     }
     const key = `draft:${crypto.randomUUID()}`;
     const draft = { ...anchor, threadId: key };
-    setExpandedConversation({
+    expandConversation({
       key,
       anchor: draft,
       anchorText: conversationAnchorTextForStorage(view.state.doc, draft),
       focusComposer: true,
     });
-  }, []);
+  }, [collapseConversation, expandConversation]);
 
   // Which formatting buttons are lit depends on the SELECTION, so the menu has to
   // redraw on every transaction and not only on edits.
@@ -777,6 +856,12 @@ export function RichStreamEditor({
         key: currentSurface.key,
         anchor: persisted,
       }));
+      const expanded = expandedConversationRef.current;
+      if (expanded?.key === currentSurface.key) {
+        const next = { ...expanded, threadId: thread.threadId, anchor: undefined };
+        expandedConversationRef.current = next;
+        setExpandedConversation(next);
+      }
     }
     const records = [
       ...conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId),
@@ -831,7 +916,7 @@ export function RichStreamEditor({
     const anchor = conversationAnchors(liveEditor.view.state)
       .find((candidate) => candidate.threadId === record.threadId);
     if (anchor && !record.detached) {
-      setExpandedConversation({
+      expandConversation({
         key: `thread:${record.threadId}`,
         threadId: record.threadId,
         anchorText: record.anchorText,
@@ -845,7 +930,7 @@ export function RichStreamEditor({
       const position = liveEditor.view.state.doc.content.size;
       // ponytail: detached conversations render at document end; add archive
       // positioning only if detached browsing grows beyond this plain list.
-      setExpandedConversation({
+      expandConversation({
         key: `thread:${record.threadId}`,
         threadId: record.threadId,
         anchor: { threadId: record.threadId, from: position, to: position, detached: true },
@@ -857,10 +942,9 @@ export function RichStreamEditor({
     }
     setShowConversationList(false);
     if (streamOverflowMenuRef.current) streamOverflowMenuRef.current.open = false;
-  }, []);
+  }, [expandConversation]);
 
   const deleteConversation = useCallback(async (record: ConversationAnchorJSON) => {
-    if (!window.confirm('Delete this conversation?')) return;
     try {
       await deleteStreamThread({ streamId: stream.id, threadId: record.threadId });
       const records = conversationRecordsRef.current
@@ -1724,7 +1808,7 @@ export function RichStreamEditor({
                         type="button"
                         className="conversation-list-delete"
                         aria-label="Delete conversation"
-                        onClick={() => void deleteConversation(record)}
+                        onClick={() => setConversationPendingDelete(record)}
                       >
                         Delete
                       </button>
@@ -1746,6 +1830,35 @@ export function RichStreamEditor({
           </details>
         </div>
       </header>
+
+      {conversationPendingDelete && (
+        <Modal
+          className="delete-confirm-dialog conversation-delete-confirm-dialog"
+          aria-labelledby="conversation-delete-confirm-title"
+          onRequestClose={() => setConversationPendingDelete(null)}
+        >
+          <h2 id="conversation-delete-confirm-title">Delete this conversation?</h2>
+          <p>This permanently deletes its turns. The Stream text stays unchanged.</p>
+          <div className="delete-confirm-actions">
+            <button
+              className="delete-confirm-cancel"
+              onClick={() => setConversationPendingDelete(null)}
+            >
+              Cancel
+            </button>
+            <button
+              className="delete-confirm-delete conversation-delete-confirm-delete"
+              onClick={() => {
+                const record = conversationPendingDelete;
+                setConversationPendingDelete(null);
+                void deleteConversation(record);
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </Modal>
+      )}
 
       {showDeleteConfirm && (
         <Modal
@@ -1848,11 +1961,15 @@ export function RichStreamEditor({
 
       {conversationWidgetTarget && expandedConversation && createPortal(
         <ConversationSurface
+          conversationKey={expandedConversation.key}
           streamId={stream.id}
           sourceScope={sourceScope}
           threadId={expandedConversation.threadId}
           anchorText={expandedConversation.anchorText}
           focusComposer={expandedConversation.focusComposer}
+          state={conversationLiveStates[expandedConversation.key]
+            ?? initialConversationLiveState(expandedConversation.threadId)}
+          updateState={updateConversationLiveState}
           createThread={createPersistedConversation}
           hasDrifted={conversationHasDrifted}
           onCollapse={collapseConversation}

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -12,7 +12,9 @@ import { TextSelection, type Command, type Transaction } from 'prosemirror-state
 import {
   bridge,
   createStreamThread,
+  deleteStreamThread,
   getExchange,
+  listConversations,
   type DocumentAIVerb,
   type SourceTitlePayload,
   type StreamDocumentConflictPayload,
@@ -83,6 +85,7 @@ import {
   type PendingPDFAnchorSelection,
 } from '../utils/pdfAnchorSelection';
 import { computeSelectionMenuPlacement } from '../utils/selectionMenuPlacement';
+import { formatRelativeTime } from '../utils/relativeTime';
 import {
   activeFormats,
   toggleBlockquote,
@@ -167,6 +170,7 @@ interface ExpandedConversation {
   key: string;
   threadId?: string;
   anchor?: ConversationAnchor;
+  renderAt?: number;
   anchorText: string;
   focusComposer: boolean;
 }
@@ -255,6 +259,12 @@ export function RichStreamEditor({
   const [editorVersion, redraw] = useState(0);
   const [expandedConversation, setExpandedConversation] = useState<ExpandedConversation | null>(null);
   const [conversationWidgetTarget, setConversationWidgetTarget] = useState<HTMLElement | null>(null);
+  const [conversationRecords, setConversationRecords] = useState<ConversationAnchorJSON[]>(
+    stream.conversationAnchors ?? [],
+  );
+  const [showConversationList, setShowConversationList] = useState(false);
+  const [conversationListLoading, setConversationListLoading] = useState(false);
+  const [conversationListError, setConversationListError] = useState(false);
   const addToast = useToastStore((state) => state.addToast);
   const { sources, setSources } = useBridgeMessages({
     streamId: stream.id,
@@ -473,7 +483,7 @@ export function RichStreamEditor({
     const open = conversationSurface(view.state);
     if (open && conversationRenderPosition(view.state.doc, open.anchor)
       === conversationRenderPosition(view.state.doc, anchor)) {
-      collapseConversation();
+      document.querySelector<HTMLButtonElement>('.conversation-rail')?.click();
       return;
     }
     const key = `draft:${crypto.randomUUID()}`;
@@ -484,7 +494,7 @@ export function RichStreamEditor({
       anchorText: conversationAnchorTextForStorage(view.state.doc, draft),
       focusComposer: true,
     });
-  }, [collapseConversation]);
+  }, []);
 
   // Which formatting buttons are lit depends on the SELECTION, so the menu has to
   // redraw on every transaction and not only on edits.
@@ -735,7 +745,9 @@ export function RichStreamEditor({
   ]);
 
   useEffect(() => {
-    conversationRecordsRef.current = stream.conversationAnchors ?? [];
+    const records = stream.conversationAnchors ?? [];
+    conversationRecordsRef.current = records;
+    setConversationRecords(records);
   }, [stream.conversationAnchors]);
 
   const createPersistedConversation = useCallback(async (query: string): Promise<StreamThreadJSON> => {
@@ -766,7 +778,7 @@ export function RichStreamEditor({
         anchor: persisted,
       }));
     }
-    conversationRecordsRef.current = [
+    const records = [
       ...conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId),
       {
         threadId: thread.threadId,
@@ -778,6 +790,8 @@ export function RichStreamEditor({
         updatedAt: thread.updatedAt,
       },
     ];
+    conversationRecordsRef.current = records;
+    setConversationRecords(records);
     sessionRef.current?.documentChanged();
     return thread;
   }, [stream.id]);
@@ -791,6 +805,83 @@ export function RichStreamEditor({
       anchorText,
     );
   }, []);
+
+  const toggleConversationList = useCallback(async () => {
+    if (showConversationList) {
+      setShowConversationList(false);
+      return;
+    }
+    setShowConversationList(true);
+    setConversationListLoading(true);
+    setConversationListError(false);
+    try {
+      const { conversations } = await listConversations(stream.id);
+      conversationRecordsRef.current = conversations;
+      setConversationRecords(conversations);
+    } catch {
+      setConversationListError(true);
+    } finally {
+      setConversationListLoading(false);
+    }
+  }, [showConversationList, stream.id]);
+
+  const openConversationFromList = useCallback((record: ConversationAnchorJSON) => {
+    const liveEditor = editorRef.current;
+    if (!liveEditor) return;
+    const anchor = conversationAnchors(liveEditor.view.state)
+      .find((candidate) => candidate.threadId === record.threadId);
+    if (anchor && !record.detached) {
+      setExpandedConversation({
+        key: `thread:${record.threadId}`,
+        threadId: record.threadId,
+        anchorText: record.anchorText,
+        focusComposer: false,
+      });
+      window.requestAnimationFrame(() => {
+        const target = liveEditor.view.domAtPos(anchor.from).node;
+        (target instanceof Element ? target : target.parentElement)?.scrollIntoView({ block: 'center' });
+      });
+    } else {
+      const position = liveEditor.view.state.doc.content.size;
+      // ponytail: detached conversations render at document end; add archive
+      // positioning only if detached browsing grows beyond this plain list.
+      setExpandedConversation({
+        key: `thread:${record.threadId}`,
+        threadId: record.threadId,
+        anchor: { threadId: record.threadId, from: position, to: position, detached: true },
+        renderAt: position,
+        anchorText: record.anchorText,
+        focusComposer: false,
+      });
+      window.requestAnimationFrame(() => liveEditor.view.dom.lastElementChild?.scrollIntoView({ block: 'center' }));
+    }
+    setShowConversationList(false);
+    if (streamOverflowMenuRef.current) streamOverflowMenuRef.current.open = false;
+  }, []);
+
+  const deleteConversation = useCallback(async (record: ConversationAnchorJSON) => {
+    if (!window.confirm('Delete this conversation?')) return;
+    try {
+      await deleteStreamThread({ streamId: stream.id, threadId: record.threadId });
+      const records = conversationRecordsRef.current
+        .filter((candidate) => candidate.threadId !== record.threadId);
+      conversationRecordsRef.current = records;
+      setConversationRecords(records);
+      const liveEditor = editorRef.current;
+      const deletingOpenConversation = liveEditor
+        && conversationSurface(liveEditor.view.state)?.anchor.threadId === record.threadId;
+      if (liveEditor) {
+        liveEditor.view.dispatch(setConversationAnchors(
+          liveEditor.view.state.tr,
+          conversationAnchors(liveEditor.view.state)
+            .filter((anchor) => anchor.threadId !== record.threadId),
+        ));
+      }
+      if (deletingOpenConversation) collapseConversation();
+    } catch {
+      addToast('This conversation could not be deleted.', 'error');
+    }
+  }, [addToast, collapseConversation, stream.id]);
 
   useLayoutEffect(() => {
     if (!editor) return;
@@ -810,6 +901,7 @@ export function RichStreamEditor({
       editor.view.dispatch(setConversationSurface(editor.view.state.tr, {
         key: expandedConversation.key,
         anchor,
+        renderAt: expandedConversation.renderAt,
       }));
       surface = conversationSurface(editor.view.state);
     }
@@ -1598,7 +1690,48 @@ export function RichStreamEditor({
             <summary title="More stream actions" aria-label="More stream actions">
               <span aria-hidden="true">•••</span>
             </summary>
-            <div className="stream-overflow-panel">
+            <div className={`stream-overflow-panel ${showConversationList ? 'stream-overflow-panel--conversations' : ''}`}>
+              <button
+                type="button"
+                className="stream-overflow-action"
+                aria-expanded={showConversationList}
+                onClick={() => void toggleConversationList()}
+              >
+                Conversations
+              </button>
+              {showConversationList && (
+                <div className="conversation-list" aria-label="Conversations">
+                  {conversationListLoading && <p>Loading…</p>}
+                  {conversationListError && <p>Conversations could not be loaded.</p>}
+                  {!conversationListLoading && !conversationListError && conversationRecords.length === 0 && (
+                    <p>No conversations yet.</p>
+                  )}
+                  {conversationRecords.map((record) => (
+                    <div className="conversation-list-row" key={record.threadId}>
+                      <button
+                        type="button"
+                        className="conversation-list-open"
+                        onClick={() => openConversationFromList(record)}
+                      >
+                        <span className="conversation-list-title">
+                          {record.anchorText.split(/\r?\n/, 1)[0] || 'Conversation'}
+                        </span>
+                        <span className="conversation-list-meta">
+                          {formatRelativeTime(record.updatedAt)}{record.detached ? ' · detached' : ''}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        className="conversation-list-delete"
+                        aria-label="Delete conversation"
+                        onClick={() => void deleteConversation(record)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
               <button
                 type="button"
                 className="stream-overflow-delete"

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -14,18 +14,25 @@ import {
   hasConversationAnchorTextDrifted,
   refreshConversationViewport,
   setConversationAnchors,
+  setConversationSurface,
   setConversationVisibleRanges,
+  type ConversationAnchorFieldOptions,
 } from './conversationAnchors';
 
 let editor: RichTextEditor | null = null;
 
-function open(markdown: string, onUpdate?: () => void): RichTextEditor {
+function open(
+  markdown: string,
+  onUpdate?: () => void,
+  conversations?: ConversationAnchorFieldOptions,
+): RichTextEditor {
   const parent = document.createElement('div');
   document.body.appendChild(parent);
   editor = createRichTextEditor({
     parent,
     docJSON: JSON.stringify(parseMarkdown(markdown).toJSON()),
     onUpdate,
+    conversations,
   });
   return editor;
 }
@@ -183,6 +190,34 @@ it('renders one passive right glyph class and the current-block left line class'
   const block = ed.view.dom.querySelector('p');
   expect(block?.classList.contains('conversation-block-active')).toBe(true);
   expect(block?.classList.contains('conversation-block-anchored')).toBe(true);
+});
+
+it('routes gutter clicks and mounts only one caret-excluded block widget', () => {
+  const onCreate = vi.fn();
+  const onOpen = vi.fn();
+  const ed = open('Visible block', undefined, { onCreate, onOpen });
+  const anchor = fullBlockConversationAnchor(ed.view.state.doc, 1, 'one')!;
+  ed.view.dispatch(setConversationAnchors(ed.view.state.tr, [anchor]));
+  ed.view.dispatch(setConversationVisibleRanges(ed.view.state.tr, [{ from: anchor.from, to: anchor.to }]));
+  const block = ed.view.dom.querySelector('p')!;
+  vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+    left: 10, right: 110, top: 0, bottom: 28, width: 100, height: 28, x: 10, y: 0,
+    toJSON: () => ({}),
+  });
+
+  block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 0 }));
+  expect(onCreate).toHaveBeenCalledWith({ ...anchor, threadId: '' });
+  block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 120 }));
+  expect(onOpen).toHaveBeenCalledWith('one');
+
+  const before = ed.getDocumentJSON();
+  ed.view.dispatch(setConversationSurface(ed.view.state.tr, { key: 'first', anchor }));
+  ed.view.dispatch(setConversationSurface(ed.view.state.tr, { key: 'second', anchor }));
+  const widgets = ed.view.dom.querySelectorAll<HTMLElement>('[data-conversation-widget]');
+  expect(widgets).toHaveLength(1);
+  expect(widgets[0].dataset.conversationWidget).toBe('second');
+  expect(widgets[0].contentEditable).toBe('false');
+  expect(ed.getDocumentJSON()).toBe(before);
 });
 
 it('coalesces viewport and hover work per animation frame and skips unchanged targets', () => {

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { undo } from 'prosemirror-history';
+import { TextSelection } from 'prosemirror-state';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRichTextEditor, type RichTextEditor } from './editor';
 import { parseMarkdown } from './markdown';
@@ -51,6 +52,11 @@ function recordFullBlock(ed: RichTextEditor, text: string) {
   if (!anchor) throw new Error('expected a non-empty block anchor');
   ed.view.dispatch(setConversationAnchors(ed.view.state.tr, [anchor]));
   return anchor;
+}
+
+function press(ed: RichTextEditor, key: string): boolean {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  return Boolean(ed.view.someProp('handleKeyDown', (handler) => handler(ed.view, event)));
 }
 
 afterEach(() => {
@@ -218,6 +224,20 @@ it('routes gutter clicks and mounts only one caret-excluded block widget', () =>
   expect(widgets[0].dataset.conversationWidget).toBe('second');
   expect(widgets[0].contentEditable).toBe('false');
   expect(ed.getDocumentJSON()).toBe(before);
+});
+
+it('moves an ArrowDown caret from the anchored block to the block below the widget', () => {
+  const ed = open('Above\n\nBelow');
+  const anchor = recordFullBlock(ed, 'Above');
+  ed.view.dispatch(setConversationSurface(ed.view.state.tr, { key: 'open', anchor }));
+  ed.view.dispatch(ed.view.state.tr.setSelection(TextSelection.create(ed.view.state.doc, anchor.to)));
+  vi.spyOn(ed.view, 'endOfTextblock').mockReturnValue(true);
+
+  expect(press(ed, 'ArrowDown')).toBe(true);
+  expect(ed.view.state.selection.$head.parent.textContent).toBe('Below');
+  expect(ed.view.dom.querySelector('.conversation-widget-host')?.contains(
+    ed.view.domAtPos(ed.view.state.selection.head).node,
+  )).toBe(false);
 });
 
 it('coalesces viewport and hover work per animation frame and skips unchanged targets', () => {

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -40,6 +40,7 @@ interface ConversationAnchorState {
 export interface ConversationSurfaceState {
   key: string;
   anchor: ConversationAnchor;
+  renderAt?: number;
 }
 
 export interface ConversationAnchorFieldOptions {
@@ -338,7 +339,13 @@ export function conversationAnchorField(
             : tr.mapping.map(current.hoveredBlockFrom, -1),
           surface: current.surface === null
             ? null
-            : { ...current.surface, anchor: mapAnchor(current.surface.anchor, tr) },
+            : {
+              ...current.surface,
+              anchor: mapAnchor(current.surface.anchor, tr),
+              renderAt: current.surface.renderAt === undefined
+                ? undefined
+                : tr.mapping.map(current.surface.renderAt, -1),
+            },
         };
         const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
         if (!meta) return mapped;
@@ -372,7 +379,8 @@ export function conversationAnchorField(
           { class: [target.left && 'conversation-block-active', target.right && 'conversation-block-anchored'].filter(Boolean).join(' ') },
         ));
         const surface = field.surface;
-        const position = surface && conversationRenderPosition(state.doc, surface.anchor);
+        const position = surface && (surface.renderAt
+          ?? conversationRenderPosition(state.doc, surface.anchor));
         if (surface && position !== null) {
           decorations.push(Decoration.widget(position, () => {
             const host = document.createElement('div');

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -1,5 +1,5 @@
 import type { Node as ProseNode } from 'prosemirror-model';
-import { Plugin, PluginKey, type EditorState, type Transaction } from 'prosemirror-state';
+import { Plugin, PluginKey, Selection, type EditorState, type Transaction } from 'prosemirror-state';
 import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
 import type { ConversationAnchorJSON } from '../types/models';
 
@@ -363,6 +363,35 @@ export function conversationAnchorField(
       },
     },
     props: {
+      handleKeyDown(view, event) {
+        const field = conversationAnchorKey.getState(view.state);
+        const surface = field?.surface;
+        const position = surface && (surface.renderAt
+          ?? conversationRenderPosition(view.state.doc, surface.anchor));
+        if (position !== null && position !== undefined && view.state.selection.empty) {
+          const block = textBlockAt(view.state.doc, view.state.selection.head);
+          const direction = event.key === 'ArrowDown' && block?.to === position
+            ? 1
+            : event.key === 'ArrowUp' && block?.from === position ? -1 : 0;
+          if (direction && view.endOfTextblock(direction > 0 ? 'down' : 'up')) {
+            const next = Selection.findFrom(view.state.doc.resolve(position), direction, true);
+            if (next) {
+              event.preventDefault();
+              view.dispatch(view.state.tr.setSelection(next).scrollIntoView());
+              return true;
+            }
+          }
+        }
+        if (event.key !== 'Tab' || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+          return false;
+        }
+        if (!field?.surface) return false;
+        const composer = view.dom.querySelector<HTMLTextAreaElement>('.conversation-composer');
+        if (!composer) return false;
+        event.preventDefault();
+        composer.focus();
+        return true;
+      },
       decorations(state) {
         const field = conversationAnchorKey.getState(state);
         if (!field) return null;
@@ -380,7 +409,8 @@ export function conversationAnchorField(
         ));
         const surface = field.surface;
         const position = surface && (surface.renderAt
-          ?? conversationRenderPosition(state.doc, surface.anchor));
+          ?? conversationRenderPosition(state.doc, surface.anchor)
+          ?? state.doc.content.size);
         if (surface && position !== null) {
           decorations.push(Decoration.widget(position, () => {
             const host = document.createElement('div');

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -34,12 +34,24 @@ interface ConversationAnchorState {
   markerBlockFrom: Set<number>;
   visibleRanges: VisibleRange[];
   hoveredBlockFrom: number | null;
+  surface: ConversationSurfaceState | null;
+}
+
+export interface ConversationSurfaceState {
+  key: string;
+  anchor: ConversationAnchor;
+}
+
+export interface ConversationAnchorFieldOptions {
+  onCreate?: (anchor: ConversationAnchor) => void;
+  onOpen?: (threadId: string) => void;
 }
 
 type AnchorMessage =
   | { kind: 'set'; anchors: ConversationAnchor[] }
   | { kind: 'visible'; ranges: VisibleRange[] }
-  | { kind: 'hover'; blockFrom: number | null };
+  | { kind: 'hover'; blockFrom: number | null }
+  | { kind: 'surface'; surface: ConversationSurfaceState | null };
 
 const conversationAnchorKey = new PluginKey<ConversationAnchorState>('tickerConversationAnchors');
 const pendingViewportRefreshes = new WeakSet<EditorView>();
@@ -57,7 +69,9 @@ const cancelFrame = (handle: number): void => {
 
 export function isConversationDecorationTransaction(tr: Transaction): boolean {
   const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
-  return !tr.docChanged && !tr.selectionSet && (meta?.kind === 'visible' || meta?.kind === 'hover');
+  return !tr.docChanged && !tr.selectionSet && (
+    meta?.kind === 'visible' || meta?.kind === 'hover' || meta?.kind === 'surface'
+  );
 }
 
 export const setConversationAnchors = (
@@ -69,6 +83,11 @@ export const setConversationVisibleRanges = (
   tr: Transaction,
   ranges: VisibleRange[],
 ): Transaction => tr.setMeta(conversationAnchorKey, { kind: 'visible', ranges });
+
+export const setConversationSurface = (
+  tr: Transaction,
+  surface: ConversationSurfaceState | null,
+): Transaction => tr.setMeta(conversationAnchorKey, { kind: 'surface', surface });
 
 export function refreshConversationViewport(view: EditorView): void {
   if (pendingViewportRefreshes.has(view)) return;
@@ -110,6 +129,10 @@ function applyConversationViewport(view: EditorView): void {
 
 export function conversationAnchors(state: EditorState): ConversationAnchor[] {
   return conversationAnchorKey.getState(state)?.anchors ?? [];
+}
+
+export function conversationSurface(state: EditorState): ConversationSurfaceState | null {
+  return conversationAnchorKey.getState(state)?.surface ?? null;
 }
 
 /** Create the initial anchor from the complete text content of the current block. */
@@ -267,7 +290,9 @@ export function conversationDecorationTargets(
   return [...visibleBlocks.values()].filter((target) => target.left || target.right);
 }
 
-export function conversationAnchorField(): Plugin<ConversationAnchorState> {
+export function conversationAnchorField(
+  options: ConversationAnchorFieldOptions = {},
+): Plugin<ConversationAnchorState> {
   let hoverFrame: number | null = null;
   let pendingHover: { view: EditorView; left: number; top: number } | { view: EditorView } | null = null;
   const queueHover = (view: EditorView, point?: { left: number; top: number }): void => {
@@ -291,7 +316,13 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
   return new Plugin<ConversationAnchorState>({
     key: conversationAnchorKey,
     state: {
-      init: () => ({ anchors: [], markerBlockFrom: new Set(), visibleRanges: [], hoveredBlockFrom: null }),
+      init: () => ({
+        anchors: [],
+        markerBlockFrom: new Set(),
+        visibleRanges: [],
+        hoveredBlockFrom: null,
+        surface: null,
+      }),
       apply(tr, current, _old, next) {
         const anchors = current.anchors.map((anchor) => mapAnchor(anchor, tr));
         const mapped: ConversationAnchorState = {
@@ -305,6 +336,9 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
           hoveredBlockFrom: current.hoveredBlockFrom === null
             ? null
             : tr.mapping.map(current.hoveredBlockFrom, -1),
+          surface: current.surface === null
+            ? null
+            : { ...current.surface, anchor: mapAnchor(current.surface.anchor, tr) },
         };
         const meta = tr.getMeta(conversationAnchorKey) as AnchorMessage | undefined;
         if (!meta) return mapped;
@@ -317,7 +351,8 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
           };
         }
         if (meta.kind === 'visible') return { ...mapped, visibleRanges: meta.ranges };
-        return { ...mapped, hoveredBlockFrom: meta.blockFrom };
+        if (meta.kind === 'hover') return { ...mapped, hoveredBlockFrom: meta.blockFrom };
+        return { ...mapped, surface: meta.surface };
       },
     },
     props: {
@@ -331,11 +366,28 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
           field.visibleRanges,
           field.hoveredBlockFrom ?? cursorBlock,
         );
-        return DecorationSet.create(state.doc, targets.map((target) => Decoration.node(
+        const decorations = targets.map((target) => Decoration.node(
           target.from,
           target.to,
           { class: [target.left && 'conversation-block-active', target.right && 'conversation-block-anchored'].filter(Boolean).join(' ') },
-        )));
+        ));
+        const surface = field.surface;
+        const position = surface && conversationRenderPosition(state.doc, surface.anchor);
+        if (surface && position !== null) {
+          decorations.push(Decoration.widget(position, () => {
+            const host = document.createElement('div');
+            host.className = 'conversation-widget-host';
+            host.contentEditable = 'false';
+            host.dataset.conversationWidget = surface.key;
+            return host;
+          }, {
+            key: surface.key,
+            side: 1,
+            stopEvent: () => true,
+            ignoreSelection: true,
+          }));
+        }
+        return DecorationSet.create(state.doc, decorations);
       },
       handleDOMEvents: {
         mousemove(view, event) {
@@ -346,8 +398,37 @@ export function conversationAnchorField(): Plugin<ConversationAnchorState> {
           queueHover(view);
           return false;
         },
-        click() {
-          // ponytail: visual no-op for C2; C3 replaces this with open/create routing.
+        click(view, event) {
+          const target = event.target instanceof Element
+            ? event.target.closest<HTMLElement>('.conversation-block-active, .conversation-block-anchored')
+            : null;
+          if (!target || !view.dom.contains(target)) return false;
+          const rect = target.getBoundingClientRect();
+          let block: BlockRange | null = null;
+          try {
+            block = textBlockAt(view.state.doc, view.posAtDOM(target, 0));
+          } catch {
+            return false;
+          }
+          if (!block) return false;
+          if (event.clientX < rect.left && target.classList.contains('conversation-block-active')) {
+            const anchor = fullBlockConversationAnchor(view.state.doc, block.contentFrom, '');
+            if (!anchor) return false;
+            event.preventDefault();
+            options.onCreate?.(anchor);
+            return true;
+          }
+          if (event.clientX > rect.right && target.classList.contains('conversation-block-anchored')) {
+            const field = conversationAnchorKey.getState(view.state);
+            const anchor = field?.anchors.find((candidate) => {
+              const position = conversationRenderPosition(view.state.doc, candidate);
+              return position !== null && textBlockAt(view.state.doc, position - 1)?.from === block?.from;
+            });
+            if (!anchor) return false;
+            event.preventDefault();
+            options.onOpen?.(anchor.threadId);
+            return true;
+          }
           return false;
         },
       },

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -119,11 +119,11 @@
 .conversation-rail {
   position: absolute;
   inset: 0 auto 0 0;
-  width: 2px;
+  width: 12px;
   padding: 0;
   border: 0;
   border-radius: 0;
-  background: var(--accent);
+  background: linear-gradient(to right, var(--accent) 0 2px, transparent 2px);
   opacity: 0.25;
   cursor: pointer;
 }

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -67,10 +67,11 @@
 .richtext-editor .ProseMirror .conversation-block-active::before {
   content: '';
   position: absolute;
-  inset: 0 auto 0 -18px;
-  width: 2px;
-  background: var(--accent);
-  pointer-events: none;
+  inset: 0 auto 0 -23px;
+  width: 12px;
+  background: linear-gradient(to right, transparent 5px, var(--accent) 5px 7px, transparent 7px);
+  cursor: pointer;
+  pointer-events: auto;
 }
 
 .richtext-editor .ProseMirror .conversation-block-anchored::after {
@@ -82,8 +83,171 @@
   font-size: 8px;
   line-height: 1;
   opacity: 0.55;
-  pointer-events: none;
+  cursor: pointer;
+  pointer-events: auto;
   transform: translateY(-50%);
+}
+
+.richtext-editor .ProseMirror .conversation-widget-host {
+  display: block;
+  width: 100%;
+}
+
+.conversation-surface {
+  position: relative;
+  margin: 0 0 var(--space-5) 28px;
+  padding-left: var(--space-4);
+  color: var(--text);
+  font-family: var(--editor-font-family);
+  font-size: var(--conversation-body);
+  line-height: var(--conversation-line-height);
+  white-space: normal;
+  animation: conversation-expand 150ms ease-out;
+}
+
+.conversation-surface--closing {
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 150ms ease-out, transform 150ms ease-out;
+}
+
+@keyframes conversation-expand {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.conversation-rail {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 2px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: var(--accent);
+  opacity: 0.25;
+  cursor: pointer;
+}
+
+.conversation-rail:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.conversation-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.conversation-drift-note,
+.conversation-status,
+.conversation-error {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--type-ui-small);
+  line-height: var(--type-ui-line-height);
+}
+
+.conversation-error {
+  color: var(--danger);
+}
+
+.conversation-exchange {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.conversation-turn {
+  position: relative;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: start;
+}
+
+.conversation-turn--you {
+  color: var(--text-muted);
+}
+
+.conversation-turn--ai {
+  color: var(--text);
+}
+
+.conversation-turn-label {
+  font-size: var(--type-ui-caption);
+  line-height: var(--conversation-line-height);
+}
+
+.conversation-turn-text {
+  min-width: 0;
+  white-space: pre-wrap;
+}
+
+.conversation-turn-copy {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--type-ui-caption);
+  opacity: 0;
+  cursor: pointer;
+}
+
+.conversation-turn:hover .conversation-turn-copy,
+.conversation-turn-copy:focus-visible {
+  opacity: 1;
+}
+
+.conversation-composer-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.conversation-composer {
+  flex: 1;
+  min-width: 0;
+  resize: vertical;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  line-height: var(--conversation-line-height);
+}
+
+.conversation-composer:focus {
+  border-color: var(--accent);
+}
+
+.conversation-composer::placeholder {
+  color: var(--text-muted);
+}
+
+.conversation-send,
+.conversation-stop {
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--type-ui-small);
+  cursor: pointer;
+}
+
+.conversation-send:hover,
+.conversation-stop:hover {
+  background: var(--surface-hover);
+}
+
+.conversation-send:disabled {
+  color: var(--text-faint);
+  cursor: default;
 }
 
 .richtext-editor .ProseMirror h1,

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -141,11 +141,27 @@
 
 .conversation-drift-note,
 .conversation-status,
+.conversation-load-error,
 .conversation-error {
   margin: 0;
   color: var(--text-muted);
   font-size: var(--type-ui-small);
   line-height: var(--type-ui-line-height);
+}
+
+.conversation-load-error button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.conversation-load-error button:hover,
+.conversation-load-error button:focus-visible {
+  color: var(--text);
 }
 
 .conversation-error {

--- a/Web/src/richtext/editor.ts
+++ b/Web/src/richtext/editor.ts
@@ -30,7 +30,11 @@ import {
 } from './commands';
 import { parseMarkdown, serializeMarkdown } from './markdown';
 import { aiWritingHighlight, setImageWidth } from './operations';
-import { conversationAnchorField, isConversationDecorationTransaction } from './conversationAnchors';
+import {
+  conversationAnchorField,
+  isConversationDecorationTransaction,
+  type ConversationAnchorFieldOptions,
+} from './conversationAnchors';
 import { provenance } from './provenance';
 import { BREAK_ATTRIBUTES, MAX_IMAGE_WIDTH, MIN_IMAGE_WIDTH, tickerSchema } from './schema';
 
@@ -181,6 +185,7 @@ export interface RichTextEditorOptions {
    * can apply metadata to text that moved while an async host action was open.
    */
   onTransaction?: (transaction: Transaction) => void;
+  conversations?: ConversationAnchorFieldOptions;
 }
 
 /** The href of a link at this position, if there is one. */
@@ -287,11 +292,11 @@ function imageView(node: ProseNode, view: EditorView, getPos: () => number | und
   };
 }
 
-function stateFor(doc: ProseNode): EditorState {
+function stateFor(doc: ProseNode, conversations?: ConversationAnchorFieldOptions): EditorState {
   // Order matters: our keymap gets first refusal, then the stock bindings.
   return EditorState.create({
     doc,
-    plugins: [history(), tickerKeymap(), keymap(baseKeymap), aiWritingHighlight(), provenance(), conversationAnchorField()],
+    plugins: [history(), tickerKeymap(), keymap(baseKeymap), aiWritingHighlight(), provenance(), conversationAnchorField(conversations)],
   });
 }
 
@@ -303,11 +308,12 @@ export function createRichTextEditor(options: RichTextEditorOptions): RichTextEd
     onOpenLink,
     onTransaction,
     onUpdate,
+    conversations,
   } = options;
   parent.classList.add('richtext-editor');
 
   const view = new EditorView(parent, {
-    state: stateFor(tickerSchema.nodeFromJSON(JSON.parse(docJSON))),
+    state: stateFor(tickerSchema.nodeFromJSON(JSON.parse(docJSON)), conversations),
     clipboardParser,
     nodeViews: { image: imageView },
     transformCopied: sanitizeTickerClipboardSlice,
@@ -346,7 +352,7 @@ export function createRichTextEditor(options: RichTextEditorOptions): RichTextEd
     },
 
     setDocumentJSON(next: string) {
-      view.updateState(stateFor(tickerSchema.nodeFromJSON(JSON.parse(next))));
+      view.updateState(stateFor(tickerSchema.nodeFromJSON(JSON.parse(next)), conversations));
       onUpdate?.();
     },
 

--- a/Web/src/styles/index.css
+++ b/Web/src/styles/index.css
@@ -583,6 +583,10 @@ body {
   backdrop-filter: var(--overlay-backdrop);
 }
 
+.stream-overflow-panel--conversations {
+  width: min(320px, calc(100vw - 2 * var(--space-4)));
+}
+
 .stream-overflow-panel button {
   width: 100%;
   padding: var(--space-2) var(--space-3);
@@ -622,6 +626,68 @@ body {
   margin-top: var(--space-1);
   border-top: 1px solid var(--border-subtle);
   border-radius: 0 0 var(--radius-small) var(--radius-small);
+}
+
+.conversation-list {
+  max-height: min(360px, 50vh);
+  margin-top: var(--space-1);
+  overflow-y: auto;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.conversation-list > p {
+  margin: 0;
+  padding: var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--type-ui-small);
+}
+
+.conversation-list-row {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.conversation-list-row:last-child {
+  border-bottom: 0;
+}
+
+.stream-overflow-panel .conversation-list-open {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text);
+  white-space: normal;
+}
+
+.stream-overflow-panel .conversation-list-open:hover,
+.stream-overflow-panel .conversation-list-open:focus-visible {
+  background: var(--surface-hover);
+}
+
+.conversation-list-title,
+.conversation-list-meta {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-list-meta {
+  margin-top: var(--space-1);
+  color: var(--text-faint);
+  font-size: var(--type-ui-caption);
+}
+
+.stream-overflow-panel .conversation-list-delete {
+  width: auto;
+  flex: 0 0 auto;
+  color: var(--danger);
+  opacity: 0;
+}
+
+.conversation-list-row:hover .conversation-list-delete,
+.conversation-list-delete:focus-visible {
+  opacity: 1;
 }
 
 /* Shared native modal behavior */

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -64,6 +64,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'clearProxyDeviceKey',
   'createStreamThread',
   'createStream',
+  'deleteStreamThread',
   'deleteStream',
   'editorFlushed',
   'editorSelection',
@@ -237,7 +238,6 @@ export function getExchange(requestId: string): Promise<{ exchange: AIExchangeJS
   return bridge.sendAsync('getExchange', { requestId });
 }
 
-// ponytail: no caller until C3 wires the conversation surface.
 export function listConversations(streamId: string): Promise<{ conversations: ConversationAnchorJSON[] }> {
   return bridge.sendAsync('listConversations', { streamId });
 }
@@ -263,6 +263,16 @@ export function loadStreamThread(
   threadId: string,
 ): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('loadStreamThread', { streamId, threadId });
+}
+
+export function deleteStreamThread(input: {
+  streamId: string;
+  threadId: string;
+}): Promise<{ highlightIds: string[] }> {
+  return bridge.sendAsync('deleteStreamThread', {
+    streamId: input.streamId,
+    threadId: input.threadId,
+  });
 }
 
 export function updateMarginNote(payload: UpdateMarginNotePayload): void {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -62,6 +62,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'cancelDocumentAI',
   'cancelAIOperation',
   'clearProxyDeviceKey',
+  'createStreamThread',
   'createStream',
   'deleteStream',
   'editorFlushed',
@@ -72,6 +73,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'loadSettings',
   'loadStorageState',
   'listConversations',
+  'loadStreamThread',
   'loadStream',
   'loadStreams',
   'getExchange',
@@ -238,6 +240,29 @@ export function getExchange(requestId: string): Promise<{ exchange: AIExchangeJS
 // ponytail: no caller until C3 wires the conversation surface.
 export function listConversations(streamId: string): Promise<{ conversations: ConversationAnchorJSON[] }> {
   return bridge.sendAsync('listConversations', { streamId });
+}
+
+export function createStreamThread(input: {
+  streamId: string;
+  title: string;
+  anchorStart: number;
+  anchorEnd: number;
+  anchorText: string;
+}): Promise<{ thread: StreamThreadJSON }> {
+  return bridge.sendAsync('createStreamThread', {
+    streamId: input.streamId,
+    title: input.title,
+    anchorStart: input.anchorStart,
+    anchorEnd: input.anchorEnd,
+    anchorText: input.anchorText,
+  });
+}
+
+export function loadStreamThread(
+  streamId: string,
+  threadId: string,
+): Promise<{ thread: StreamThreadJSON }> {
+  return bridge.sendAsync('loadStreamThread', { streamId, threadId });
 }
 
 export function updateMarginNote(payload: UpdateMarginNotePayload): void {

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -135,6 +135,10 @@ export interface StreamThreadJSON {
   sourceShortTitle?: string;
   highlightId?: string;
   sourcePage?: number;
+  anchorStart?: number;
+  anchorEnd?: number;
+  detached?: boolean;
+  ephemeral?: boolean;
   revision: number;
   createdAt: string;
   updatedAt: string;

--- a/Web/src/utils/relativeTime.ts
+++ b/Web/src/utils/relativeTime.ts
@@ -1,0 +1,12 @@
+export function formatRelativeTime(dateString: string): string {
+  const age = Date.now() - new Date(dateString).getTime();
+  const minutes = Math.floor(age / 60_000);
+  const hours = Math.floor(age / 3_600_000);
+  const days = Math.floor(age / 86_400_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -158,6 +158,10 @@
       "deletePdfHighlight": {
         "requiredPayloadKeys": ["streamId", "highlightId"]
       },
+      "deleteStreamThread": {
+        "requiredPayloadKeys": ["streamId", "threadId"],
+        "requiredCallbackId": true
+      },
       "cancelDocumentAI": {
         "requiredPayloadKeys": ["requestId"]
       },

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -168,6 +168,10 @@
         "requiredPayloadKeys": [],
         "requiredCallbackId": true
       },
+      "createStreamThread": {
+        "requiredPayloadKeys": ["streamId", "title", "anchorStart", "anchorEnd", "anchorText"],
+        "requiredCallbackId": true
+      },
       "createStream": {
         "requiredPayloadKeys": []
       },
@@ -202,6 +206,10 @@
       },
       "listConversations": {
         "requiredPayloadKeys": ["streamId"],
+        "requiredCallbackId": true
+      },
+      "loadStreamThread": {
+        "requiredPayloadKeys": ["streamId", "threadId"],
         "requiredCallbackId": true
       },
       "loadStream": {


### PR DESCRIPTION
Phase C3 of `docs/CONVERSATIONS_PLAN.md` — the conversation surface itself: ProseMirror block-widget + React portal after the anchor block (document isolation verified airtight: never in markdown/docJSON/clipboard/undo/other AI context), exclusive expansion, gutter create/open, ephemeral-until-first-send creation, streaming composer with Stop, persisted-turn reload, drift note, minimal Conversations list in header overflow. Bridge re-adds: createStreamThread / loadStreamThread / deleteStreamThread.

**Review (Opus): pass-with-notes → fix round `604335d`:** WKWebView-safe delete confirm (window.confirm is a silent no-op — replaced with Modal), send-before-load duplicate-row guard + Retry, detached-anchor surface fallback preserving drafts, cancel-on-collapse/unmount, portal-remount state hoisting (conflict reloads keep composer + stream), memoized turns, behavior-level caret/Tab tests.

**Gates (independent):** build-dev ✓ · swift-test ✓ · typecheck ✓ · 581/581 web tests ✓ · prod build ✓ · contract checker ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)