### PR TITLE
C4: full-context conversations, pinned context, receipts v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: add complete AI context, persistent pins, and receipts to inline conversations (phase C4)
 - editor: open block-anchored conversations inline with streaming replies (phase C3)
 - editor: add durable conversation anchors and passive gutter markers (phase C2)
 - editor: adopt the inline-conversation design language (phase C1)

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -56,6 +56,8 @@ struct ThreadAISentFacts: Codable, Equatable {
     struct Anchor: Codable, Equatable {
         let kind: String
         let text: String
+        let from: Int?
+        let to: Int?
         let sourceId: String?
         let sourceName: String?
         let highlightId: String?
@@ -81,6 +83,17 @@ struct ThreadAISentFacts: Codable, Equatable {
         let shortTitle: String
     }
 
+    struct Pinned: Codable, Equatable {
+        let kind: String
+        let quote: String
+        let from: Int?
+        let to: Int?
+        let sourceId: String?
+        let sourceName: String?
+        let highlightId: String?
+        let page: Int?
+    }
+
     let version: Int
     let kind: String
     let requestId: String
@@ -89,6 +102,7 @@ struct ThreadAISentFacts: Codable, Equatable {
     let turns: Turns
     let sourceContextMode: String
     let sources: [Source]
+    let pinned: [Pinned]
 
     var jsonString: String {
         let encoder = JSONEncoder()
@@ -112,7 +126,8 @@ typealias ThreadAIRoute = (
     _ streamId: UUID,
     _ sourceScope: SourceScope,
     _ anchorText: String,
-    _ workingText: String,
+    _ streamMarkdown: String,
+    _ pinnedContext: [ThreadAIPinnedContext],
     _ priorTurns: [ThreadAIConversationTurn],
     _ onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
     _ onChunk: @escaping (String) -> Void,
@@ -250,14 +265,15 @@ final class AIMessageHandler: BridgeMessageHandler {
                 onModelSelected: onModelSelected
             )
         }
-        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, workingText, priorTurns, onPrepared, onChunk, onComplete, onError, onModelSelected in
+        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, streamMarkdown, pinnedContext, priorTurns, onPrepared, onChunk, onComplete, onError, onModelSelected in
             await orchestrator.routeThread(
                 query: query,
                 retrievalQuery: retrievalQuery,
                 streamId: streamId,
                 sourceScope: sourceScope,
                 anchorText: anchorText,
-                workingText: workingText,
+                streamMarkdown: streamMarkdown,
+                pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
                 onPrepared: onPrepared,
                 onChunk: onChunk,
@@ -289,7 +305,7 @@ final class AIMessageHandler: BridgeMessageHandler {
             _ onError: @escaping (Error) -> Void,
             _ onModelSelected: ((String) -> Void)?
         ) async -> Void,
-        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, onError, _ in
+        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, _, onError, _ in
             onError(OrchestratorError.noProviderAvailable)
         }
     ) {
@@ -533,6 +549,8 @@ final class AIMessageHandler: BridgeMessageHandler {
 
         let thread: StreamThread
         let anchors: [StreamThreadAnchor]
+        let storedStreamMarkdown: String
+        let priorTurns: [ThreadAIConversationTurn]
         do {
             guard let storedThread = try persistence.loadStreamThread(
                 threadId: threadId,
@@ -542,6 +560,14 @@ final class AIMessageHandler: BridgeMessageHandler {
             }
             thread = storedThread
             anchors = try persistence.loadStreamThreadAnchors(threadId: threadId, streamId: streamId)
+            storedStreamMarkdown = try persistence.loadStreamDocument(streamId: streamId)?.markdown ?? ""
+            priorTurns = try persistence.loadThreadExchanges(threadId: threadId, streamId: streamId).map {
+                ThreadAIConversationTurn(
+                    requestId: $0.requestId,
+                    userInput: $0.userInput,
+                    responseRaw: $0.responseRaw
+                )
+            }
         } catch {
             sendToWeb(BridgeMessage(
                 type: "documentAIError",
@@ -556,22 +582,20 @@ final class AIMessageHandler: BridgeMessageHandler {
 
         let sourceScopeRaw = payload["sourceScope"]?.value as? String
         let sourceScope = SourceScope(rawValue: sourceScopeRaw ?? "") ?? .auto
-        let anchorQuotes = anchors
-            .compactMap(\.quote)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        let anchorContext = anchorQuotes
-            .enumerated()
-            .map { anchorQuotes.count > 1 ? "Evidence \($0.offset + 1):\n\($0.element)" : $0.element }
-            .joined(separator: "\n\n")
-        // A canonical legacy thread document already contains every immutable evidence
-        // block. Sending the anchor bundle again makes the model weigh each quote
-        // twice; legacy textarea rows still need the separate starting passage.
-        let canonicalDraft = thread.docJSON != nil && thread.docFormatVersion == 1
-        let sentAnchorContext = canonicalDraft ? "" : (anchorContext.isEmpty ? thread.anchorText : anchorContext)
-        let isCompositeAnchor = anchorQuotes.count > 1
+        let sentAnchorContext = (payload["context"]?.value as? String ?? thread.anchorText)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let streamMarkdown = payload["streamMarkdown"]?.value as? String ?? storedStreamMarkdown
+        let anchorStart = payload["anchorStart"]?.intValue ?? thread.anchorStart
+        let anchorEnd = payload["anchorEnd"]?.intValue ?? thread.anchorEnd
+        let pinnedContext = anchors.compactMap { anchor -> ThreadAIPinnedContext? in
+            guard let quote = anchor.quote, !quote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return ThreadAIPinnedContext(kind: anchor.kind, quote: quote)
+        }
         let outboundQuery = TickerInternalURLSanitizer.sanitize(query)
-        let retrievalQuery = [outboundQuery, sentAnchorContext, thread.workingText]
+        let retrievalQuery = [outboundQuery, sentAnchorContext] + pinnedContext.map(\.quote)
+        let cleanedRetrievalQuery = retrievalQuery
             .map(TickerInternalURLSanitizer.sanitize)
             .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             .joined(separator: "\n")
@@ -585,7 +609,9 @@ final class AIMessageHandler: BridgeMessageHandler {
                 requestId: requestId,
                 thread: thread,
                 anchorText: sentAnchorContext,
-                isCompositeAnchor: isCompositeAnchor,
+                anchorStart: anchorStart,
+                anchorEnd: anchorEnd,
+                anchors: anchors,
                 receipt: receipt
             )
             sentFacts = facts
@@ -611,7 +637,9 @@ final class AIMessageHandler: BridgeMessageHandler {
                 requestId: requestId,
                 thread: thread,
                 anchorText: sentAnchorContext,
-                isCompositeAnchor: isCompositeAnchor,
+                anchorStart: anchorStart,
+                anchorEnd: anchorEnd,
+                anchors: anchors,
                 receipt: receipt
             )
             guard !responseRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -709,12 +737,13 @@ final class AIMessageHandler: BridgeMessageHandler {
 
             await self.routeThreadAI(
                 outboundQuery,
-                retrievalQuery,
+                cleanedRetrievalQuery,
                 streamId,
                 sourceScope,
                 sentAnchorContext,
-                thread.workingText,
-                [],
+                streamMarkdown,
+                pinnedContext,
+                priorTurns,
                 onPrepared,
                 onChunk,
                 onComplete,
@@ -736,7 +765,9 @@ final class AIMessageHandler: BridgeMessageHandler {
         requestId: String,
         thread: StreamThread,
         anchorText: String,
-        isCompositeAnchor: Bool,
+        anchorStart: Int?,
+        anchorEnd: Int?,
+        anchors: [StreamThreadAnchor],
         receipt: ThreadAIRequestReceipt
     ) -> ThreadAISentFacts {
         var source: SourceReference?
@@ -747,9 +778,6 @@ final class AIMessageHandler: BridgeMessageHandler {
                 highlight = try? persistence.loadPDFHighlight(id: highlightId, sourceId: sourceId)
             }
         }
-        let cleanNote = TickerInternalURLSanitizer.sanitize(thread.workingText)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
         let sources: [ThreadAISentFacts.Source]
         if receipt.sourceContext?.mode == .retrieved {
             sources = (DocumentAICitationManifest.entries(from: receipt.sourceContext) ?? []).map {
@@ -781,29 +809,66 @@ final class AIMessageHandler: BridgeMessageHandler {
             sources = []
         }
 
+        let pinned = anchors.compactMap { anchor -> ThreadAISentFacts.Pinned? in
+            guard let quote = anchor.quote, !quote.isEmpty else { return nil }
+            var anchorSource: SourceReference?
+            var anchorHighlight: PDFHighlightRecord?
+            if let persistence, let sourceId = anchor.sourceId {
+                anchorSource = try? persistence.loadSource(id: sourceId)
+                if let highlightId = anchor.highlightId {
+                    anchorHighlight = try? persistence.loadPDFHighlight(id: highlightId, sourceId: sourceId)
+                }
+            }
+            let range = Self.streamAnchorRange(anchor.anchorSpanId)
+            return ThreadAISentFacts.Pinned(
+                kind: anchor.kind.rawValue,
+                quote: quote,
+                from: range?.from,
+                to: range?.to,
+                sourceId: anchor.sourceId?.uuidString,
+                sourceName: anchorSource?.shortTitle,
+                highlightId: anchor.highlightId?.uuidString,
+                page: anchorHighlight?.page
+            )
+        }
+
         return ThreadAISentFacts(
-            version: 1,
+            version: 2,
             kind: "threadAI",
             requestId: requestId,
             anchor: ThreadAISentFacts.Anchor(
-                kind: isCompositeAnchor ? "mixed" : thread.sourceId == nil ? "stream" : "pdf",
+                kind: thread.sourceId == nil ? "stream" : "pdf",
                 text: TickerInternalURLSanitizer.sanitize(anchorText),
-                sourceId: isCompositeAnchor ? nil : thread.sourceId?.uuidString,
-                sourceName: isCompositeAnchor ? nil : source?.shortTitle,
-                highlightId: isCompositeAnchor ? nil : thread.highlightId?.uuidString,
-                page: isCompositeAnchor ? nil : highlight?.page
+                from: anchorStart,
+                to: anchorEnd,
+                sourceId: thread.sourceId?.uuidString,
+                sourceName: source?.shortTitle,
+                highlightId: thread.highlightId?.uuidString,
+                page: highlight?.page
             ),
             note: ThreadAISentFacts.Note(
-                sent: !cleanNote.isEmpty,
-                text: cleanNote.isEmpty ? nil : cleanNote
+                sent: false,
+                text: nil
             ),
             turns: ThreadAISentFacts.Turns(
                 includedRequestIds: receipt.includedPriorRequestIds,
                 totalAtSend: receipt.totalPriorExchangeCount
             ),
             sourceContextMode: Self.sourceContextMode(receipt.sourceContext),
-            sources: sources
+            sources: sources,
+            pinned: pinned
         )
+    }
+
+    private static func streamAnchorRange(_ value: String?) -> (from: Int, to: Int)? {
+        guard let parts = value?.split(separator: ":"),
+              parts.count == 3,
+              parts[0] == "pm",
+              let from = Int(parts[1]),
+              let to = Int(parts[2]),
+              from >= 0,
+              to > from else { return nil }
+        return (from, to)
     }
 
     private static func sourceContextMode(_ context: SourceContext?) -> String {

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -74,6 +74,11 @@ struct ThreadAISentFacts: Codable, Equatable {
         let totalAtSend: Int
     }
 
+    struct StreamDocument: Codable, Equatable {
+        let sent: Bool
+        let charCount: Int
+    }
+
     struct Source: Codable, Equatable {
         let kind: String
         let n: Int?
@@ -98,6 +103,7 @@ struct ThreadAISentFacts: Codable, Equatable {
     let kind: String
     let requestId: String
     let anchor: Anchor
+    let streamDocument: StreamDocument
     let note: Note
     let turns: Turns
     let sourceContextMode: String
@@ -587,10 +593,9 @@ final class AIMessageHandler: BridgeMessageHandler {
         let streamMarkdown = payload["streamMarkdown"]?.value as? String ?? storedStreamMarkdown
         let anchorStart = payload["anchorStart"]?.intValue ?? thread.anchorStart
         let anchorEnd = payload["anchorEnd"]?.intValue ?? thread.anchorEnd
-        let pinnedContext = anchors.compactMap { anchor -> ThreadAIPinnedContext? in
-            guard let quote = anchor.quote, !quote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                return nil
-            }
+        let pinnedAnchors = Self.sentPinnedAnchors(anchors, excluding: thread)
+        let pinnedContext = pinnedAnchors.compactMap { anchor -> ThreadAIPinnedContext? in
+            guard let quote = anchor.quote else { return nil }
             return ThreadAIPinnedContext(kind: anchor.kind, quote: quote)
         }
         let outboundQuery = TickerInternalURLSanitizer.sanitize(query)
@@ -611,7 +616,8 @@ final class AIMessageHandler: BridgeMessageHandler {
                 anchorText: sentAnchorContext,
                 anchorStart: anchorStart,
                 anchorEnd: anchorEnd,
-                anchors: anchors,
+                streamMarkdown: streamMarkdown,
+                anchors: pinnedAnchors,
                 receipt: receipt
             )
             sentFacts = facts
@@ -639,7 +645,8 @@ final class AIMessageHandler: BridgeMessageHandler {
                 anchorText: sentAnchorContext,
                 anchorStart: anchorStart,
                 anchorEnd: anchorEnd,
-                anchors: anchors,
+                streamMarkdown: streamMarkdown,
+                anchors: pinnedAnchors,
                 receipt: receipt
             )
             guard !responseRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -767,6 +774,7 @@ final class AIMessageHandler: BridgeMessageHandler {
         anchorText: String,
         anchorStart: Int?,
         anchorEnd: Int?,
+        streamMarkdown: String,
         anchors: [StreamThreadAnchor],
         receipt: ThreadAIRequestReceipt
     ) -> ThreadAISentFacts {
@@ -810,7 +818,7 @@ final class AIMessageHandler: BridgeMessageHandler {
         }
 
         let pinned = anchors.compactMap { anchor -> ThreadAISentFacts.Pinned? in
-            guard let quote = anchor.quote, !quote.isEmpty else { return nil }
+            guard let quote = anchor.quote else { return nil }
             var anchorSource: SourceReference?
             var anchorHighlight: PDFHighlightRecord?
             if let persistence, let sourceId = anchor.sourceId {
@@ -832,6 +840,7 @@ final class AIMessageHandler: BridgeMessageHandler {
             )
         }
 
+        let sentStreamDocument = AIOrchestrator.threadDocumentText(streamMarkdown)
         return ThreadAISentFacts(
             version: 2,
             kind: "threadAI",
@@ -846,6 +855,10 @@ final class AIMessageHandler: BridgeMessageHandler {
                 highlightId: thread.highlightId?.uuidString,
                 page: highlight?.page
             ),
+            streamDocument: ThreadAISentFacts.StreamDocument(
+                sent: !sentStreamDocument.isEmpty,
+                charCount: sentStreamDocument.count
+            ),
             note: ThreadAISentFacts.Note(
                 sent: false,
                 text: nil
@@ -858,6 +871,25 @@ final class AIMessageHandler: BridgeMessageHandler {
             sources: sources,
             pinned: pinned
         )
+    }
+
+    private static func sentPinnedAnchors(
+        _ anchors: [StreamThreadAnchor],
+        excluding thread: StreamThread
+    ) -> [StreamThreadAnchor] {
+        let primaryQuote = thread.anchorText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return anchors.filter { anchor in
+            guard let quote = anchor.quote,
+                  !quote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+            if !primaryQuote.isEmpty,
+               quote.trimmingCharacters(in: .whitespacesAndNewlines) == primaryQuote { return false }
+            if let range = streamAnchorRange(anchor.anchorSpanId),
+               let primaryFrom = thread.anchorStart,
+               let primaryTo = thread.anchorEnd,
+               range.from == primaryFrom,
+               range.to == primaryTo { return false }
+            return true
+        }
     }
 
     private static func streamAnchorRange(_ value: String?) -> (from: Int, to: Int)? {

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -181,7 +181,15 @@ enum StreamCodec {
             "createdAt": ISO8601DateFormatter().string(from: anchor.createdAt)
         ]
         if let quote = anchor.quote { payload["quote"] = quote }
-        if let anchorSpanId = anchor.anchorSpanId { payload["anchorSpanId"] = anchorSpanId }
+        if let anchorSpanId = anchor.anchorSpanId {
+            payload["anchorSpanId"] = anchorSpanId
+            // ponytail: encode PM positions in the frozen span-id column; add columns if pins become mapped ranges.
+            let parts = anchorSpanId.split(separator: ":")
+            if parts.count == 3, parts[0] == "pm", let from = Int(parts[1]), let to = Int(parts[2]) {
+                payload["anchorStart"] = from
+                payload["anchorEnd"] = to
+            }
+        }
         if let source {
             payload["sourceId"] = source.id.uuidString
             payload["sourceName"] = source.displayName

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -3,10 +3,12 @@ import Foundation
 @MainActor
 final class ThreadMessageHandler: BridgeMessageHandler {
     let handledTypes: Set<String> = [
+        "addStreamThreadAnchor",
         "listConversations",
         "createStreamThread",
         "deleteStreamThread",
         "loadStreamThread",
+        "removeStreamThreadAnchor",
         "saveStreamThread"
     ]
 
@@ -105,6 +107,47 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 respondWithError(callbackId, error.localizedDescription)
             }
 
+        case "addStreamThreadAnchor":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let threadId = decodeUUID(payload, key: "threadId") else {
+                respondWithError(callbackId, "Invalid addStreamThreadAnchor payload")
+                return
+            }
+            do {
+                let decoded = try decodeAnchors(payload["anchors"]?.value, threadId: threadId)
+                guard decoded.anchors.count == 1, decoded.highlights.count <= 1 else {
+                    throw StreamThreadPersistenceError.invalidAnchor
+                }
+                let anchor = try persistence.addStreamThreadAnchor(
+                    decoded.anchors[0],
+                    streamId: streamId,
+                    pdfHighlight: decoded.highlights.first
+                )
+                respond(callbackId, ["anchor": AnyCodable(try encodeAnchor(anchor))])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
+        case "removeStreamThreadAnchor":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let threadId = decodeUUID(payload, key: "threadId"),
+                  let anchorId = payload["anchorId"]?.value as? String,
+                  !anchorId.isEmpty else {
+                respondWithError(callbackId, "Invalid removeStreamThreadAnchor payload")
+                return
+            }
+            do {
+                respond(callbackId, ["removed": AnyCodable(try persistence.removeStreamThreadAnchor(
+                    anchorId: anchorId,
+                    threadId: threadId,
+                    streamId: streamId
+                ))])
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
         case "deleteStreamThread":
             guard let payload = message.payload,
                   let streamId = decodeUUID(payload, key: "streamId"),
@@ -193,6 +236,99 @@ final class ThreadMessageHandler: BridgeMessageHandler {
             exchanges: exchanges,
             anchors: anchors
         )
+    }
+
+    private func encodeAnchor(_ anchor: StreamThreadAnchor) throws -> [String: Any] {
+        let source = try anchor.sourceId.flatMap { try persistence.loadSource(id: $0) }
+        let highlight = try source.flatMap { source in
+            try anchor.highlightId.flatMap {
+                try persistence.loadPDFHighlight(id: $0, sourceId: source.id)
+            }
+        }
+        return StreamCodec.encodeThreadAnchor(anchor, source: source, highlight: highlight)
+    }
+
+    private func decodeAnchors(
+        _ value: Any?,
+        threadId: UUID
+    ) throws -> (anchors: [StreamThreadAnchor], highlights: [PDFHighlightRecord]) {
+        guard let items = value as? [[String: Any]] else {
+            throw StreamThreadPersistenceError.invalidAnchor
+        }
+        var anchors: [StreamThreadAnchor] = []
+        var highlights: [PDFHighlightRecord] = []
+        for item in items {
+            guard let anchorId = item["anchorId"] as? String,
+                  !anchorId.isEmpty,
+                  let kindRaw = item["kind"] as? String,
+                  let kind = StreamThreadAnchorKind(rawValue: kindRaw),
+                  let quote = Self.optionalString(item["quote"]) else {
+                throw StreamThreadPersistenceError.invalidAnchor
+            }
+            let createdAt = Self.dateValue(item["createdAt"]) ?? Date()
+            let anchorSpanId = Self.optionalString(item["anchorSpanId"])
+            let sourceId = Self.optionalString(item["sourceId"]).flatMap(UUID.init(uuidString:))
+            let highlightId = Self.optionalString(item["highlightId"]).flatMap(UUID.init(uuidString:))
+            anchors.append(StreamThreadAnchor(
+                anchorId: anchorId,
+                threadId: threadId,
+                kind: kind,
+                quote: quote,
+                anchorSpanId: anchorSpanId,
+                sourceId: sourceId,
+                highlightId: highlightId,
+                createdAt: createdAt
+            ))
+
+            guard kind == .pdfQuote,
+                  let sourceId,
+                  let highlightId,
+                  let rectItems = item["rects"] as? [[String: Any]],
+                  !rectItems.isEmpty else { continue }
+            let rects = try rectItems.map { rect -> PDFHighlightRect in
+                guard let page = Self.intValue(rect["page"]),
+                      let x = Self.doubleValue(rect["x"]),
+                      let y = Self.doubleValue(rect["y"]),
+                      let w = Self.doubleValue(rect["w"]),
+                      let h = Self.doubleValue(rect["h"]),
+                      page > 0, w > 0, h > 0 else {
+                    throw StreamThreadPersistenceError.invalidAnchor
+                }
+                return PDFHighlightRect(page: page, x: x, y: y, w: w, h: h)
+            }
+            highlights.append(PDFHighlightRecord(
+                id: highlightId,
+                sourceId: sourceId,
+                page: rects[0].page,
+                rects: rects,
+                quote: quote,
+                createdAt: createdAt
+            ))
+        }
+        return (anchors, highlights)
+    }
+
+    private static func optionalString(_ value: Any?) -> String? {
+        guard let value = value as? String, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? Double, value.rounded(.towardZero) == value { return Int(value) }
+        return nil
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        if let value = value as? Double { return value }
+        if let value = value as? Int { return Double(value) }
+        return nil
+    }
+
+    private static func dateValue(_ value: Any?) -> Date? {
+        if let raw = value as? String { return ISO8601DateFormatter().date(from: raw) }
+        if let seconds = doubleValue(value) { return Date(timeIntervalSince1970: seconds) }
+        return nil
     }
 
     private func respond(_ callbackId: String, _ payload: [String: AnyCodable]) {

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -339,6 +339,7 @@ final class PDFReaderPaneController: NSViewController {
     var onRevealHighlightInStream: (@MainActor (PDFHighlightRevealPayload) -> Void)?
     var onDeleteHighlight: (@MainActor (PDFHighlightRevealPayload) -> Bool)?
     var onPageChanged: ((UUID, Int) -> Void)?
+    var onSelectionChanged: (@MainActor (UUID, UUID, String, PDFHighlightRecord?) -> Void)?
     var highlightsProvider: ((UUID) -> [PDFHighlightRecord])?
     var sectionProvider: ((UUID, UUID, Int) throws -> PDFSectionDescriptor)?
     var onClose: (() -> Void)?
@@ -1515,10 +1516,12 @@ final class PDFReaderPaneController: NSViewController {
     @objc private func handlePDFPaneSelectionChanged() {
         guard !isAnchorPickMode else {
             setPDFSelectionActionsEnabled(false)
+            notifySelectionChanged(nil)
             return
         }
-        let selectedText = pdfPanePDFView.currentSelection?.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        setPDFSelectionActionsEnabled(!selectedText.isEmpty)
+        let payload = currentSelectionPayload()
+        setPDFSelectionActionsEnabled(payload != nil)
+        notifySelectionChanged(payload?.highlight)
     }
 
     @objc private func handlePDFPanePageChanged() {
@@ -1678,44 +1681,47 @@ final class PDFReaderPaneController: NSViewController {
     ) {
         exitAnchorPickMode(notifyCancelled: true)
 
-        guard let context = activePDFContext else {
+        guard activePDFContext != nil else {
             showPDFPaneMessage(missingPDFMessage)
             return
         }
-        guard let selection = pdfPanePDFView.currentSelection else {
+        guard pdfPanePDFView.currentSelection != nil else {
             showPDFPaneMessage(missingSelectionMessage)
             return
         }
-
-        let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !quote.isEmpty else {
-            showPDFPaneMessage(missingSelectionMessage)
-            return
-        }
-
-        let rects = highlightRects(for: selection)
-        guard let firstRect = rects.first else {
+        guard let payload = currentSelectionPayload() else {
             showPDFPaneMessage(invalidSelectionMessage)
             return
         }
-
-        let highlight = PDFHighlightRecord(
-            id: UUID(),
-            sourceId: context.sourceId,
-            page: firstRect.page,
-            rects: rects,
-            quote: quote,
-            createdAt: Date()
-        )
-        let payload = PDFHighlightLinkPayload(
-            streamId: context.streamId,
-            sourceName: context.sourceName,
-            highlight: highlight
-        )
         guard action?(payload) == true else { return }
 
-        applyHighlight(highlight)
+        applyHighlight(payload.highlight)
         pdfPanePDFView.clearSelection()
+    }
+
+    private func currentSelectionPayload() -> PDFHighlightLinkPayload? {
+        guard let context = activePDFContext,
+              let selection = pdfPanePDFView.currentSelection else { return nil }
+        let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let rects = highlightRects(for: selection)
+        guard !quote.isEmpty, let firstRect = rects.first else { return nil }
+        return PDFHighlightLinkPayload(
+            streamId: context.streamId,
+            sourceName: context.sourceName,
+            highlight: PDFHighlightRecord(
+                id: UUID(),
+                sourceId: context.sourceId,
+                page: firstRect.page,
+                rects: rects,
+                quote: quote,
+                createdAt: Date()
+            )
+        )
+    }
+
+    private func notifySelectionChanged(_ highlight: PDFHighlightRecord?) {
+        guard let context = activePDFContext else { return }
+        onSelectionChanged?(context.streamId, context.sourceId, context.sourceName, highlight)
     }
 
     private func highlightRects(for selection: PDFSelection) -> [PDFHighlightRect] {

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -388,6 +388,13 @@ final class PDFReaderPaneController: NSViewController {
     private var pdfHighlightClickTracker: PDFHighlightClickTracker?
     private var anchorPickPreviousAcceptsMouseMovedEvents: Bool?
     private var pdfFindDebounceWorkItem: DispatchWorkItem?
+    private var pdfSelectionNotifyWorkItem: DispatchWorkItem?
+    private var pdfSelectionCache: (
+        sourceId: UUID,
+        quote: String,
+        rects: [PDFHighlightRect],
+        payload: PDFHighlightLinkPayload
+    )?
     private var pdfFindGeneration = 0
     private var pdfFindMatches: [PDFSelection] = []
     private var pdfFindCurrentIndex: Int?
@@ -401,6 +408,7 @@ final class PDFReaderPaneController: NSViewController {
     deinit {
         pdfFindDebounceWorkItem?.cancel()
         pdfPageSaveWorkItem?.cancel()
+        pdfSelectionNotifyWorkItem?.cancel()
         pdfPaneMessageWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self)
         if let pdfHighlightActivationMonitor {
@@ -1494,6 +1502,9 @@ final class PDFReaderPaneController: NSViewController {
         exitAnchorPickMode(notifyCancelled: false)
         flushPDFPageSave()
         pdfPageSaveWorkItem?.cancel()
+        pdfSelectionNotifyWorkItem?.cancel()
+        pdfSelectionNotifyWorkItem = nil
+        pdfSelectionCache = nil
         pdfPaneMessageWorkItem?.cancel()
         pdfPaneTransientMessage = nil
         resetPDFFindState()
@@ -1516,12 +1527,12 @@ final class PDFReaderPaneController: NSViewController {
     @objc private func handlePDFPaneSelectionChanged() {
         guard !isAnchorPickMode else {
             setPDFSelectionActionsEnabled(false)
-            notifySelectionChanged(nil)
+            scheduleSelectionChanged(nil)
             return
         }
         let payload = currentSelectionPayload()
         setPDFSelectionActionsEnabled(payload != nil)
-        notifySelectionChanged(payload?.highlight)
+        scheduleSelectionChanged(payload?.highlight)
     }
 
     @objc private func handlePDFPanePageChanged() {
@@ -1701,11 +1712,23 @@ final class PDFReaderPaneController: NSViewController {
 
     private func currentSelectionPayload() -> PDFHighlightLinkPayload? {
         guard let context = activePDFContext,
-              let selection = pdfPanePDFView.currentSelection else { return nil }
+              let selection = pdfPanePDFView.currentSelection else {
+            pdfSelectionCache = nil
+            return nil
+        }
         let quote = selection.string?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let rects = highlightRects(for: selection)
-        guard !quote.isEmpty, let firstRect = rects.first else { return nil }
-        return PDFHighlightLinkPayload(
+        guard !quote.isEmpty, let firstRect = rects.first else {
+            pdfSelectionCache = nil
+            return nil
+        }
+        if let cached = pdfSelectionCache,
+           cached.sourceId == context.sourceId,
+           cached.quote == quote,
+           cached.rects == rects {
+            return cached.payload
+        }
+        let payload = PDFHighlightLinkPayload(
             streamId: context.streamId,
             sourceName: context.sourceName,
             highlight: PDFHighlightRecord(
@@ -1717,6 +1740,18 @@ final class PDFReaderPaneController: NSViewController {
                 createdAt: Date()
             )
         )
+        pdfSelectionCache = (context.sourceId, quote, rects, payload)
+        return payload
+    }
+
+    private func scheduleSelectionChanged(_ highlight: PDFHighlightRecord?) {
+        pdfSelectionNotifyWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pdfSelectionNotifyWorkItem = nil
+            self?.notifySelectionChanged(highlight)
+        }
+        pdfSelectionNotifyWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
     }
 
     private func notifySelectionChanged(_ highlight: PDFHighlightRecord?) {

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -219,6 +219,15 @@ final class WebViewManager: NSObject {
                 DebugLog.log("[WebViewManager] Failed to save PDF page position (\(DebugLog.errorSummary(error)))")
             }
         }
+        pdfPaneController.onSelectionChanged = { [weak self] streamId, sourceId, sourceName, selection in
+            self?.sendPDFPaneStateChanged(
+                visible: true,
+                streamId: streamId,
+                sourceId: sourceId,
+                sourceName: sourceName,
+                selection: selection
+            )
+        }
         pdfPaneController.onClose = { [weak self] in
             Task { @MainActor in
                 self?.activePDFPaneStreamId = nil
@@ -428,7 +437,8 @@ final class WebViewManager: NSObject {
         visible: Bool,
         streamId: UUID? = nil,
         sourceId: UUID? = nil,
-        sourceName: String? = nil
+        sourceName: String? = nil,
+        selection: PDFHighlightRecord? = nil
     ) {
         var payload: [String: AnyCodable] = ["visible": AnyCodable(visible)]
         if let streamId {
@@ -440,6 +450,17 @@ final class WebViewManager: NSObject {
         if let sourceName {
             payload["sourceName"] = AnyCodable(sourceName)
             payload["shortTitle"] = AnyCodable(SourceShortTitle.derive(displayName: sourceName))
+        }
+        if let selection {
+            payload["selection"] = AnyCodable([
+                "highlightId": selection.id.uuidString,
+                "page": selection.page,
+                "quote": selection.quote,
+                "createdAt": ISO8601DateFormatter().string(from: selection.createdAt),
+                "rects": selection.rects.map { rect in
+                    ["page": rect.page, "x": rect.x, "y": rect.y, "w": rect.w, "h": rect.h]
+                }
+            ])
         }
         bridgeService.send(BridgeMessage(type: "pdfPaneStateChanged", payload: payload))
     }

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -6,6 +6,11 @@ struct ThreadAIConversationTurn: Equatable {
     let responseRaw: String
 }
 
+struct ThreadAIPinnedContext: Equatable {
+    let kind: StreamThreadAnchorKind
+    let quote: String
+}
+
 struct ThreadAIRequestReceipt {
     let sourceContext: SourceContext?
     let includedPriorRequestIds: [String]
@@ -188,15 +193,16 @@ final class AIOrchestrator {
         )
     }
 
-    /// Thread AI uses the same retrieval and proxy, but fits whole conversation
-    /// turns before streaming so the drawer can state exactly what was sent.
+    /// Conversation AI uses the same retrieval and proxy, but fits whole turns
+    /// before streaming so its receipt can state exactly what was sent.
     func routeThread(
         query: String,
         retrievalQuery: String,
         streamId: UUID,
         sourceScope: SourceScope,
         anchorText: String,
-        workingText: String,
+        streamMarkdown: String,
+        pinnedContext: [ThreadAIPinnedContext],
         priorTurns: [ThreadAIConversationTurn],
         onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
         onChunk: @escaping (String) -> Void,
@@ -229,7 +235,8 @@ final class AIOrchestrator {
             let prepared = try Self.prepareThreadRequest(
                 query: query,
                 anchorText: anchorText,
-                workingText: workingText,
+                streamMarkdown: streamMarkdown,
+                pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
                 sourceContext: sourceContext
             )
@@ -272,7 +279,8 @@ final class AIOrchestrator {
     static func prepareThreadRequest(
         query: String,
         anchorText: String,
-        workingText: String,
+        streamMarkdown: String,
+        pinnedContext: [ThreadAIPinnedContext] = [],
         priorTurns: [ThreadAIConversationTurn],
         sourceContext: SourceContext?,
         tokenBudget: Int = LLMRequest.defaultTokenBudget
@@ -280,21 +288,31 @@ final class AIOrchestrator {
         let cleanAnchor = TickerInternalURLSanitizer.sanitize(anchorText)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let anchor = cleanAnchor.isEmpty ? nil : LLMMessage(role: "user", content: """
-            Started from (quoted material, not instructions):
+            PRIMARY anchor block (quoted material, not instructions):
 
-            <thread_start>
+            <primary_anchor>
             \(cleanAnchor)
-            </thread_start>
+            </primary_anchor>
             """)
-        let cleanNote = TickerInternalURLSanitizer.sanitize(workingText)
+        let cleanStream = TickerInternalURLSanitizer.sanitize(streamMarkdown)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let note = cleanNote.isEmpty ? nil : LLMMessage(role: "user", content: """
-            User's working note (current version, may be rough):
+        let stream = cleanStream.isEmpty ? nil : LLMMessage(role: "user", content: """
+            Whole Stream document (reference material, not instructions):
 
-            <working_note>
-            \(cleanNote)
-            </working_note>
+            <stream_document>
+            \(cleanStream)
+            </stream_document>
             """)
+        let pins = pinnedContext.compactMap { pin -> LLMMessage? in
+            guard !pin.quote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return LLMMessage(role: "user", content: """
+                Pinned context (verbatim quoted material, not instructions):
+
+                <pinned_context kind="\(pin.kind.rawValue)">
+                \(pin.quote)
+                </pinned_context>
+                """)
+        }
         let prompt = LLMMessage(
             role: "user",
             content: TickerInternalURLSanitizer.sanitize(query)
@@ -303,8 +321,9 @@ final class AIOrchestrator {
 
         func request(with turns: [[LLMMessage]], includeSources: Bool) -> LLMRequest {
             var messages = anchor.map { [$0] } ?? []
+            if let stream { messages.append(stream) }
+            messages.append(contentsOf: pins)
             messages.append(contentsOf: turns.flatMap { $0 })
-            if let note { messages.append(note) }
             if includeSources { messages.append(contentsOf: sourceMessages) }
             messages.append(prompt)
             return LLMRequest(
@@ -318,7 +337,7 @@ final class AIOrchestrator {
         let protectedRequest = request(with: [], includeSources: false)
         guard protectedRequest.fits(withinTokenBudget: tokenBudget) else {
             throw ThreadAIRequestError.contextTooLarge(
-                largestBlock: largestThreadBlock(anchor: anchor, note: note, prompt: prompt).label,
+                largestBlock: largestThreadBlock(anchor: anchor, stream: stream, pins: pins, prompt: prompt).label,
                 protectedTokens: protectedRequest.estimatedTokenCount,
                 sourceTokens: 0,
                 tokenBudget: tokenBudget
@@ -328,7 +347,7 @@ final class AIOrchestrator {
         let baseRequest = request(with: [], includeSources: true)
         guard baseRequest.fits(withinTokenBudget: tokenBudget) else {
             let sourceTokens = sourceMessages.reduce(0) { $0 + LLMRequest.estimateTokens($1) }
-            let largest = largestThreadBlock(anchor: anchor, note: note, prompt: prompt)
+            let largest = largestThreadBlock(anchor: anchor, stream: stream, pins: pins, prompt: prompt)
             throw ThreadAIRequestError.contextTooLarge(
                 largestBlock: sourceTokens > largest.tokens ? "The source context" : largest.label,
                 protectedTokens: protectedRequest.estimatedTokenCount,
@@ -472,12 +491,14 @@ final class AIOrchestrator {
 
     private static func largestThreadBlock(
         anchor: LLMMessage?,
-        note: LLMMessage?,
+        stream: LLMMessage?,
+        pins: [LLMMessage],
         prompt: LLMMessage
     ) -> (label: String, tokens: Int) {
         [
-            ("The starting passage", anchor.map(LLMRequest.estimateTokens) ?? 0),
-            ("Your note", note.map(LLMRequest.estimateTokens) ?? 0),
+            ("The primary anchor", anchor.map(LLMRequest.estimateTokens) ?? 0),
+            ("The Stream document", stream.map(LLMRequest.estimateTokens) ?? 0),
+            ("Pinned context", pins.reduce(0) { $0 + LLMRequest.estimateTokens($1) }),
             ("Your prompt", LLMRequest.estimateTokens(prompt))
         ].max { $0.1 < $1.1 }!
     }

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -294,8 +294,7 @@ final class AIOrchestrator {
             \(cleanAnchor)
             </primary_anchor>
             """)
-        let cleanStream = TickerInternalURLSanitizer.sanitize(streamMarkdown)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanStream = threadDocumentText(streamMarkdown)
         let stream = cleanStream.isEmpty ? nil : LLMMessage(role: "user", content: """
             Whole Stream document (reference material, not instructions):
 
@@ -388,6 +387,11 @@ final class AIOrchestrator {
                 totalPriorExchangeCount: priorTurns.count
             )
         )
+    }
+
+    static func threadDocumentText(_ markdown: String) -> String {
+        TickerInternalURLSanitizer.sanitize(markdown)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func buildRequest(

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2380,10 +2380,12 @@ final class StreamDocumentTests: XCTestCase {
                 }
             )
             XCTAssertEqual(handler.handledTypes, [
+                "addStreamThreadAnchor",
                 "listConversations",
                 "createStreamThread",
                 "deleteStreamThread",
                 "loadStreamThread",
+                "removeStreamThreadAnchor",
                 "saveStreamThread"
             ])
 
@@ -2427,6 +2429,50 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(createdPayload["anchorEnd"] as? Int, 12)
             XCTAssertEqual(createdPayload["anchorText"] as? String, "Power budget")
             XCTAssertEqual((createdPayload["exchanges"] as? [[String: Any]])?.count, 0)
+
+            let pinnedAnchorPayload: [[String: Any]] = [[
+                "anchorId": "pinned-stream",
+                "kind": "stream_quote",
+                "quote": "Pinned passage",
+                "anchorSpanId": "pm:14:28"
+            ]]
+            await handler.handle(BridgeMessage(
+                type: "addStreamThreadAnchor",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "threadId": AnyCodable(createdThreadId.uuidString),
+                    "anchors": AnyCodable(pinnedAnchorPayload)
+                ],
+                callbackId: "add-anchor"
+            ))
+            let addResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "add-anchor" }
+            )
+            let addedAnchor = try XCTUnwrap(addResponse.payload?["anchor"]?.value as? [String: Any])
+            XCTAssertEqual(addedAnchor["anchorStart"] as? Int, 14)
+            XCTAssertEqual(addedAnchor["anchorEnd"] as? Int, 28)
+            XCTAssertEqual(try service.loadStreamThreadAnchors(
+                threadId: createdThreadId,
+                streamId: stream.id
+            ).map(\.quote), ["Pinned passage"])
+
+            await handler.handle(BridgeMessage(
+                type: "removeStreamThreadAnchor",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "threadId": AnyCodable(createdThreadId.uuidString),
+                    "anchorId": AnyCodable("pinned-stream")
+                ],
+                callbackId: "remove-anchor"
+            ))
+            let removeResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "remove-anchor" }
+            )
+            XCTAssertEqual(removeResponse.payload?["removed"]?.value as? Bool, true)
+            XCTAssertEqual(try service.loadStreamThreadAnchors(
+                threadId: createdThreadId,
+                streamId: stream.id
+            ), [])
 
             try service.saveExchange(AIExchange(
                 requestId: "conversation-turn",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -6658,6 +6658,25 @@ final class StreamDocumentTests: XCTestCase {
             responseRaw: "Existing answer",
             createdAt: Date(timeIntervalSince1970: 5_001)
         )
+        let prototypeThread = StreamThread(
+            streamId: stream.id,
+            title: "Existing sidenote",
+            workingText: "Existing draft",
+            docJSON: #"{"type":"doc","content":[]}"#,
+            docFormatVersion: 1,
+            anchorText: "Existing passage",
+            anchorSpanId: "existing-span",
+            createdAt: Date(timeIntervalSince1970: 5_002),
+            updatedAt: Date(timeIntervalSince1970: 5_003)
+        )
+        let prototypeAnchor = StreamThreadAnchor(
+            anchorId: "existing-anchor",
+            threadId: prototypeThread.threadId,
+            kind: .streamQuote,
+            quote: prototypeThread.anchorText,
+            anchorSpanId: prototypeThread.anchorSpanId,
+            createdAt: prototypeThread.createdAt
+        )
 
         var service: PersistenceService? = try PersistenceService(
             databaseURL: dbURL,
@@ -6668,20 +6687,18 @@ final class StreamDocumentTests: XCTestCase {
         try service?.saveSource(source)
         try service?.savePDFHighlight(highlight)
         try service?.saveExchange(exchange)
+        try service?.createStreamThread(prototypeThread, anchors: [prototypeAnchor])
         service = nil
 
-        // Turn the fresh database into the exact pre-v28 shape while preserving
-        // representative released data. Reopening it must exercise v28 and v29.
+        // Turn the fresh database into the exact released v29 shape while preserving
+        // representative prototype data. Reopening it must run the real v30 migrator.
         var dbQueue: DatabaseQueue? = try DatabaseQueue(path: dbURL.path)
         try dbQueue?.write { db in
-            try db.execute(sql: "DROP TABLE stream_thread_anchors")
-            try db.execute(sql: "ALTER TABLE ai_exchanges DROP COLUMN thread_disposition")
-            try db.execute(sql: "DROP INDEX idx_ai_exchanges_thread")
-            try db.execute(sql: "ALTER TABLE ai_exchanges DROP COLUMN thread_id")
-            try db.execute(sql: "DROP TABLE stream_threads")
-            try db.execute(
-                sql: "DELETE FROM grdb_migrations WHERE identifier IN ('v28_stream_threads', 'v29_sidenote_documents')"
-            )
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN ephemeral")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN detached")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_end")
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_start")
+            try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v30_conversation_anchors'")
         }
         dbQueue = nil
 
@@ -6695,7 +6712,24 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(try service?.loadSource(id: source.id)?.displayName, source.displayName)
         XCTAssertEqual(try service?.loadPDFHighlights(sourceId: source.id), [highlight])
         XCTAssertEqual(try service?.loadExchange(requestId: exchange.requestId), exchange)
-        XCTAssertTrue(try service?.loadStreamThreads(streamId: stream.id).isEmpty == true)
+        let migratedThread = try XCTUnwrap(service?.loadStreamThreads(streamId: stream.id).first)
+        XCTAssertEqual(migratedThread.threadId, prototypeThread.threadId)
+        XCTAssertEqual(migratedThread.title, prototypeThread.title)
+        XCTAssertEqual(migratedThread.workingText, prototypeThread.workingText)
+        XCTAssertEqual(migratedThread.docJSON, prototypeThread.docJSON)
+        XCTAssertEqual(migratedThread.docFormatVersion, prototypeThread.docFormatVersion)
+        XCTAssertEqual(migratedThread.anchorText, prototypeThread.anchorText)
+        XCTAssertNil(migratedThread.anchorStart)
+        XCTAssertNil(migratedThread.anchorEnd)
+        XCTAssertTrue(migratedThread.detached)
+        XCTAssertFalse(migratedThread.ephemeral)
+        XCTAssertEqual(
+            try service?.loadStreamThreadAnchors(
+                threadId: prototypeThread.threadId,
+                streamId: stream.id
+            ),
+            [prototypeAnchor]
+        )
         service = nil
 
         let backupURL = try XCTUnwrap(preMigrationBackups(nextTo: dbURL, fileManager: fileManager).first)
@@ -6707,15 +6741,34 @@ final class StreamDocumentTests: XCTestCase {
             )
             let exchangeColumns = try Row.fetchAll(db, sql: "PRAGMA table_info(ai_exchanges)")
                 .map { (row: Row) -> String in row["name"] }
+            let threadColumns = try Row.fetchAll(db, sql: "PRAGMA table_info(stream_threads)")
+                .map { (row: Row) -> String in row["name"] }
             let storedAnswer = try String.fetchOne(
                 db,
                 sql: "SELECT response_raw FROM ai_exchanges WHERE request_id = ?",
                 arguments: [exchange.requestId]
             )
+            let storedThreadTitle = try String.fetchOne(
+                db,
+                sql: "SELECT title FROM stream_threads WHERE thread_id = ?",
+                arguments: [prototypeThread.threadId.uuidString]
+            )
+            let migrations = try String.fetchAll(db, sql: "SELECT identifier FROM grdb_migrations")
 
-            XCTAssertFalse(tables.contains("stream_threads"))
-            XCTAssertFalse(exchangeColumns.contains("thread_id"))
+            XCTAssertTrue(tables.contains("stream_threads"))
+            XCTAssertTrue(tables.contains("stream_thread_anchors"))
+            XCTAssertTrue(exchangeColumns.contains("thread_id"))
+            XCTAssertTrue(exchangeColumns.contains("thread_disposition"))
+            XCTAssertTrue(threadColumns.contains("doc_json"))
+            XCTAssertTrue(threadColumns.contains("doc_format_version"))
+            XCTAssertFalse(threadColumns.contains("anchor_start"))
+            XCTAssertFalse(threadColumns.contains("anchor_end"))
+            XCTAssertFalse(threadColumns.contains("detached"))
+            XCTAssertFalse(threadColumns.contains("ephemeral"))
+            XCTAssertTrue(migrations.contains("v29_sidenote_documents"))
+            XCTAssertFalse(migrations.contains("v30_conversation_anchors"))
             XCTAssertEqual(storedAnswer, exchange.responseRaw)
+            XCTAssertEqual(storedThreadTitle, prototypeThread.title)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1289,12 +1289,12 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(truncated.messages.map(\.content), prepared.request.messages.map(\.content))
     }
 
-    func test_conversationAIFramesPrimaryWholeStreamAndPinnedContextExactlyOnce() throws {
+    func test_conversationAIFramesAndSanitizesPrimaryStreamAndPinnedMaterial() throws {
         let pinnedQuote = "Pinned [link](ticker-pdf://private) verbatim."
         let prepared = try AIOrchestrator.prepareThreadRequest(
             query: "Check this",
             anchorText: "Primary block",
-            streamMarkdown: "Whole [Stream](ticker-thread://private)",
+            streamMarkdown: "Primary block\n\nWhole [Stream](ticker-thread://private)",
             pinnedContext: [ThreadAIPinnedContext(kind: .pdfQuote, quote: pinnedQuote)],
             priorTurns: [],
             sourceContext: nil
@@ -1303,9 +1303,11 @@ final class StreamDocumentTests: XCTestCase {
 
         XCTAssertTrue(content.contains("PRIMARY anchor block"))
         XCTAssertTrue(content.contains("<primary_anchor>\nPrimary block\n</primary_anchor>"))
-        XCTAssertTrue(content.contains("<stream_document>\nWhole Stream\n</stream_document>"))
+        XCTAssertTrue(content.contains("<stream_document>\nPrimary block\n\nWhole Stream\n</stream_document>"))
         XCTAssertTrue(content.contains("<pinned_context kind=\"pdf_quote\">\n\(pinnedQuote)\n</pinned_context>"))
         XCTAssertEqual(content.components(separatedBy: pinnedQuote).count - 1, 1)
+        let pinnedFrames = prepared.request.messages.filter { $0.content.contains("<pinned_context") }
+        XCTAssertFalse(pinnedFrames.contains { $0.content.contains("Primary block") })
     }
 
     func test_threadAIRequestRefusesOneTokenPastProtectedBoundary() throws {
@@ -1629,6 +1631,19 @@ final class StreamDocumentTests: XCTestCase {
                     threadId: thread.threadId,
                     kind: .streamQuote,
                     quote: "A second constraint."
+                ),
+                StreamThreadAnchor(
+                    anchorId: "anchor-range-duplicate",
+                    threadId: thread.threadId,
+                    kind: .streamQuote,
+                    quote: "Same primary range",
+                    anchorSpanId: "pm:1:58"
+                ),
+                StreamThreadAnchor(
+                    anchorId: "anchor-whitespace",
+                    threadId: thread.threadId,
+                    kind: .streamQuote,
+                    quote: " \n "
                 )
             ])
             let prior = AIExchange(
@@ -1654,7 +1669,7 @@ final class StreamDocumentTests: XCTestCase {
                     routedRetrievalQuery = retrievalQuery
                     XCTAssertEqual(anchorText, thread.anchorText)
                     XCTAssertEqual(streamMarkdown, "Stream stays unchanged.")
-                    XCTAssertEqual(pinned.map(\.quote), [thread.anchorText, "A second constraint."])
+                    XCTAssertEqual(pinned.map(\.quote), ["A second constraint."])
                     XCTAssertEqual(turns.map(\.requestId), [prior.requestId])
                     let receipt = ThreadAIRequestReceipt(
                         sourceContext: SourceContext(
@@ -1708,7 +1723,10 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(turns["includedRequestIds"] as? [String], [prior.requestId])
             XCTAssertEqual(turns["totalAtSend"] as? Int, 1)
             let pinned = try XCTUnwrap(receipt["pinned"] as? [[String: Any]])
-            XCTAssertEqual(pinned.map { $0["quote"] as? String }, [thread.anchorText, "A second constraint."])
+            XCTAssertEqual(pinned.map { $0["quote"] as? String }, ["A second constraint."])
+            let streamDocument = try XCTUnwrap(receipt["streamDocument"] as? [String: Any])
+            XCTAssertEqual(streamDocument["sent"] as? Bool, true)
+            XCTAssertEqual(streamDocument["charCount"] as? Int, "Stream stays unchanged.".count)
             let sources = try XCTUnwrap(receipt["sources"] as? [[String: Any]])
             XCTAssertEqual(sources.map { $0["sourceId"] as? String }, [sentSource.id.uuidString])
             XCTAssertFalse(sources.contains { $0["sourceId"] as? String == otherSource.id.uuidString })
@@ -1961,8 +1979,8 @@ final class StreamDocumentTests: XCTestCase {
 
             XCTAssertThrowsError(try service.saveStreamDocument(
                 streamId: stream.id,
-                docJSON: initial.docJSON,
-                docFormatVersion: initial.docFormatVersion,
+                docJSON: docJSON,
+                docFormatVersion: 1,
                 markdown: "stale",
                 baseRevision: initial.revision,
                 spans: [],

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1260,7 +1260,7 @@ final class StreamDocumentTests: XCTestCase {
         let withoutHistory = try AIOrchestrator.prepareThreadRequest(
             query: "What follows?",
             anchorText: "A fixed starting passage.",
-            workingText: "My current note.",
+            streamMarkdown: "My current Stream.",
             priorTurns: [],
             sourceContext: nil
         )
@@ -1275,7 +1275,7 @@ final class StreamDocumentTests: XCTestCase {
         let prepared = try AIOrchestrator.prepareThreadRequest(
             query: "What follows?",
             anchorText: "A fixed starting passage.",
-            workingText: "My current note.",
+            streamMarkdown: "My current Stream.",
             priorTurns: [old, recent],
             sourceContext: nil,
             tokenBudget: boundary
@@ -1289,11 +1289,30 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(truncated.messages.map(\.content), prepared.request.messages.map(\.content))
     }
 
+    func test_conversationAIFramesPrimaryWholeStreamAndPinnedContextExactlyOnce() throws {
+        let pinnedQuote = "Pinned [link](ticker-pdf://private) verbatim."
+        let prepared = try AIOrchestrator.prepareThreadRequest(
+            query: "Check this",
+            anchorText: "Primary block",
+            streamMarkdown: "Whole [Stream](ticker-thread://private)",
+            pinnedContext: [ThreadAIPinnedContext(kind: .pdfQuote, quote: pinnedQuote)],
+            priorTurns: [],
+            sourceContext: nil
+        )
+        let content = prepared.request.messages.map(\.content).joined(separator: "\n")
+
+        XCTAssertTrue(content.contains("PRIMARY anchor block"))
+        XCTAssertTrue(content.contains("<primary_anchor>\nPrimary block\n</primary_anchor>"))
+        XCTAssertTrue(content.contains("<stream_document>\nWhole Stream\n</stream_document>"))
+        XCTAssertTrue(content.contains("<pinned_context kind=\"pdf_quote\">\n\(pinnedQuote)\n</pinned_context>"))
+        XCTAssertEqual(content.components(separatedBy: pinnedQuote).count - 1, 1)
+    }
+
     func test_threadAIRequestRefusesOneTokenPastProtectedBoundary() throws {
         let fitted = try AIOrchestrator.prepareThreadRequest(
             query: "Question",
             anchorText: "Starting passage",
-            workingText: "Working note",
+            streamMarkdown: "Whole Stream",
             priorTurns: [],
             sourceContext: nil
         )
@@ -1302,7 +1321,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertThrowsError(try AIOrchestrator.prepareThreadRequest(
             query: "Question",
             anchorText: "Starting passage",
-            workingText: "Working note",
+            streamMarkdown: "Whole Stream",
             priorTurns: [],
             sourceContext: nil,
             tokenBudget: exactBudget - 1
@@ -1322,7 +1341,7 @@ final class StreamDocumentTests: XCTestCase {
         let protected = try AIOrchestrator.prepareThreadRequest(
             query: "Question",
             anchorText: "Starting passage",
-            workingText: "Working note",
+            streamMarkdown: "Whole Stream",
             priorTurns: [],
             sourceContext: nil
         )
@@ -1338,7 +1357,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertThrowsError(try AIOrchestrator.prepareThreadRequest(
             query: "Question",
             anchorText: "Starting passage",
-            workingText: "Working note",
+            streamMarkdown: "Whole Stream",
             priorTurns: [],
             sourceContext: sourceContext,
             tokenBudget: protectedBudget
@@ -1368,7 +1387,7 @@ final class StreamDocumentTests: XCTestCase {
         let prepared = try AIOrchestrator.prepareThreadRequest(
             query: "Follow up",
             anchorText: "Starting passage",
-            workingText: "",
+            streamMarkdown: "Whole Stream",
             priorTurns: [ThreadAIConversationTurn(
                 requestId: "earlier",
                 userInput: "How many controllers?",
@@ -1557,7 +1576,7 @@ final class StreamDocumentTests: XCTestCase {
     }
 
     @MainActor
-    func test_threadAIStoresRawPromptAndExactSentReceiptWithoutChangingStream() async throws {
+    func test_conversationAISendsFullContextAndPersistsVersion2ReceiptWithoutChangingStream() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Thread AI")
             try service.saveStream(stream)
@@ -1594,7 +1613,9 @@ final class StreamDocumentTests: XCTestCase {
                 workingText: canonicalWorkingText,
                 docJSON: #"{"type":"doc","content":[]}"#,
                 docFormatVersion: 1,
-                anchorText: "Read [the source](ticker-pdf://private-source?page=2)."
+                anchorText: "Read [the source](ticker-pdf://private-source?page=2).",
+                anchorStart: 1,
+                anchorEnd: 58
             )
             try service.createStreamThread(thread, anchors: [
                 StreamThreadAnchor(
@@ -1628,17 +1649,13 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { query, retrievalQuery, _, _, anchorText, workingText, turns, onPrepared, onChunk, onComplete, _, onModelSelected in
+                routeThreadAI: { query, retrievalQuery, _, _, anchorText, streamMarkdown, pinned, turns, onPrepared, onChunk, onComplete, _, onModelSelected in
                     routedQuery = query
                     routedRetrievalQuery = retrievalQuery
-                    XCTAssertEqual(anchorText, "")
-                    XCTAssertEqual(workingText, canonicalWorkingText)
-                    XCTAssertEqual(
-                        (anchorText + workingText).components(separatedBy: "A second constraint.").count - 1,
-                        1,
-                        "canonical evidence must be sent exactly once"
-                    )
-                    XCTAssertTrue(turns.isEmpty)
+                    XCTAssertEqual(anchorText, thread.anchorText)
+                    XCTAssertEqual(streamMarkdown, "Stream stays unchanged.")
+                    XCTAssertEqual(pinned.map(\.quote), [thread.anchorText, "A second constraint."])
+                    XCTAssertEqual(turns.map(\.requestId), [prior.requestId])
                     let receipt = ThreadAIRequestReceipt(
                         sourceContext: SourceContext(
                             text: sentSource.extractedText ?? "",
@@ -1646,8 +1663,8 @@ final class StreamDocumentTests: XCTestCase {
                             mode: .passthrough,
                             sourceIds: [sentSource.id]
                         ),
-                        includedPriorRequestIds: [],
-                        totalPriorExchangeCount: 0
+                        includedPriorRequestIds: [prior.requestId],
+                        totalPriorExchangeCount: 1
                     )
                     onPrepared(receipt)
                     onModelSelected?("provider/model")
@@ -1678,16 +1695,20 @@ final class StreamDocumentTests: XCTestCase {
 
             let data = try XCTUnwrap(exchange.sourceManifest.data(using: .utf8))
             let receipt = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-            XCTAssertEqual(receipt["version"] as? Int, 1)
+            XCTAssertEqual(receipt["version"] as? Int, 2)
             XCTAssertEqual(receipt["kind"] as? String, "threadAI")
             let anchor = try XCTUnwrap(receipt["anchor"] as? [String: Any])
-            XCTAssertEqual(anchor["text"] as? String, "")
-            XCTAssertEqual(anchor["kind"] as? String, "mixed")
+            XCTAssertEqual(anchor["text"] as? String, "Read the source.")
+            XCTAssertEqual(anchor["kind"] as? String, "stream")
+            XCTAssertEqual(anchor["from"] as? Int, 1)
+            XCTAssertEqual(anchor["to"] as? Int, 58)
             let note = try XCTUnwrap(receipt["note"] as? [String: Any])
-            XCTAssertEqual(note["text"] as? String, TickerInternalURLSanitizer.sanitize(canonicalWorkingText))
+            XCTAssertEqual(note["sent"] as? Bool, false)
             let turns = try XCTUnwrap(receipt["turns"] as? [String: Any])
-            XCTAssertEqual(turns["includedRequestIds"] as? [String], [])
-            XCTAssertEqual(turns["totalAtSend"] as? Int, 0)
+            XCTAssertEqual(turns["includedRequestIds"] as? [String], [prior.requestId])
+            XCTAssertEqual(turns["totalAtSend"] as? Int, 1)
+            let pinned = try XCTUnwrap(receipt["pinned"] as? [[String: Any]])
+            XCTAssertEqual(pinned.map { $0["quote"] as? String }, [thread.anchorText, "A second constraint."])
             let sources = try XCTUnwrap(receipt["sources"] as? [[String: Any]])
             XCTAssertEqual(sources.map { $0["sourceId"] as? String }, [sentSource.id.uuidString])
             XCTAssertFalse(sources.contains { $0["sourceId"] as? String == otherSource.id.uuidString })
@@ -1713,7 +1734,7 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, onError, _ in
+                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, _, onError, _ in
                     onError(ThreadAIRequestError.contextTooLarge(
                         largestBlock: "Your note",
                         protectedTokens: 98_000,

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -95,6 +95,9 @@ function ThreadContextDisclosure({ value }: { value: unknown }) {
       <summary>What AI saw</summary>
       <div className="conversation-receipt-body">
         <p><span>Primary passage</span> {receipt.anchor.text || 'Unavailable'}</p>
+        {receipt.streamDocument && (
+          <p><span>Full stream document</span> · {receipt.streamDocument.charCount} chars</p>
+        )}
         {receipt.pinned.map((pin, index) => (
           <p key={`${pin.kind}:${index}`}>
             <span>{pin.kind === 'pdf_quote' ? 'Pinned PDF' : 'Pinned Stream'}</span> {pin.quote}

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, type KeyboardEvent } from 'react';
 import { bridge, loadStreamThread } from '../types/bridge';
 import type { AIExchangeJSON, SourceScope, StreamThreadJSON } from '../types/models';
+import { parseThreadAISentFacts } from '../threads/context';
 
 export interface ConversationActiveTurn {
   requestId: string;
@@ -8,6 +9,7 @@ export interface ConversationActiveTurn {
   response: string;
   running: boolean;
   error?: string;
+  sentContext?: unknown;
 }
 
 export interface ConversationLiveState {
@@ -42,6 +44,10 @@ interface ConversationSurfaceProps {
   sourceScope: SourceScope;
   threadId?: string;
   anchorText: string;
+  primaryText: string;
+  anchorStart: number;
+  anchorEnd: number;
+  streamMarkdown: string;
   focusComposer: boolean;
   state: ConversationLiveState;
   updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
@@ -52,11 +58,49 @@ interface ConversationSurfaceProps {
 
 const copy = (text: string) => void navigator.clipboard?.writeText(text);
 
-const Turn = memo(function Turn({ who, text }: { who: 'You' | 'AI'; text: string }) {
+function ThreadContextDisclosure({ value }: { value: unknown }) {
+  const receipt = parseThreadAISentFacts(value);
+  if (!receipt) return null;
+  const retrieval = receipt.sourceContextMode === 'none'
+    ? 'No source retrieval'
+    : receipt.sourceContextMode === 'passthrough' ? 'All selected sources'
+      : receipt.sourceContextMode === 'retrieved' ? 'Retrieved passages' : 'Source retrieval unavailable';
+  return (
+    <details className="conversation-receipt">
+      <summary>What AI saw</summary>
+      <div className="conversation-receipt-body">
+        <p><span>Primary passage</span> {receipt.anchor.text || 'Unavailable'}</p>
+        {receipt.pinned.map((pin, index) => (
+          <p key={`${pin.kind}:${index}`}>
+            <span>{pin.kind === 'pdf_quote' ? 'Pinned PDF' : 'Pinned Stream'}</span> {pin.quote}
+          </p>
+        ))}
+        <p>
+          <span>Sources</span> {retrieval}
+          {receipt.sources.length > 0
+            ? ` · ${receipt.sources.map((source) => `${source.shortTitle}${source.page ? ` p.${source.page}` : ''}`).join(', ')}`
+            : ''}
+        </p>
+        <p><span>Prior turns</span> {receipt.turns.includedRequestIds.length} of {receipt.turns.totalAtSend}</p>
+      </div>
+    </details>
+  );
+}
+
+const Turn = memo(function Turn({
+  who,
+  text,
+  receipt,
+}: {
+  who: 'You' | 'AI';
+  text: string;
+  receipt?: unknown;
+}) {
   return (
     <div className={`conversation-turn conversation-turn--${who === 'You' ? 'you' : 'ai'}`}>
       <span className="conversation-turn-label">{who}</span>
       <div className="conversation-turn-text">{text}</div>
+      {who === 'AI' && <ThreadContextDisclosure value={receipt} />}
       <button type="button" className="conversation-turn-copy" onClick={() => copy(text)}>Copy</button>
     </div>
   );
@@ -68,6 +112,10 @@ export function ConversationSurface({
   sourceScope,
   threadId,
   anchorText,
+  primaryText,
+  anchorStart,
+  anchorEnd,
+  streamMarkdown,
   focusComposer,
   state,
   updateState,
@@ -119,6 +167,12 @@ export function ConversationSurface({
     if (message.type === 'documentAIChunk' && typeof payload.chunk === 'string') {
       updateState(conversationKey, (current) => current.active?.requestId === requestId
         ? { ...current, active: { ...current.active, response: current.active.response + payload.chunk } }
+        : current);
+      return;
+    }
+    if (message.type === 'threadAIContext') {
+      updateState(conversationKey, (current) => current.active?.requestId === requestId
+        ? { ...current, active: { ...current.active, sentContext: payload.sentContext } }
         : current);
       return;
     }
@@ -187,6 +241,10 @@ export function ConversationSurface({
         streamId,
         threadId: current.threadId,
         query,
+        context: primaryText,
+        anchorStart,
+        anchorEnd,
+        streamMarkdown,
         imageURLs: [],
         sourceScope,
         verb: 'develop',
@@ -228,13 +286,17 @@ export function ConversationSurface({
         {state.exchanges.map((exchange) => (
           <div className="conversation-exchange" key={exchange.requestId}>
             <Turn who="You" text={exchange.userInput} />
-            <Turn who="AI" text={exchange.responseRaw} />
+            <Turn who="AI" text={exchange.responseRaw} receipt={exchange.sourceManifest} />
           </div>
         ))}
         {state.active && (
           <div className="conversation-exchange">
             <Turn who="You" text={state.active.userInput} />
-            <Turn who="AI" text={state.active.response || state.active.error || 'Thinking…'} />
+            <Turn
+              who="AI"
+              text={state.active.response || state.active.error || 'Thinking…'}
+              receipt={state.active.sentContext}
+            />
           </div>
         )}
         {state.error && <p className="conversation-error" role="alert">{state.error}</p>}

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -1,6 +1,16 @@
-import { memo, useEffect, useRef, type KeyboardEvent } from 'react';
-import { bridge, loadStreamThread } from '../types/bridge';
-import type { AIExchangeJSON, SourceScope, StreamThreadJSON } from '../types/models';
+import { memo, useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import {
+  addStreamThreadAnchor,
+  bridge,
+  loadStreamThread,
+  removeStreamThreadAnchor,
+} from '../types/bridge';
+import type {
+  AIExchangeJSON,
+  SourceScope,
+  StreamThreadAnchorJSON,
+  StreamThreadJSON,
+} from '../types/models';
 import { parseThreadAISentFacts } from '../threads/context';
 
 export interface ConversationActiveTurn {
@@ -48,12 +58,27 @@ interface ConversationSurfaceProps {
   anchorStart: number;
   anchorEnd: number;
   streamMarkdown: string;
+  contextOptions: ConversationContextOption[];
   focusComposer: boolean;
   state: ConversationLiveState;
   updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
   createThread: (query: string) => Promise<StreamThreadJSON>;
   hasDrifted: (anchorText: string) => boolean;
   onCollapse: () => void;
+}
+
+export interface ConversationContextOption {
+  kind: 'stream_quote' | 'pdf_quote';
+  quote: string;
+  from?: number;
+  to?: number;
+  sourceId?: string;
+  sourceName?: string;
+  sourceShortTitle?: string;
+  highlightId?: string;
+  page?: number;
+  createdAt?: string;
+  rects?: Array<{ page: number; x: number; y: number; w: number; h: number }>;
 }
 
 const copy = (text: string) => void navigator.clipboard?.writeText(text);
@@ -116,6 +141,7 @@ export function ConversationSurface({
   anchorStart,
   anchorEnd,
   streamMarkdown,
+  contextOptions,
   focusComposer,
   state,
   updateState,
@@ -124,6 +150,7 @@ export function ConversationSurface({
   onCollapse,
 }: ConversationSurfaceProps) {
   const composerRef = useRef<HTMLTextAreaElement>(null);
+  const [showContextMenu, setShowContextMenu] = useState(false);
   const stateRef = useRef(state);
   const activeRequestId = useRef(state.active?.running ? state.active.requestId : null);
   stateRef.current = state;
@@ -267,6 +294,57 @@ export function ConversationSurface({
     loading: true,
     loadError: false,
   }));
+  const addContext = async (option: ConversationContextOption) => {
+    const thread = stateRef.current.thread;
+    if (!thread) return;
+    setShowContextMenu(false);
+    try {
+      const { anchor } = await addStreamThreadAnchor({
+        streamId,
+        threadId: thread.threadId,
+        anchor: {
+          anchorId: crypto.randomUUID(),
+          kind: option.kind,
+          quote: option.quote,
+          createdAt: option.createdAt ?? new Date().toISOString(),
+          ...(option.kind === 'stream_quote'
+            ? { anchorSpanId: `pm:${option.from}:${option.to}` }
+            : {
+              sourceId: option.sourceId,
+              highlightId: option.highlightId,
+              rects: option.rects,
+            }),
+        },
+      });
+      updateState(conversationKey, (current) => current.thread ? {
+        ...current,
+        thread: { ...current.thread, anchors: [...(current.thread.anchors ?? []), anchor] },
+      } : current);
+    } catch {
+      updateState(conversationKey, (current) => ({ ...current, error: 'Context could not be added.' }));
+    }
+  };
+  const removeContext = async (anchor: StreamThreadAnchorJSON) => {
+    const thread = stateRef.current.thread;
+    if (!thread) return;
+    try {
+      const { removed } = await removeStreamThreadAnchor({
+        streamId,
+        threadId: thread.threadId,
+        anchorId: anchor.anchorId,
+      });
+      if (!removed) return;
+      updateState(conversationKey, (current) => current.thread ? {
+        ...current,
+        thread: {
+          ...current.thread,
+          anchors: (current.thread.anchors ?? []).filter((item) => item.anchorId !== anchor.anchorId),
+        },
+      } : current);
+    } catch {
+      updateState(conversationKey, (current) => ({ ...current, error: 'Context could not be removed.' }));
+    }
+  };
   const originalAnchorText = state.thread?.anchorText ?? anchorText;
   const sendDisabled = !state.composer.trim() || state.loading || state.creating
     || Boolean(threadId && !state.thread);
@@ -300,7 +378,42 @@ export function ConversationSurface({
           </div>
         )}
         {state.error && <p className="conversation-error" role="alert">{state.error}</p>}
+        {(state.thread?.anchors?.length ?? 0) > 0 && (
+          <div className="conversation-pins" aria-label="Pinned context">
+            {state.thread!.anchors!.map((anchor) => (
+              <span className="conversation-pin" key={anchor.anchorId}>
+                {anchor.kind === 'pdf_quote'
+                  ? `${anchor.sourceShortTitle ?? anchor.sourceName ?? 'PDF'}${anchor.sourcePage ? ` p.${anchor.sourcePage}` : ''}`
+                  : anchor.quote}
+                <button type="button" aria-label="Remove pinned context" onClick={() => void removeContext(anchor)}>×</button>
+              </span>
+            ))}
+          </div>
+        )}
         <div className="conversation-composer-row">
+          <div className="conversation-context-picker">
+            <button
+              type="button"
+              className="conversation-context-button"
+              disabled={!state.thread || contextOptions.length === 0}
+              onClick={() => setShowContextMenu((visible) => !visible)}
+            >
+              + context
+            </button>
+            {showContextMenu && (
+              <div className="conversation-context-menu">
+                {contextOptions.map((option) => (
+                  <button
+                    type="button"
+                    key={`${option.kind}:${option.highlightId ?? `${option.from}:${option.to}`}`}
+                    onClick={() => void addContext(option)}
+                  >
+                    {option.kind === 'pdf_quote' ? 'PDF selection' : 'Stream selection'}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <textarea
             ref={composerRef}
             className="conversation-composer"

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -462,7 +462,7 @@ describe('RichStreamEditor inline conversations', () => {
     await vi.waitFor(() => expect(document.activeElement).toBe(editor()));
   });
 
-  it('creates on first send, streams the AI turn, and keeps the widget out of the document save', async () => {
+  it('round-trips the v2 receipt from send through completion and disclosure rendering', async () => {
     const createdAt = new Date(0).toISOString();
     vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
       if (type === 'createStreamThread') {
@@ -510,7 +510,29 @@ describe('RichStreamEditor inline conversations', () => {
     expect(document.querySelector('.conversation-stop')).not.toBe(null);
 
     const requestId = String(sent.find((message) => message.type === 'thinkDocument')?.payload?.requestId);
+    const request = sent.find((message) => message.type === 'thinkDocument');
+    expect(request?.payload).toMatchObject({
+      context: 'Original paragraph.',
+      streamMarkdown: 'Original paragraph.',
+      anchorStart: 1,
+      anchorEnd: 20,
+    });
+    const sentContext = {
+      version: 2,
+      kind: 'threadAI',
+      requestId,
+      anchor: { kind: 'stream', text: 'Original paragraph.', from: 1, to: 20 },
+      note: { sent: false },
+      turns: { includedRequestIds: [], totalAtSend: 0 },
+      sourceContextMode: 'retrieved',
+      sources: [{
+        kind: 'passage', n: 1, sourceId: 'source-1', chunkId: 'chunk-1',
+        page: 4, shortTitle: 'Manual',
+      }],
+      pinned: [{ kind: 'stream_quote', quote: 'Pinned constraint.', from: 1, to: 8 }],
+    };
     await act(async () => {
+      bridge.receive({ type: 'threadAIContext', payload: { requestId, sentContext } });
       bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: 'It streams.' } });
       bridge.receive({ type: 'documentAIChunk', payload: { requestId, chunk: ' Live.' } });
     });
@@ -536,7 +558,7 @@ describe('RichStreamEditor inline conversations', () => {
             threadId: 'thread-created',
             verb: 'thread',
             userInput: 'Does this hold?',
-            sourceManifest: '[]',
+            sourceManifest: JSON.stringify(sentContext),
             responseRaw: 'It streams. Live.',
             createdAt,
           },
@@ -545,6 +567,13 @@ describe('RichStreamEditor inline conversations', () => {
     });
     expect(document.querySelector('.conversation-stop')).toBe(null);
     expect(document.querySelector('.conversation-turn--ai')?.textContent).toContain('It streams. Live.');
+    const disclosure = document.querySelector('.conversation-receipt') as HTMLDetailsElement;
+    expect(disclosure.open).toBe(false);
+    await act(async () => { (disclosure.querySelector('summary') as HTMLElement).click(); });
+    expect(disclosure.textContent).toContain('Primary passage Original paragraph.');
+    expect(disclosure.textContent).toContain('Pinned Stream Pinned constraint.');
+    expect(disclosure.textContent).toContain('Retrieved passages · Manual p.4');
+    expect(disclosure.textContent).toContain('Prior turns 0 of 0');
 
     await vi.waitFor(() => {
       const save = vi.mocked(bridge.sendAsync).mock.calls

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -12,6 +12,7 @@ import type {
   AIExchangeJSON,
   SourceReference,
   Stream,
+  StreamThreadJSON,
 } from '../types/models';
 import { DocumentSession } from '../richtext/session';
 import { parseMarkdown } from '../richtext/markdown';
@@ -661,6 +662,122 @@ describe('RichStreamEditor inline conversations', () => {
     await act(async () => { editor().dispatchEvent(tab); });
     expect(tab.defaultPrevented).toBe(true);
     expect(document.activeElement).toBe(document.querySelector('.conversation-composer'));
+  });
+
+  it('persists pin and unpin across conversation reloads', async () => {
+    const updatedAt = new Date().toISOString();
+    const anchored: Stream = {
+      ...stream,
+      id: 'pinned-conversation-stream',
+      document: {
+        ...stream.document,
+        streamId: 'pinned-conversation-stream',
+        docJSON: docJSON('Original paragraph.\n\nFollowing paragraph.'),
+        markdown: 'Original paragraph.\n\nFollowing paragraph.',
+      },
+      conversationAnchors: [{
+        threadId: 'thread-pinned',
+        anchorStart: 1,
+        anchorEnd: 20,
+        anchorText: 'Original paragraph.',
+        detached: false,
+        ephemeral: false,
+        updatedAt,
+      }],
+    };
+    let persistedAnchors: NonNullable<StreamThreadJSON['anchors']> = [];
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'loadStreamThread') return {
+        thread: {
+          threadId: 'thread-pinned', streamId: anchored.id, title: 'Pinned', workingText: '',
+          anchorText: 'Original paragraph.', anchorStart: 1, anchorEnd: 20,
+          detached: false, ephemeral: false, revision: 0, createdAt: updatedAt, updatedAt,
+          exchanges: [], anchors: persistedAnchors,
+        },
+      };
+      if (type === 'addStreamThreadAnchor') {
+        const raw = (payload?.anchors as Array<Record<string, unknown>>)[0];
+        const anchor = { ...raw, threadId: 'thread-pinned', anchorStart: 22, anchorEnd: 42 } as NonNullable<StreamThreadJSON['anchors']>[number];
+        persistedAnchors = [anchor];
+        return { anchor };
+      }
+      if (type === 'removeStreamThreadAnchor') {
+        persistedAnchors = [];
+        return { removed: true };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+
+    const open = async () => {
+      const block = editor().querySelector('p') as HTMLParagraphElement;
+      await vi.waitFor(() => expect(block.classList.contains('conversation-block-anchored')).toBe(true));
+      vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+        left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+        toJSON: () => ({}),
+      });
+      await act(async () => {
+        block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
+        await Promise.resolve();
+      });
+      await vi.waitFor(() => expect(document.querySelector('.conversation-composer')).not.toBe(null));
+    };
+    const reload = async () => {
+      await act(async () => { root?.unmount(); });
+      root = createRoot(document.querySelector('#root')!);
+      await renderStream(anchored);
+      await open();
+    };
+
+    await renderStream(anchored);
+    await open();
+    let context = [...document.querySelectorAll('button')]
+      .find((button) => button.textContent?.trim() === '+ context') as HTMLButtonElement;
+    expect(context.disabled).toBe(true);
+    await act(async () => {
+      bridge.receive({
+        type: 'pdfPaneStateChanged',
+        payload: {
+          visible: true,
+          streamId: anchored.id,
+          sourceId: 'source-1',
+          sourceName: 'manual.pdf',
+          shortTitle: 'Manual',
+          selection: {
+            highlightId: 'highlight-1', page: 4, quote: 'Selected PDF passage',
+            createdAt: updatedAt, rects: [{ page: 4, x: 1, y: 2, w: 3, h: 4 }],
+          },
+        },
+      });
+    });
+    await vi.waitFor(() => expect(context.disabled).toBe(false));
+    await act(async () => { context.click(); });
+    expect([...document.querySelectorAll('.conversation-context-menu button')]
+      .map((button) => button.textContent)).toEqual(['PDF selection']);
+    await act(async () => { context.click(); });
+
+    await selectEditorText('Following paragraph.');
+    context = [...document.querySelectorAll('button')]
+      .find((button) => button.textContent?.trim() === '+ context') as HTMLButtonElement;
+    await act(async () => { context.click(); });
+    await act(async () => {
+      ([...document.querySelectorAll('.conversation-context-menu button')]
+        .find((button) => button.textContent === 'Stream selection') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-pin')?.textContent)
+      .toContain('Following paragraph.'));
+
+    await reload();
+    await vi.waitFor(() => expect(document.querySelector('.conversation-pin')?.textContent)
+      .toContain('Following paragraph.'));
+    await act(async () => {
+      (document.querySelector('[aria-label="Remove pinned context"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-pin')).toBe(null));
+
+    await reload();
+    expect(document.querySelector('.conversation-pin')).toBe(null);
   });
 
   it('keeps send disabled until a persisted conversation loads successfully', async () => {

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -523,6 +523,7 @@ describe('RichStreamEditor inline conversations', () => {
       kind: 'threadAI',
       requestId,
       anchor: { kind: 'stream', text: 'Original paragraph.', from: 1, to: 20 },
+      streamDocument: { sent: true, charCount: 19 },
       note: { sent: false },
       turns: { includedRequestIds: [], totalAtSend: 0 },
       sourceContextMode: 'retrieved',
@@ -572,6 +573,7 @@ describe('RichStreamEditor inline conversations', () => {
     expect(disclosure.open).toBe(false);
     await act(async () => { (disclosure.querySelector('summary') as HTMLElement).click(); });
     expect(disclosure.textContent).toContain('Primary passage Original paragraph.');
+    expect(disclosure.textContent).toContain('Full stream document · 19 chars');
     expect(disclosure.textContent).toContain('Pinned Stream Pinned constraint.');
     expect(disclosure.textContent).toContain('Retrieved passages · Manual p.4');
     expect(disclosure.textContent).toContain('Prior turns 0 of 0');
@@ -732,6 +734,7 @@ describe('RichStreamEditor inline conversations', () => {
     await open();
     let context = [...document.querySelectorAll('button')]
       .find((button) => button.textContent?.trim() === '+ context') as HTMLButtonElement;
+    await selectEditorText('Original paragraph.');
     expect(context.disabled).toBe(true);
     await act(async () => {
       bridge.receive({

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -159,8 +159,16 @@ type PromptIntent = {
 interface PDFPaneState {
   visible: boolean;
   streamId?: string;
+  sourceId?: string;
   sourceName?: string;
   shortTitle?: string;
+  selection?: {
+    highlightId: string;
+    page: number;
+    quote: string;
+    createdAt: string;
+    rects: Array<{ page: number; x: number; y: number; w: number; h: number }>;
+  };
 }
 
 interface SelectionMenuState {
@@ -1261,11 +1269,20 @@ export function RichStreamEditor({
     }
 
     if (message.type === 'pdfPaneStateChanged') {
+      const rawSelection = payload?.selection as PDFPaneState['selection'];
       setPDFPaneState({
         visible: payload?.visible === true,
         streamId: typeof payload?.streamId === 'string' ? payload.streamId : undefined,
+        sourceId: typeof payload?.sourceId === 'string' ? payload.sourceId : undefined,
         sourceName: (payload as SourceTitlePayload | undefined)?.sourceName,
         shortTitle: (payload as SourceTitlePayload | undefined)?.shortTitle,
+        selection: rawSelection
+          && typeof rawSelection.highlightId === 'string'
+          && typeof rawSelection.quote === 'string'
+          && rawSelection.quote.length > 0
+          && Array.isArray(rawSelection.rects)
+          ? rawSelection
+          : undefined,
       });
       return;
     }
@@ -1610,6 +1627,29 @@ export function RichStreamEditor({
   const formats = editor ? activeFormats(editor.view.state) : null;
   const activePDFHighlight = editor ? selectedPDFHighlight(editor.view.state) : null;
   const liveConversationSurface = editor ? conversationSurface(editor.view.state) : null;
+  const streamSelection = editor?.view.state.selection;
+  const conversationContextOptions = [
+    ...(editor && streamSelection && !streamSelection.empty ? [{
+      kind: 'stream_quote' as const,
+      quote: editor.view.state.doc.textBetween(streamSelection.from, streamSelection.to, '\n', ''),
+      from: streamSelection.from,
+      to: streamSelection.to,
+    }] : []),
+    ...(pdfPaneState.visible
+      && pdfPaneState.streamId === stream.id
+      && pdfPaneState.sourceId
+      && pdfPaneState.selection ? [{
+        kind: 'pdf_quote' as const,
+        quote: pdfPaneState.selection.quote,
+        sourceId: pdfPaneState.sourceId,
+        sourceName: pdfPaneState.sourceName,
+        sourceShortTitle: pdfPaneState.shortTitle,
+        highlightId: pdfPaneState.selection.highlightId,
+        page: pdfPaneState.selection.page,
+        createdAt: pdfPaneState.selection.createdAt,
+        rects: pdfPaneState.selection.rects,
+      }] : []),
+  ].filter((option) => option.quote.length > 0);
   const sourceScopeLabel = sourceScope === 'all' ? 'All' : sourceScope === 'none' ? 'None' : 'Auto';
   const openPDFTitle = pdfPaneState.visible && pdfPaneState.streamId === stream.id
     ? pdfPaneState.shortTitle ?? pdfPaneState.sourceName ?? 'Open PDF'
@@ -1974,6 +2014,7 @@ export function RichStreamEditor({
           anchorStart={liveConversationSurface?.anchor.from ?? 0}
           anchorEnd={liveConversationSurface?.anchor.to ?? 0}
           streamMarkdown={editor?.getMarkdownProjection() ?? stream.document.markdown}
+          contextOptions={conversationContextOptions}
           focusComposer={expandedConversation.focusComposer}
           state={conversationLiveStates[expandedConversation.key]
             ?? initialConversationLiveState(expandedConversation.threadId)}

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -1629,7 +1629,10 @@ export function RichStreamEditor({
   const liveConversationSurface = editor ? conversationSurface(editor.view.state) : null;
   const streamSelection = editor?.view.state.selection;
   const conversationContextOptions = [
-    ...(editor && streamSelection && !streamSelection.empty ? [{
+    ...(editor && streamSelection && !streamSelection.empty
+      && (!liveConversationSurface
+        || streamSelection.to <= liveConversationSurface.anchor.from
+        || streamSelection.from >= liveConversationSurface.anchor.to) ? [{
       kind: 'stream_quote' as const,
       quote: editor.view.state.doc.textBetween(streamSelection.from, streamSelection.to, '\n', ''),
       from: streamSelection.from,

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -45,6 +45,7 @@ import {
 import { createRichTextEditor, type RichTextEditor } from '../richtext/editor';
 import {
   conversationAnchorFromJSON,
+  conversationAnchorText,
   conversationAnchorTextForStorage,
   conversationAnchors,
   conversationRenderPosition,
@@ -1608,6 +1609,7 @@ export function RichStreamEditor({
 
   const formats = editor ? activeFormats(editor.view.state) : null;
   const activePDFHighlight = editor ? selectedPDFHighlight(editor.view.state) : null;
+  const liveConversationSurface = editor ? conversationSurface(editor.view.state) : null;
   const sourceScopeLabel = sourceScope === 'all' ? 'All' : sourceScope === 'none' ? 'None' : 'Auto';
   const openPDFTitle = pdfPaneState.visible && pdfPaneState.streamId === stream.id
     ? pdfPaneState.shortTitle ?? pdfPaneState.sourceName ?? 'Open PDF'
@@ -1966,6 +1968,12 @@ export function RichStreamEditor({
           sourceScope={sourceScope}
           threadId={expandedConversation.threadId}
           anchorText={expandedConversation.anchorText}
+          primaryText={editor && liveConversationSurface
+            ? conversationAnchorText(editor.view.state.doc, liveConversationSurface.anchor)
+            : expandedConversation.anchorText}
+          anchorStart={liveConversationSurface?.anchor.from ?? 0}
+          anchorEnd={liveConversationSurface?.anchor.to ?? 0}
+          streamMarkdown={editor?.getMarkdownProjection() ?? stream.document.markdown}
           focusComposer={expandedConversation.focusComposer}
           state={conversationLiveStates[expandedConversation.key]
             ?? initialConversationLiveState(expandedConversation.threadId)}

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -200,6 +200,31 @@
   white-space: pre-wrap;
 }
 
+.conversation-receipt {
+  grid-column: 2 / -1;
+  color: var(--text-muted);
+  font-size: var(--type-ui-small);
+  line-height: var(--type-ui-line-height);
+}
+
+.conversation-receipt summary {
+  width: max-content;
+  cursor: pointer;
+}
+
+.conversation-receipt-body,
+.conversation-receipt-body p {
+  margin: 0;
+}
+
+.conversation-receipt-body {
+  padding-top: var(--space-2);
+}
+
+.conversation-receipt-body span {
+  color: var(--text-faint);
+}
+
 .conversation-turn-copy {
   padding: 0;
   border: 0;

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -247,6 +247,78 @@
   gap: var(--space-2);
 }
 
+.conversation-pins {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.conversation-pin {
+  display: inline-flex;
+  max-width: 32ch;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  overflow: hidden;
+  border-radius: var(--radius-small);
+  background: var(--surface-hover);
+  color: var(--text-muted);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-pin button,
+.conversation-context-button,
+.conversation-context-menu button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.conversation-context-picker {
+  position: relative;
+  align-self: center;
+}
+
+.conversation-context-button {
+  white-space: nowrap;
+}
+
+.conversation-context-button:hover,
+.conversation-context-menu button:hover,
+.conversation-pin button:hover {
+  color: var(--text);
+}
+
+.conversation-context-button:disabled {
+  color: var(--text-faint);
+  cursor: default;
+}
+
+.conversation-context-menu {
+  position: absolute;
+  z-index: 20;
+  bottom: calc(100% + var(--space-2));
+  left: 0;
+  display: grid;
+  min-width: 140px;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--overlay-shadow);
+}
+
+.conversation-context-menu button {
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+}
+
 .conversation-composer {
   flex: 1;
   min-width: 0;

--- a/Web/src/threads/context.test.ts
+++ b/Web/src/threads/context.test.ts
@@ -19,6 +19,7 @@ const receiptV2 = {
   ...receipt,
   version: 2,
   anchor: { kind: 'stream', text: 'Start here.', from: 5, to: 16 },
+  streamDocument: { sent: true, charCount: 1200 },
   pinned: [{
     kind: 'stream_quote', quote: 'Pinned Stream text.', from: 30, to: 49,
   }, {
@@ -36,15 +37,30 @@ describe('thread AI context receipts', () => {
     });
     expect(parsed?.version).toBe(1);
     expect(parsed?.pinned).toEqual([]);
+    expect(parsed?.streamDocument).toBeUndefined();
   });
 
   it('parses v2 primary range and pinned context without weakening v1', () => {
     expect(parseThreadAISentFacts(receiptV2)).toMatchObject({
       version: 2,
       anchor: { text: 'Start here.', from: 5, to: 16 },
+      streamDocument: { sent: true, charCount: 1200 },
       pinned: receiptV2.pinned,
     });
-    expect(parseThreadAISentFacts({ ...receiptV2, pinned: [{ kind: 'stream_quote' }] })).toBe(null);
+    expect(parseThreadAISentFacts({
+      ...receiptV2,
+      pinned: [{ kind: 'stream_quote' }, receiptV2.pinned[1]],
+    })?.pinned).toEqual([receiptV2.pinned[1]]);
+    for (const invalidPosition of [null, '', false, []]) {
+      expect(parseThreadAISentFacts({
+        ...receiptV2,
+        anchor: { ...receiptV2.anchor, from: invalidPosition, to: 16 },
+      })).toBe(null);
+    }
+    expect(parseThreadAISentFacts({
+      ...receiptV2,
+      pinned: [{ kind: 'stream_quote', quote: 'Bad range', from: '', to: 4 }],
+    })?.pinned).toEqual([]);
   });
 
   it('keeps released citation-array manifests readable', () => {

--- a/Web/src/threads/context.test.ts
+++ b/Web/src/threads/context.test.ts
@@ -15,12 +15,36 @@ const receipt = {
   }],
 };
 
+const receiptV2 = {
+  ...receipt,
+  version: 2,
+  anchor: { kind: 'stream', text: 'Start here.', from: 5, to: 16 },
+  pinned: [{
+    kind: 'stream_quote', quote: 'Pinned Stream text.', from: 30, to: 49,
+  }, {
+    kind: 'pdf_quote', quote: 'Pinned PDF text.', sourceId: 'source-2',
+    sourceName: 'Datasheet', highlightId: 'highlight-2', page: 12,
+  }],
+};
+
 describe('thread AI context receipts', () => {
   it('keeps stable history IDs and parses the exact host receipt', () => {
-    expect(parseThreadAISentFacts(receipt)?.turns).toEqual({
+    const parsed = parseThreadAISentFacts(receipt);
+    expect(parsed?.turns).toEqual({
       includedRequestIds: ['request-1', 'request-2'],
       totalAtSend: 2,
     });
+    expect(parsed?.version).toBe(1);
+    expect(parsed?.pinned).toEqual([]);
+  });
+
+  it('parses v2 primary range and pinned context without weakening v1', () => {
+    expect(parseThreadAISentFacts(receiptV2)).toMatchObject({
+      version: 2,
+      anchor: { text: 'Start here.', from: 5, to: 16 },
+      pinned: receiptV2.pinned,
+    });
+    expect(parseThreadAISentFacts({ ...receiptV2, pinned: [{ kind: 'stream_quote' }] })).toBe(null);
   });
 
   it('keeps released citation-array manifests readable', () => {

--- a/Web/src/threads/context.ts
+++ b/Web/src/threads/context.ts
@@ -34,6 +34,7 @@ export interface ThreadAISentFacts {
     highlightId?: string;
     page?: number;
   };
+  streamDocument?: { sent: boolean; charCount: number };
   note: { sent: boolean; text?: string };
   turns: { includedRequestIds: string[]; totalAtSend: number };
   sourceContextMode: 'none' | 'passthrough' | 'retrieved' | 'unavailable';
@@ -79,8 +80,7 @@ function parseSource(value: unknown): ThreadAISourceFact | null {
 }
 
 function nonnegativeInteger(value: unknown): number | undefined {
-  const number = Number(value);
-  return Number.isInteger(number) && number >= 0 ? number : undefined;
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
 function parsePinned(value: unknown): ThreadAIPinnedFact | null {
@@ -112,6 +112,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   const anchor = object(receipt?.anchor);
   const note = object(receipt?.note);
   const turns = object(receipt?.turns);
+  const streamDocument = object(receipt?.streamDocument);
   if ((receipt?.version !== 1 && receipt?.version !== 2)
     || receipt.kind !== 'threadAI' || !anchor || !note || !turns) return null;
   if (typeof receipt.requestId !== 'string' || typeof anchor.text !== 'string') return null;
@@ -129,12 +130,14 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   const anchorTo = nonnegativeInteger(anchor.to);
   if ((anchorFrom === undefined) !== (anchorTo === undefined)
     || (anchorFrom !== undefined && anchorTo! < anchorFrom)) return null;
+  const streamCharCount = nonnegativeInteger(streamDocument?.charCount);
+  if (receipt.version === 2 && (!streamDocument
+    || typeof streamDocument.sent !== 'boolean'
+    || streamCharCount === undefined)) return null;
   const pinned = Array.isArray(receipt.pinned)
-    ? receipt.pinned.map(parsePinned)
+    ? receipt.pinned.flatMap((pin) => parsePinned(pin) ?? [])
     : [];
-  if (receipt.version === 2 && (!Array.isArray(receipt.pinned) || pinned.some((pin) => pin === null))) {
-    return null;
-  }
+  if (receipt.version === 2 && !Array.isArray(receipt.pinned)) return null;
 
   return {
     version: receipt.version,
@@ -150,6 +153,9 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
       highlightId: optionalString(anchor.highlightId),
       page: positiveInteger(anchor.page),
     },
+    streamDocument: receipt.version === 2
+      ? { sent: streamDocument!.sent as boolean, charCount: streamCharCount! }
+      : undefined,
     note: {
       sent: note.sent,
       text: optionalString(note.text),
@@ -159,7 +165,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
     sources: Array.isArray(receipt.sources)
       ? receipt.sources.flatMap((source) => parseSource(source) ?? [])
       : [],
-    pinned: pinned.flatMap((pin) => pin ?? []),
+    pinned,
   };
 }
 

--- a/Web/src/threads/context.ts
+++ b/Web/src/threads/context.ts
@@ -9,13 +9,26 @@ export interface ThreadAISourceFact {
   shortTitle: string;
 }
 
+export interface ThreadAIPinnedFact {
+  kind: 'stream_quote' | 'pdf_quote';
+  quote: string;
+  from?: number;
+  to?: number;
+  sourceId?: string;
+  sourceName?: string;
+  highlightId?: string;
+  page?: number;
+}
+
 export interface ThreadAISentFacts {
-  version: 1;
+  version: 1 | 2;
   kind: 'threadAI';
   requestId: string;
   anchor: {
     kind: 'stream' | 'pdf';
     text: string;
+    from?: number;
+    to?: number;
     sourceId?: string;
     sourceName?: string;
     highlightId?: string;
@@ -25,6 +38,7 @@ export interface ThreadAISentFacts {
   turns: { includedRequestIds: string[]; totalAtSend: number };
   sourceContextMode: 'none' | 'passthrough' | 'retrieved' | 'unavailable';
   sources: ThreadAISourceFact[];
+  pinned: ThreadAIPinnedFact[];
 }
 
 function object(value: unknown): Record<string, unknown> | null {
@@ -64,6 +78,30 @@ function parseSource(value: unknown): ThreadAISourceFact | null {
   };
 }
 
+function nonnegativeInteger(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isInteger(number) && number >= 0 ? number : undefined;
+}
+
+function parsePinned(value: unknown): ThreadAIPinnedFact | null {
+  const pin = object(value);
+  if (!pin || (pin.kind !== 'stream_quote' && pin.kind !== 'pdf_quote')) return null;
+  if (typeof pin.quote !== 'string' || !pin.quote) return null;
+  const from = nonnegativeInteger(pin.from);
+  const to = nonnegativeInteger(pin.to);
+  if ((from === undefined) !== (to === undefined) || (from !== undefined && to! < from)) return null;
+  return {
+    kind: pin.kind,
+    quote: pin.quote,
+    from,
+    to,
+    sourceId: optionalString(pin.sourceId),
+    sourceName: optionalString(pin.sourceName),
+    highlightId: optionalString(pin.highlightId),
+    page: pageNumber(pin.page),
+  };
+}
+
 export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null {
   let parsed = value;
   if (typeof parsed === 'string') {
@@ -74,7 +112,8 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   const anchor = object(receipt?.anchor);
   const note = object(receipt?.note);
   const turns = object(receipt?.turns);
-  if (receipt?.version !== 1 || receipt.kind !== 'threadAI' || !anchor || !note || !turns) return null;
+  if ((receipt?.version !== 1 && receipt?.version !== 2)
+    || receipt.kind !== 'threadAI' || !anchor || !note || !turns) return null;
   if (typeof receipt.requestId !== 'string' || typeof anchor.text !== 'string') return null;
   if (anchor.kind !== 'stream' && anchor.kind !== 'pdf') return null;
   if (typeof note.sent !== 'boolean' || !Array.isArray(turns.includedRequestIds)) return null;
@@ -86,14 +125,26 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   if (!Number.isInteger(totalAtSend) || totalAtSend < includedRequestIds.length) return null;
   const modes = new Set(['none', 'passthrough', 'retrieved', 'unavailable']);
   if (typeof receipt.sourceContextMode !== 'string' || !modes.has(receipt.sourceContextMode)) return null;
+  const anchorFrom = nonnegativeInteger(anchor.from);
+  const anchorTo = nonnegativeInteger(anchor.to);
+  if ((anchorFrom === undefined) !== (anchorTo === undefined)
+    || (anchorFrom !== undefined && anchorTo! < anchorFrom)) return null;
+  const pinned = Array.isArray(receipt.pinned)
+    ? receipt.pinned.map(parsePinned)
+    : [];
+  if (receipt.version === 2 && (!Array.isArray(receipt.pinned) || pinned.some((pin) => pin === null))) {
+    return null;
+  }
 
   return {
-    version: 1,
+    version: receipt.version,
     kind: 'threadAI',
     requestId: receipt.requestId,
     anchor: {
       kind: anchor.kind,
       text: anchor.text,
+      from: anchorFrom,
+      to: anchorTo,
       sourceId: optionalString(anchor.sourceId),
       sourceName: optionalString(anchor.sourceName),
       highlightId: optionalString(anchor.highlightId),
@@ -108,6 +159,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
     sources: Array.isArray(receipt.sources)
       ? receipt.sources.flatMap((source) => parseSource(source) ?? [])
       : [],
+    pinned: pinned.flatMap((pin) => pin ?? []),
   };
 }
 
@@ -124,7 +176,7 @@ function citation(value: unknown, fallbackNumber: number): DocumentAICitation | 
     : null;
 }
 
-/** Accepts both released citation arrays and the v1 thread receipt object. */
+/** Accepts released citation arrays and both thread receipt versions. */
 export function manifestCitations(sourceManifest: string): DocumentAICitation[] {
   let parsed: unknown;
   try { parsed = JSON.parse(sourceManifest) as unknown; } catch { return []; }

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -5,6 +5,7 @@ import type {
   PendingAppendJSON,
   ProvenanceSpanJSON,
   StreamAppendInboxJSON,
+  StreamThreadAnchorJSON,
   StreamThreadJSON,
 } from './models';
 
@@ -57,6 +58,7 @@ export type AIOperationState = 'queued' | 'preparing' | 'generating' | 'saving' 
 
 export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'addSource',
+  'addStreamThreadAnchor',
   'beginPdfAnchorPick',
   'deletePdfHighlight',
   'cancelDocumentAI',
@@ -84,6 +86,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'quitApp',
   'refreshProxyAuth',
   'removeSource',
+  'removeStreamThreadAnchor',
   'retrySourceIndexing',
   'runPdfSectionAI',
   'saveImage',
@@ -266,6 +269,32 @@ export function loadStreamThread(
   threadId: string,
 ): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('loadStreamThread', { streamId, threadId });
+}
+
+export function addStreamThreadAnchor(input: {
+  streamId: string;
+  threadId: string;
+  anchor: Omit<StreamThreadAnchorJSON, 'threadId'> & {
+    rects?: Array<{ page: number; x: number; y: number; w: number; h: number }>;
+  };
+}): Promise<{ anchor: StreamThreadAnchorJSON }> {
+  return bridge.sendAsync('addStreamThreadAnchor', {
+    streamId: input.streamId,
+    threadId: input.threadId,
+    anchors: [input.anchor],
+  });
+}
+
+export function removeStreamThreadAnchor(input: {
+  streamId: string;
+  threadId: string;
+  anchorId: string;
+}): Promise<{ removed: boolean }> {
+  return bridge.sendAsync('removeStreamThreadAnchor', {
+    streamId: input.streamId,
+    threadId: input.threadId,
+    anchorId: input.anchorId,
+  });
 }
 
 export function deleteStreamThread(input: {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -116,6 +116,9 @@ export interface ThinkDocumentPayload extends Record<string, unknown> {
   verb?: DocumentAIVerb;
   parentRequestId?: string;
   threadId?: string;
+  anchorStart?: number;
+  anchorEnd?: number;
+  streamMarkdown?: string;
 }
 
 export interface UpdateMarginNotePayload extends Record<string, unknown> {

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -104,6 +104,8 @@ export interface StreamThreadAnchorJSON {
   kind: 'stream_quote' | 'pdf_quote';
   quote?: string;
   anchorSpanId?: string;
+  anchorStart?: number;
+  anchorEnd?: number;
   sourceId?: string;
   sourceName?: string;
   sourceShortTitle?: string;

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -306,7 +306,7 @@
       },
       "thinkDocument": {
         "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
-        "optionalPayloadKeys": ["context", "sourceScope", "verb", "parentRequestId", "threadId"]
+        "optionalPayloadKeys": ["context", "sourceScope", "verb", "parentRequestId", "threadId", "anchorStart", "anchorEnd", "streamMarkdown"]
       },
       "updateMarginNote": {
         "requiredPayloadKeys": ["noteId", "status"]

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -79,7 +79,7 @@
       },
       "pdfPaneStateChanged": {
         "requiredPayloadKeys": ["visible"],
-        "optionalPayloadKeys": ["streamId", "sourceId", "sourceName", "shortTitle"]
+        "optionalPayloadKeys": ["streamId", "sourceId", "sourceName", "shortTitle", "selection"]
       },
       "pdfSectionActionRequested": {
         "requiredPayloadKeys": ["action", "streamId", "sourceId", "shortTitle", "sectionTitle", "page"]
@@ -149,6 +149,10 @@
   },
   "webToSwift": {
     "messages": {
+      "addStreamThreadAnchor": {
+        "requiredPayloadKeys": ["streamId", "threadId", "anchors"],
+        "requiredCallbackId": true
+      },
       "addSource": {
         "requiredPayloadKeys": ["streamId"]
       },
@@ -246,6 +250,10 @@
       },
       "removeSource": {
         "requiredPayloadKeys": ["id"]
+      },
+      "removeStreamThreadAnchor": {
+        "requiredPayloadKeys": ["streamId", "threadId", "anchorId"],
+        "requiredCallbackId": true
       },
       "retrySourceIndexing": {
         "requiredPayloadKeys": ["sourceId"]


### PR DESCRIPTION
Phase C4 of `docs/CONVERSATIONS_PLAN.md` §5 — every conversation request sends anchor-as-PRIMARY + whole Stream + scope-chip-honoring retrieval + bounded prior turns; pinned context (+ context → PDF/Stream selections as `stream_thread_anchors` rows, removable chips, verbatim injection); receipts v2 (primary range, pinned items, stream-document fact, retrieval mode, turn counts) with v1 back-compat; per-turn collapsed 'What AI saw' disclosure. Bridge re-adds add/removeStreamThreadAnchor; `pdfPaneStateChanged` carries a debounced live selection.

**Review (Opus): fail → two fix rounds (`be5f97b`, fixture fix):** (1) the Swift test target had not compiled since C3 — my gate pipeline was swallowing the exit code (corrected on PR #71; gates now capture per-gate exit codes) — fixed, full suite now actually executes: **231/231 pass, 2 skipped**; (2) receipts omitted the whole-stream fact — now recorded + rendered; plus primary-anchor-as-pin dedup, request/receipt filter symmetry, strict pin parsing with per-entry drops, debounced PDF selection with stable highlight ids, self-pin guard, honest test naming, and a v29→v30 production-fixture migration test running the real migrator.

**Gates (exit-code-verified):** build-dev 0 · swift-test 0 · typecheck 0 · web tests 0 (583) · web build 0 · contract 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)