### PR TITLE
C5: promotion + PDF Quote & discuss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: add conversation reply promotion and PDF Quote & discuss (phase C5)
 - editor: add complete AI context, persistent pins, and receipts to inline conversations (phase C4)
 - editor: open block-anchored conversations inline with streaming replies (phase C3)
 - editor: add durable conversation anchors and passive gutter markers (phase C2)

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -319,13 +319,11 @@ final class ThreadMessageHandler: BridgeMessageHandler {
     private static func decodePrimaryPDFReferences(
         _ payload: [String: AnyCodable]
     ) -> (sourceId: UUID?, highlightId: UUID?)? {
-        let hasSource = payload["sourceId"] != nil
-        let hasHighlight = payload["highlightId"] != nil
-        guard hasSource == hasHighlight else { return nil }
-        guard hasSource else { return (nil, nil) }
-        guard let source = payload["sourceId"]?.value as? String,
-              let highlight = payload["highlightId"]?.value as? String,
-              let sourceId = UUID(uuidString: source),
+        let source = payload["sourceId"]?.value as? String
+        let highlight = payload["highlightId"]?.value as? String
+        guard (source == nil) == (highlight == nil) else { return nil }
+        guard let source, let highlight else { return (nil, nil) }
+        guard let sourceId = UUID(uuidString: source),
               let highlightId = UUID(uuidString: highlight) else { return nil }
         return (sourceId, highlightId)
     }

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -67,7 +67,8 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                   let anchorStart = payload["anchorStart"]?.intValue,
                   let anchorEnd = payload["anchorEnd"]?.intValue,
                   anchorStart >= 0,
-                  anchorEnd > anchorStart else {
+                  anchorEnd > anchorStart,
+                  let references = Self.decodePrimaryPDFReferences(payload) else {
                 respondWithError(callbackId, "Invalid createStreamThread payload")
                 return
             }
@@ -76,6 +77,8 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                     streamId: streamId,
                     title: title,
                     anchorText: anchorText,
+                    sourceId: references.sourceId,
+                    highlightId: references.highlightId,
                     anchorStart: anchorStart,
                     anchorEnd: anchorEnd
                 ))
@@ -311,6 +314,20 @@ final class ThreadMessageHandler: BridgeMessageHandler {
     private static func optionalString(_ value: Any?) -> String? {
         guard let value = value as? String, !value.isEmpty else { return nil }
         return value
+    }
+
+    private static func decodePrimaryPDFReferences(
+        _ payload: [String: AnyCodable]
+    ) -> (sourceId: UUID?, highlightId: UUID?)? {
+        let hasSource = payload["sourceId"] != nil
+        let hasHighlight = payload["highlightId"] != nil
+        guard hasSource == hasHighlight else { return nil }
+        guard hasSource else { return (nil, nil) }
+        guard let source = payload["sourceId"]?.value as? String,
+              let highlight = payload["highlightId"]?.value as? String,
+              let sourceId = UUID(uuidString: source),
+              let highlightId = UUID(uuidString: highlight) else { return nil }
+        return (sourceId, highlightId)
     }
 
     private static func intValue(_ value: Any?) -> Int? {

--- a/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
+++ b/Sources/Ticker/App/PDFReader/PDFReaderPaneController.swift
@@ -798,8 +798,8 @@ final class PDFReaderPaneController: NSViewController {
         pdfPaneDiscussButton.imageScaling = .scaleProportionallyDown
         pdfPaneDiscussButton.isBordered = true
         pdfPaneDiscussButton.showsBorderOnlyWhileMouseInside = true
-        pdfPaneDiscussButton.toolTip = "Discuss selected PDF text"
-        pdfPaneDiscussButton.setAccessibilityLabel("Discuss selected PDF text")
+        pdfPaneDiscussButton.toolTip = "Quote & discuss"
+        pdfPaneDiscussButton.setAccessibilityLabel("Quote & discuss")
         pdfPaneDiscussButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         pdfPaneDiscussButton.setContentHuggingPriority(.required, for: .horizontal)
         setPDFSelectionActionsEnabled(false)
@@ -1678,8 +1678,8 @@ final class PDFReaderPaneController: NSViewController {
     @objc private func handlePDFPaneDiscussSelection() {
         handlePDFPaneSelection(
             missingPDFMessage: "Open a PDF before starting a conversation.",
-            missingSelectionMessage: "Nothing is selected to discuss.",
-            invalidSelectionMessage: "That selection cannot start a conversation.",
+            missingSelectionMessage: "Select PDF text to Quote & discuss.",
+            invalidSelectionMessage: "That selection cannot be quoted and discussed.",
             action: onDiscussSelection
         )
     }

--- a/Sources/Ticker/App/WebViewManager.swift
+++ b/Sources/Ticker/App/WebViewManager.swift
@@ -174,9 +174,19 @@ final class WebViewManager: NSObject {
         }
         pdfPaneController.onDiscussSelection = { [weak self] payload in
             guard let self else { return false }
-            // The highlight is provisional; C0's web surface immediately removes it.
-            self.sendPDFThreadRequested(payload)
-            return true
+            guard let persistence = self.persistence else {
+                self.sendSourceError("Could not save PDF highlight.")
+                return false
+            }
+            do {
+                try persistence.savePDFHighlight(payload.highlight)
+                self.sendPDFThreadRequested(payload)
+                return true
+            } catch {
+                DebugLog.log("[WebViewManager] Failed to save PDF highlight (\(DebugLog.errorSummary(error)))")
+                self.sendSourceError("Could not save PDF highlight.")
+                return false
+            }
         }
         pdfPaneController.onAnchorPlaced = { [weak self] payload in
             guard let self else { return false }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2373,6 +2373,23 @@ final class StreamDocumentTests: XCTestCase {
             let otherStream = Stream(title: "Other bridge stream")
             try service.saveStream(stream)
             try service.saveStream(otherStream)
+            let source = SourceReference(
+                streamId: stream.id,
+                displayName: "Paper.pdf",
+                fileType: .pdf,
+                bookmarkData: Data("paper".utf8),
+                status: .ready
+            )
+            try service.saveSource(source)
+            let highlight = PDFHighlightRecord(
+                id: UUID(),
+                sourceId: source.id,
+                page: 4,
+                rects: [PDFHighlightRect(page: 4, x: 1, y: 2, w: 3, h: 4)],
+                quote: "Quoted evidence",
+                createdAt: Date(timeIntervalSince1970: 6_000)
+            )
+            try service.savePDFHighlight(highlight)
             let docJSON = #"{"type":"doc","content":[{"type":"paragraph"}]}"#
             let thread = StreamThread(
                 streamId: stream.id,
@@ -2426,6 +2443,28 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(conversations[0]["detached"] as? Bool, false)
             XCTAssertEqual(conversations[0]["ephemeral"] as? Bool, true)
             XCTAssertNotNil(conversations[0]["updatedAt"] as? String)
+
+            await handler.handle(BridgeMessage(
+                type: "createStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "title": AnyCodable("Quoted evidence"),
+                    "anchorStart": AnyCodable(1),
+                    "anchorEnd": AnyCodable(20),
+                    "anchorText": AnyCodable("Quoted evidence Paper p.4"),
+                    "sourceId": AnyCodable(source.id.uuidString),
+                    "highlightId": AnyCodable(highlight.id.uuidString)
+                ],
+                callbackId: "create-pdf"
+            ))
+            let pdfCreateResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "create-pdf" }
+            )
+            let pdfThread = try XCTUnwrap(pdfCreateResponse.payload?["thread"]?.value as? [String: Any])
+            XCTAssertEqual(pdfThread["sourceId"] as? String, source.id.uuidString)
+            XCTAssertEqual(pdfThread["highlightId"] as? String, highlight.id.uuidString)
+            XCTAssertEqual(pdfThread["sourcePage"] as? Int, 4)
+            XCTAssertEqual((pdfThread["anchors"] as? [[String: Any]])?.count, 0)
 
             await handler.handle(BridgeMessage(
                 type: "createStreamThread",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2473,7 +2473,9 @@ final class StreamDocumentTests: XCTestCase {
                     "title": AnyCodable("Does this hold?"),
                     "anchorStart": AnyCodable(1),
                     "anchorEnd": AnyCodable(12),
-                    "anchorText": AnyCodable("Power budget")
+                    "anchorText": AnyCodable("Power budget"),
+                    "sourceId": AnyCodable(NSNull()),
+                    "highlightId": AnyCodable(NSNull())
                 ],
                 callbackId: "create"
             ))

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -64,6 +64,7 @@ interface ConversationSurfaceProps {
   updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
   createThread: (query: string) => Promise<StreamThreadJSON>;
   hasDrifted: (anchorText: string) => boolean;
+  onPromote: (exchange: AIExchangeJSON) => void;
   onCollapse: () => void;
 }
 
@@ -119,17 +120,26 @@ const Turn = memo(function Turn({
   who,
   text,
   receipt,
+  exchange,
+  onPromote,
 }: {
   who: 'You' | 'AI';
   text: string;
   receipt?: unknown;
+  exchange?: AIExchangeJSON;
+  onPromote?: (exchange: AIExchangeJSON) => void;
 }) {
   return (
     <div className={`conversation-turn conversation-turn--${who === 'You' ? 'you' : 'ai'}`}>
       <span className="conversation-turn-label">{who}</span>
       <div className="conversation-turn-text">{text}</div>
       {who === 'AI' && <ThreadContextDisclosure value={receipt} />}
-      <button type="button" className="conversation-turn-copy" onClick={() => copy(text)}>Copy</button>
+      <div className="conversation-turn-controls">
+        {exchange && onPromote && (
+          <button type="button" onClick={() => onPromote(exchange)}>↑ Add to Stream</button>
+        )}
+        <button type="button" onClick={() => copy(text)}>Copy</button>
+      </div>
     </div>
   );
 });
@@ -150,6 +160,7 @@ export function ConversationSurface({
   updateState,
   createThread,
   hasDrifted,
+  onPromote,
   onCollapse,
 }: ConversationSurfaceProps) {
   const composerRef = useRef<HTMLTextAreaElement>(null);
@@ -367,7 +378,13 @@ export function ConversationSurface({
         {state.exchanges.map((exchange) => (
           <div className="conversation-exchange" key={exchange.requestId}>
             <Turn who="You" text={exchange.userInput} />
-            <Turn who="AI" text={exchange.responseRaw} receipt={exchange.sourceManifest} />
+            <Turn
+              who="AI"
+              text={exchange.responseRaw}
+              receipt={exchange.sourceManifest}
+              exchange={exchange}
+              onPromote={onPromote}
+            />
           </div>
         ))}
         {state.active && (

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -196,9 +196,7 @@ export function ConversationSurface({
   }, [conversationKey, state.loading, state.thread, streamId, threadId, updateState]);
 
   useEffect(() => {
-    if (!focusComposer) return;
-    const frame = window.requestAnimationFrame(() => composerRef.current?.focus());
-    return () => window.cancelAnimationFrame(frame);
+    if (focusComposer) composerRef.current?.focus();
   }, [focusComposer]);
 
   useEffect(() => bridge.onMessage((message) => {

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -2,6 +2,7 @@
 import { act, StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { EditorView } from 'prosemirror-view';
+import { TextSelection } from 'prosemirror-state';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   bridge,
@@ -586,7 +587,7 @@ describe('RichStreamEditor inline conversations', () => {
     });
   });
 
-  it('opens a saved turn and promotes it after the anchor with visible AI provenance', async () => {
+  it('promotes saved turns in order with citation links and visible AI provenance', async () => {
     const updatedAt = new Date().toISOString();
     const anchored: Stream = {
       ...stream,
@@ -629,8 +630,23 @@ describe('RichStreamEditor inline conversations', () => {
               threadId: 'thread-existing',
               verb: 'thread',
               userInput: 'Why?',
+              sourceManifest: JSON.stringify([{
+                n: 1,
+                sourceId: 'source-1',
+                shortTitle: 'Paper',
+                page: 4,
+                chunkId: 'chunk-1',
+              }]),
+              responseRaw: 'Because.【1|"support"】',
+              createdAt: updatedAt,
+            }, {
+              requestId: 'exchange-2',
+              streamId: anchored.id,
+              threadId: 'thread-existing',
+              verb: 'thread',
+              userInput: 'And then?',
               sourceManifest: '[]',
-              responseRaw: 'Because.',
+              responseRaw: 'Second reply.',
               createdAt: updatedAt,
             }],
           },
@@ -666,16 +682,21 @@ describe('RichStreamEditor inline conversations', () => {
     expect(document.activeElement).toBe(document.querySelector('.conversation-composer'));
 
     const promote = [...document.querySelectorAll<HTMLButtonElement>('button')]
-      .find((button) => button.textContent === '↑ Add to Stream');
-    expect(promote).toBeDefined();
-    await act(async () => { promote!.click(); });
+      .filter((button) => button.textContent === '↑ Add to Stream');
+    expect(promote).toHaveLength(2);
+    await act(async () => { promote[0].click(); });
+    await act(async () => { promote[1].click(); });
     expect([...editor().querySelectorAll('p')].map((node) => node.textContent)).toEqual([
       'Original paragraph.',
-      'Because.',
+      'Because. p.4',
+      'Second reply.',
       'Following paragraph.',
     ]);
+    expect(editor().querySelector('a')?.getAttribute('href'))
+      .toBe('ticker-pdf://source-1?page=4&chunk=chunk-1&q=support');
     await toggleXray();
-    expect(document.querySelector('.richtext-provenance')?.textContent).toBe('Because.');
+    expect([...document.querySelectorAll('.richtext-provenance')].map((node) => node.textContent))
+      .toEqual(['Because. ', 'p.4', 'Second reply.']);
   });
 
   it('persists pin and unpin across conversation reloads', async () => {
@@ -2763,7 +2784,7 @@ describe('RichStreamEditor PDF anchor placement', () => {
 });
 
 describe('RichStreamEditor PDF highlight links', () => {
-  it('inserts the quote before creating its primary-only conversation and undo detaches it', async () => {
+  it('saves before create, undo detaches exactly, and redo keeps the conversation at document end', async () => {
     const updatedAt = new Date().toISOString();
     const quotedStream: Stream = {
       ...stream,
@@ -2775,6 +2796,7 @@ describe('RichStreamEditor PDF highlight links', () => {
         markdown: 'First paragraph.\n\nLast paragraph.',
       },
     };
+    const beforeDocument = quotedStream.document!.docJSON!;
     await renderStream(quotedStream);
     await selectEditorText('First paragraph.');
     let liveView: EditorView | null = null;
@@ -2787,11 +2809,28 @@ describe('RichStreamEditor PDF highlight links', () => {
       updateState.call(this, state);
     });
     let pdfThread: StreamThreadJSON | undefined;
+    const bridgeOrder: string[] = [];
     vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      bridgeOrder.push(type);
       if (type === 'loadStreamThread') return { thread: pdfThread! };
+      if (type === 'listConversations') return {
+        conversations: [{
+          threadId: 'pdf-thread',
+          anchorStart: null,
+          anchorEnd: null,
+          anchorText: 'A selected quote. Paper p.4',
+          detached: true,
+          ephemeral: false,
+          updatedAt,
+        }],
+      };
       if (type !== 'createStreamThread') return { revision: 2 };
       expect(editor().querySelector('blockquote')?.textContent)
         .toBe('A selected quote. Paper p.4');
+      expect(bridgeOrder).toContain('saveRichStreamDocument');
+      expect(bridgeOrder.indexOf('saveRichStreamDocument')).toBeLessThan(
+        bridgeOrder.indexOf('createStreamThread'),
+      );
       pdfThread = {
           threadId: 'pdf-thread',
           streamId: quotedStream.id,
@@ -2850,6 +2889,39 @@ describe('RichStreamEditor PDF highlight links', () => {
     expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'addStreamThreadAnchor'))
       .toBe(false);
 
+    let lastParagraph = -1;
+    liveView!.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text === 'Last paragraph.') lastParagraph = pos;
+    });
+    await act(async () => {
+      liveView!.dispatch(liveView!.state.tr.setSelection(
+        TextSelection.create(liveView!.state.doc, lastParagraph, lastParagraph + 4),
+      ));
+      bridge.receive({
+        type: 'pdfPaneStateChanged',
+        payload: {
+          visible: true,
+          streamId: quotedStream.id,
+          sourceId: 'source-1',
+          sourceName: 'paper.pdf',
+          shortTitle: 'Paper',
+          selection: {
+            highlightId: 'highlight-1',
+            quote: 'A selected quote.',
+            page: 4,
+            createdAt: updatedAt,
+            rects: [],
+          },
+        },
+      });
+    });
+    const context = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent === '+ context');
+    expect(context?.disabled).toBe(false);
+    await act(async () => { context!.click(); });
+    expect([...document.querySelectorAll('.conversation-context-menu button')]
+      .map((button) => button.textContent)).toEqual(['Stream selection']);
+
     await act(async () => {
       (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
       await new Promise((resolve) => window.setTimeout(resolve, 160));
@@ -2899,6 +2971,7 @@ describe('RichStreamEditor PDF highlight links', () => {
       }));
     });
     expect(editor().querySelector('blockquote')).toBe(null);
+    expect(JSON.stringify(liveView!.state.doc.toJSON())).toBe(beforeDocument);
     expect(document.querySelector('.conversation-surface')).not.toBe(null);
     expect(document.querySelector('.conversation-drift-note')?.textContent)
       .toBe('The passage has changed since this conversation started.');
@@ -2906,6 +2979,87 @@ describe('RichStreamEditor PDF highlight links', () => {
       .toHaveLength(1);
     expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'deleteStreamThread'))
       .toBe(false);
+    await vi.waitFor(() => {
+      const detachedSave = vi.mocked(bridge.sendAsync).mock.calls.find(([type, payload]) => (
+        type === 'saveRichStreamDocument'
+        && Array.isArray(payload?.conversationAnchors)
+        && payload.conversationAnchors.some((anchor) => (
+          anchor.threadId === 'pdf-thread' && anchor.detached === true
+        ))
+      ));
+      expect(detachedSave).toBeDefined();
+    });
+
+    const conversations = document.querySelector('.stream-overflow-action') as HTMLButtonElement;
+    await act(async () => {
+      conversations.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(document.querySelector('.conversation-list-row')?.textContent).toContain('detached');
+    });
+    await act(async () => { conversations.click(); });
+
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'z', ctrlKey: true, shiftKey: true, bubbles: true, cancelable: true,
+      }));
+    });
+    expect(editor().querySelector('blockquote')).not.toBe(null);
+    expect([...editor().children].map((node) => node.tagName)).toEqual(['P', 'BLOCKQUOTE', 'P', 'DIV']);
+    expect(editor().lastElementChild).toBe(document.querySelector('.conversation-widget-host'));
+  });
+
+  it('removes a persisted PDF highlight when quote creation cannot reach this editor', async () => {
+    await act(async () => {
+      bridge.receive({
+        type: 'pdfThreadRequested',
+        payload: {
+          streamId: 'other-stream',
+          sourceId: 'source-1',
+          sourceName: 'paper.pdf',
+          shortTitle: 'Paper',
+          highlightId: 'wrong-stream-highlight',
+          page: 4,
+          quote: 'A selected quote.',
+        },
+      });
+    });
+    expect(sent).toContainEqual({
+      type: 'deletePdfHighlight',
+      payload: { streamId: 'other-stream', highlightId: 'wrong-stream-highlight' },
+    });
+
+    await renderStream({
+      ...stream,
+      id: 'unconverted-quote-stream',
+      document: {
+        ...stream.document,
+        streamId: 'unconverted-quote-stream',
+        docJSON: undefined,
+        docFormatVersion: undefined,
+      },
+    });
+    await act(async () => {
+      bridge.receive({
+        type: 'pdfThreadRequested',
+        payload: {
+          streamId: 'unconverted-quote-stream',
+          sourceId: 'source-1',
+          sourceName: 'paper.pdf',
+          shortTitle: 'Paper',
+          highlightId: 'missing-editor-highlight',
+          page: 4,
+          quote: 'A selected quote.',
+        },
+      });
+    });
+    expect(sent).toContainEqual({
+      type: 'deletePdfHighlight',
+      payload: { streamId: 'unconverted-quote-stream', highlightId: 'missing-editor-highlight' },
+    });
+    expect(useToastStore.getState().toasts.map((toast) => toast.message))
+      .toContain("Couldn't add the quote");
   });
 
   it('inserts a linked PDF quote as one undo step', async () => {

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -2763,12 +2763,61 @@ describe('RichStreamEditor PDF anchor placement', () => {
 });
 
 describe('RichStreamEditor PDF highlight links', () => {
-  it('cleans up a requested discussion while inline conversations are unavailable', async () => {
+  it('inserts the quote before creating its primary-only conversation and undo detaches it', async () => {
+    const updatedAt = new Date().toISOString();
+    const quotedStream: Stream = {
+      ...stream,
+      id: 'quote-discuss-stream',
+      document: {
+        ...stream.document,
+        streamId: 'quote-discuss-stream',
+        docJSON: docJSON('First paragraph.\n\nLast paragraph.'),
+        markdown: 'First paragraph.\n\nLast paragraph.',
+      },
+    };
+    await renderStream(quotedStream);
+    await selectEditorText('First paragraph.');
+    let liveView: EditorView | null = null;
+    const updateState = EditorView.prototype.updateState;
+    vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+      this: EditorView,
+      state,
+    ) {
+      liveView = this;
+      updateState.call(this, state);
+    });
+    let pdfThread: StreamThreadJSON | undefined;
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'loadStreamThread') return { thread: pdfThread! };
+      if (type !== 'createStreamThread') return { revision: 2 };
+      expect(editor().querySelector('blockquote')?.textContent)
+        .toBe('A selected quote. Paper p.4');
+      pdfThread = {
+          threadId: 'pdf-thread',
+          streamId: quotedStream.id,
+          title: String(payload?.title),
+          workingText: '',
+          anchorText: String(payload?.anchorText),
+          sourceId: String(payload?.sourceId),
+          highlightId: String(payload?.highlightId),
+          anchorStart: Number(payload?.anchorStart),
+          anchorEnd: Number(payload?.anchorEnd),
+          detached: false,
+          ephemeral: false,
+          revision: 0,
+          createdAt: updatedAt,
+          updatedAt,
+          anchors: [],
+          exchanges: [],
+      };
+      return { thread: pdfThread };
+    }) as typeof bridge.sendAsync);
+
     await act(async () => {
       bridge.receive({
         type: 'pdfThreadRequested',
         payload: {
-          streamId: stream.id,
+          streamId: quotedStream.id,
           sourceId: 'source-1',
           sourceName: 'paper.pdf',
           shortTitle: 'Paper',
@@ -2781,12 +2830,82 @@ describe('RichStreamEditor PDF highlight links', () => {
       });
     });
 
-    expect(sent).toContainEqual({
-      type: 'deletePdfHighlight',
-      payload: { streamId: stream.id, highlightId: 'highlight-1' },
+    await vi.waitFor(() => expect(document.querySelector('.conversation-composer')).not.toBe(null));
+    await act(async () => { await new Promise((resolve) => window.setTimeout(resolve, 20)); });
+    expect(document.activeElement).toBe(document.querySelector('.conversation-composer'));
+    expect([...editor().children].map((node) => node.tagName)).toEqual(['P', 'BLOCKQUOTE', 'DIV', 'P']);
+    expect(editor().children[0].textContent).toBe('First paragraph.');
+    expect(editor().querySelector('blockquote > p')?.textContent).toBe('A selected quote. Paper p.4');
+    expect(editor().querySelector('blockquote')?.nextElementSibling)
+      .toBe(document.querySelector('.conversation-widget-host'));
+    expect(editor().children[3].textContent).toBe('Last paragraph.');
+    const createCall = vi.mocked(bridge.sendAsync).mock.calls
+      .find(([type]) => type === 'createStreamThread');
+    expect(createCall?.[1]).toMatchObject({
+      streamId: quotedStream.id,
+      anchorText: 'A selected quote. Paper p.4',
+      sourceId: 'source-1',
+      highlightId: 'highlight-1',
     });
-    expect(useToastStore.getState().toasts.map((toast) => toast.message))
-      .toContain('Inline conversations are temporarily unavailable.');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'addStreamThreadAnchor'))
+      .toBe(false);
+
+    await act(async () => {
+      (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+    });
+    let linkPos = -1;
+    liveView!.state.doc.descendants((node, pos) => {
+      if (linkPos < 0 && node.isText && node.text === 'Paper p.4') linkPos = pos;
+    });
+    expect(linkPos).toBeGreaterThan(0);
+    await act(async () => {
+      const handled = liveView!.someProp('handleClick', (handler) => (
+        handler(liveView!, linkPos + 1, new MouseEvent('click'))
+      ));
+      expect(handled).toBe(true);
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-surface')).not.toBe(null));
+    expect(sent).toContainEqual({
+      type: 'openPdfDestination',
+      payload: {
+        streamId: quotedStream.id,
+        url: 'ticker-pdf://source-1?highlight=highlight-1&page=4',
+      },
+    });
+
+    await act(async () => {
+      (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+      bridge.receive({
+        type: 'revealPdfHighlightInStream',
+        payload: {
+          streamId: quotedStream.id,
+          sourceId: 'source-1',
+          highlightId: 'highlight-1',
+        },
+      });
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-surface')).not.toBe(null));
+    expect(liveView).not.toBe(null);
+    expect(liveView!.state.doc.textBetween(
+      liveView!.state.selection.from,
+      liveView!.state.selection.to,
+    )).toBe('Paper p.4');
+
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'z', ctrlKey: true, bubbles: true, cancelable: true,
+      }));
+    });
+    expect(editor().querySelector('blockquote')).toBe(null);
+    expect(document.querySelector('.conversation-surface')).not.toBe(null);
+    expect(document.querySelector('.conversation-drift-note')?.textContent)
+      .toBe('The passage has changed since this conversation started.');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.filter(([type]) => type === 'createStreamThread'))
+      .toHaveLength(1);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'deleteStreamThread'))
+      .toBe(false);
   });
 
   it('inserts a linked PDF quote as one undo step', async () => {

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -586,7 +586,7 @@ describe('RichStreamEditor inline conversations', () => {
     });
   });
 
-  it('opens a persisted glyph in place and restores its saved turns', async () => {
+  it('opens a saved turn and promotes it after the anchor with visible AI provenance', async () => {
     const updatedAt = new Date().toISOString();
     const anchored: Stream = {
       ...stream,
@@ -664,6 +664,18 @@ describe('RichStreamEditor inline conversations', () => {
     await act(async () => { editor().dispatchEvent(tab); });
     expect(tab.defaultPrevented).toBe(true);
     expect(document.activeElement).toBe(document.querySelector('.conversation-composer'));
+
+    const promote = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent === '↑ Add to Stream');
+    expect(promote).toBeDefined();
+    await act(async () => { promote!.click(); });
+    expect([...editor().querySelectorAll('p')].map((node) => node.textContent)).toEqual([
+      'Original paragraph.',
+      'Because.',
+      'Following paragraph.',
+    ]);
+    await toggleXray();
+    expect(document.querySelector('.richtext-provenance')?.textContent).toBe('Because.');
   });
 
   it('persists pin and unpin across conversation reloads', async () => {

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -59,6 +59,7 @@ import {
 import {
   aiWritingRange,
   insertImage,
+  promoteConversationMarkdown,
   removePDFHighlightLink,
   revealPDFHighlight,
   selectedPDFHighlight,
@@ -899,6 +900,28 @@ export function RichStreamEditor({
       anchorText,
     );
   }, []);
+
+  const promoteConversationTurn = useCallback((exchange: AIExchangeJSON) => {
+    const currentEditor = editorRef.current;
+    const surface = currentEditor && conversationSurface(currentEditor.view.state);
+    if (!currentEditor || !surface) return;
+    const inserted = promoteConversationMarkdown(
+      currentEditor.view,
+      conversationRenderPosition(currentEditor.view.state.doc, surface.anchor)
+        ?? currentEditor.view.state.doc.content.size,
+      exchange.responseRaw,
+      { requestId: exchange.requestId, model: exchange.model, verb: exchange.verb },
+    );
+    window.setTimeout(() => {
+      if (currentEditor.view.isDestroyed) return;
+      const highlighted = aiWritingRange(currentEditor.view.state);
+      if (highlighted?.from !== inserted.from || highlighted.to !== inserted.to) return;
+      currentEditor.view.dispatch(
+        setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
+      );
+    }, 1_200);
+    addToast('Added to the Stream.', 'success');
+  }, [addToast]);
 
   const toggleConversationList = useCallback(async () => {
     if (showConversationList) {
@@ -2024,6 +2047,7 @@ export function RichStreamEditor({
           updateState={updateConversationLiveState}
           createThread={createPersistedConversation}
           hasDrifted={conversationHasDrifted}
+          onPromote={promoteConversationTurn}
           onCollapse={collapseConversation}
         />,
         conversationWidgetTarget,

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -43,13 +43,16 @@ import {
   type PDFSectionActionRequest,
 } from './StreamEditor';
 import { createRichTextEditor, type RichTextEditor } from '../richtext/editor';
+import { parseTickerPDFURL } from '../extensions/PDFHighlightLink';
 import {
   conversationAnchorFromJSON,
   conversationAnchorText,
   conversationAnchorTextForStorage,
   conversationAnchors,
   conversationRenderPosition,
+  conversationSurfacePosition,
   conversationSurface,
+  fullBlockConversationAnchor,
   hasConversationAnchorTextDrifted,
   refreshConversationViewport,
   setConversationAnchors,
@@ -59,6 +62,8 @@ import {
 import {
   aiWritingRange,
   insertImage,
+  insertMarkdownBlocks,
+  pdfHighlightRange,
   promoteConversationMarkdown,
   removePDFHighlightLink,
   revealPDFHighlight,
@@ -233,6 +238,7 @@ export function RichStreamEditor({
   const aiRequestRef = useRef<ActiveDocumentAI | null>(null);
   const aiInFlightRef = useRef(false);
   const pendingPDFAnchorSelectionRef = useRef<PendingPDFAnchorSelection | null>(null);
+  const lastEditorCursorRef = useRef<number | null>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const editorShellRef = useRef<HTMLDivElement>(null);
   const streamOverflowMenuRef = useRef<HTMLDetailsElement>(null);
@@ -566,6 +572,18 @@ export function RichStreamEditor({
     });
   }, [expandConversation]);
 
+  const revealPDFConversation = useCallback((sourceId: string, highlightId: string) => {
+    const view = editorRef.current?.view;
+    if (!view) return false;
+    const range = pdfHighlightRange(view.state, sourceId, highlightId);
+    if (!range || !revealPDFHighlight(view, sourceId, highlightId)) return false;
+    const anchor = conversationAnchors(view.state).find((candidate) => (
+      range.from < candidate.to && range.to > candidate.from
+    ));
+    if (anchor) openConversationFromGlyph(anchor.threadId);
+    return true;
+  }, [openConversationFromGlyph]);
+
   const createConversationAtBlock = useCallback((anchor: ConversationAnchor) => {
     const view = editorRef.current?.view;
     if (!view) return;
@@ -626,6 +644,10 @@ export function RichStreamEditor({
     if (pendingPDF) {
       pendingPDFAnchorSelectionRef.current = mapPendingPDFAnchorSelection(pendingPDF, mapper);
     }
+    if (transaction.selectionSet) lastEditorCursorRef.current = transaction.selection.head;
+    else if (transaction.docChanged && lastEditorCursorRef.current !== null) {
+      lastEditorCursorRef.current = transaction.mapping.map(lastEditorCursorRef.current, 1);
+    }
   }, []);
 
   /**
@@ -636,10 +658,14 @@ export function RichStreamEditor({
   const openLink = useCallback((href: string) => {
     if (href.startsWith(PDF_URL_PREFIX)) {
       bridge.send({ type: 'openPdfDestination', payload: { streamId: stream.id, url: href } });
+      const destination = parseTickerPDFURL(href);
+      if (destination?.sourceId && destination.highlightId) {
+        revealPDFConversation(destination.sourceId, destination.highlightId);
+      }
       return;
     }
     bridge.send({ type: 'openExternalURL', payload: { url: href } });
-  }, [stream.id]);
+  }, [revealPDFConversation, stream.id]);
 
   const saveImageToAssets = useCallback(async (blob: Blob): Promise<string> => {
     const requestId = crypto.randomUUID();
@@ -839,27 +865,37 @@ export function RichStreamEditor({
     setConversationRecords(records);
   }, [stream.conversationAnchors]);
 
-  const createPersistedConversation = useCallback(async (query: string): Promise<StreamThreadJSON> => {
+  const persistConversation = useCallback(async (
+    currentSurface: { key: string; anchor: ConversationAnchor },
+    title: string,
+    pdf?: { sourceId: string; highlightId: string },
+  ): Promise<StreamThreadJSON> => {
     const currentEditor = editorRef.current;
-    const currentSurface = currentEditor && conversationSurface(currentEditor.view.state);
-    if (!currentEditor || !currentSurface) throw new Error('Conversation closed');
+    if (!currentEditor) throw new Error('Conversation closed');
     const anchorText = conversationAnchorTextForStorage(currentEditor.view.state.doc, currentSurface.anchor);
     if (!anchorText) throw new Error('Anchor deleted');
     const { thread } = await createStreamThread({
       streamId: stream.id,
-      title: query.split(/\r?\n/, 1)[0],
+      title,
       anchorStart: currentSurface.anchor.from,
       anchorEnd: currentSurface.anchor.to,
       anchorText,
+      sourceId: pdf?.sourceId,
+      highlightId: pdf?.highlightId,
     });
 
     const liveEditor = editorRef.current;
     if (!liveEditor || liveEditor.view.isDestroyed) return thread;
     const liveSurface = conversationSurface(liveEditor.view.state);
-    const mapped = liveSurface?.key === currentSurface.key ? liveSurface.anchor : currentSurface.anchor;
+    const mapped = liveSurface?.key === currentSurface.key
+      ? liveSurface.anchor
+      : conversationAnchors(liveEditor.view.state)
+        .find((anchor) => anchor.threadId === currentSurface.anchor.threadId)
+        ?? currentSurface.anchor;
     const persisted = { ...mapped, threadId: thread.threadId, detached: mapped.from >= mapped.to };
     const anchors = conversationAnchors(liveEditor.view.state)
-      .filter((anchor) => anchor.threadId !== thread.threadId);
+      .filter((anchor) => anchor.threadId !== thread.threadId
+        && anchor.threadId !== currentSurface.anchor.threadId);
     liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [...anchors, persisted]));
     if (liveSurface?.key === currentSurface.key) {
       liveEditor.view.dispatch(setConversationSurface(liveEditor.view.state.tr, {
@@ -880,7 +916,7 @@ export function RichStreamEditor({
         anchorStart: persisted.from,
         anchorEnd: persisted.to,
         anchorText,
-        detached: false,
+        detached: persisted.detached,
         ephemeral: false,
         updatedAt: thread.updatedAt,
       },
@@ -890,6 +926,13 @@ export function RichStreamEditor({
     sessionRef.current?.documentChanged();
     return thread;
   }, [stream.id]);
+
+  const createPersistedConversation = useCallback(async (query: string): Promise<StreamThreadJSON> => {
+    const currentEditor = editorRef.current;
+    const currentSurface = currentEditor && conversationSurface(currentEditor.view.state);
+    if (!currentSurface) throw new Error('Conversation closed');
+    return persistConversation(currentSurface, query.split(/\r?\n/, 1)[0]);
+  }, [persistConversation]);
 
   const conversationHasDrifted = useCallback((anchorText: string) => {
     const currentEditor = editorRef.current;
@@ -907,7 +950,7 @@ export function RichStreamEditor({
     if (!currentEditor || !surface) return;
     const inserted = promoteConversationMarkdown(
       currentEditor.view,
-      conversationRenderPosition(currentEditor.view.state.doc, surface.anchor)
+      conversationSurfacePosition(currentEditor.view.state.doc, surface.anchor)
         ?? currentEditor.view.state.doc.content.size,
       exchange.responseRaw,
       { requestId: exchange.requestId, model: exchange.model, verb: exchange.verb },
@@ -922,6 +965,73 @@ export function RichStreamEditor({
     }, 1_200);
     addToast('Added to the Stream.', 'success');
   }, [addToast]);
+
+  const quoteAndDiscussPDF = useCallback(async (selection: {
+    sourceId: string;
+    sourceName: string;
+    shortTitle: string;
+    highlightId: string;
+    page: number;
+    quote: string;
+  }) => {
+    const currentEditor = editorRef.current;
+    if (!currentEditor) return;
+    const { view } = currentEditor;
+    const cursor = lastEditorCursorRef.current;
+    const cursorAnchor = cursor === null
+      ? null
+      : fullBlockConversationAnchor(view.state.doc, cursor, '');
+    const insertAt = cursorAnchor
+      ? conversationSurfacePosition(view.state.doc, cursorAnchor) ?? view.state.doc.content.size
+      : view.state.doc.content.size;
+    const linkURL = buildTickerPDFLinkURL(selection);
+    const inserted = insertMarkdownBlocks(view, insertAt, buildPDFQuoteSnippet({
+      quote: selection.quote,
+      linkLabel: `${selection.shortTitle || selection.sourceName || 'PDF'} p.${selection.page}`,
+      linkURL,
+    }));
+    const key = `pdf:${crypto.randomUUID()}`;
+    const anchor = fullBlockConversationAnchor(view.state.doc, inserted.from + 2, key);
+    if (!anchor) {
+      addToast('The PDF quote was added, but its conversation could not be anchored.', 'warning');
+      return;
+    }
+    view.dispatch(setConversationAnchors(view.state.tr, [...conversationAnchors(view.state), anchor]));
+    view.dispatch(setConversationSurface(view.state.tr, { key, anchor }));
+
+    try {
+      const thread = await persistConversation(
+        { key, anchor },
+        selection.quote.slice(0, 80),
+        { sourceId: selection.sourceId, highlightId: selection.highlightId },
+      );
+      updateConversationLiveState(key, (current) => ({
+        ...current,
+        thread,
+        exchanges: thread.exchanges ?? [],
+        loading: false,
+      }));
+      expandConversation({
+        key,
+        threadId: thread.threadId,
+        anchorText: thread.anchorText,
+        focusComposer: true,
+      });
+      addToast('Added PDF quote and opened a conversation.', 'success');
+    } catch {
+      const liveEditor = editorRef.current;
+      if (liveEditor && !liveEditor.view.isDestroyed) {
+        liveEditor.view.dispatch(setConversationAnchors(
+          liveEditor.view.state.tr,
+          conversationAnchors(liveEditor.view.state).filter((item) => item.threadId !== key),
+        ));
+        if (conversationSurface(liveEditor.view.state)?.key === key) {
+          liveEditor.view.dispatch(setConversationSurface(liveEditor.view.state.tr, null));
+        }
+      }
+      addToast('The PDF quote was added, but its conversation could not be created.', 'error');
+    }
+  }, [addToast, expandConversation, persistConversation, updateConversationLiveState]);
 
   const toggleConversationList = useCallback(async () => {
     if (showConversationList) {
@@ -1333,15 +1443,21 @@ export function RichStreamEditor({
 
     if (message.type === 'pdfThreadRequested') {
       if (payload?.streamId !== stream.id) return;
-      // ponytail: C0 has no conversation surface; C3 replaces this cleanup path.
+      const sourceId = payload.sourceId;
+      const sourceName = payload.sourceName;
+      const shortTitle = payload.shortTitle;
       const highlightId = payload.highlightId;
-      if (typeof highlightId === 'string' && highlightId) {
-        bridge.send({
-          type: 'deletePdfHighlight',
-          payload: { streamId: stream.id, highlightId },
-        });
-      }
-      addToast('Inline conversations are temporarily unavailable.', 'info');
+      const quote = payload.quote;
+      const page = Number(payload.page);
+      if (typeof sourceId !== 'string'
+        || typeof sourceName !== 'string'
+        || typeof shortTitle !== 'string'
+        || typeof highlightId !== 'string'
+        || typeof quote !== 'string'
+        || !quote.trim()
+        || !Number.isInteger(page)
+        || page < 1) return;
+      void quoteAndDiscussPDF({ sourceId, sourceName, shortTitle, highlightId, page, quote });
       return;
     }
 
@@ -1359,7 +1475,7 @@ export function RichStreamEditor({
       const sourceId = payload.sourceId;
       const highlightId = payload.highlightId;
       if (typeof sourceId !== 'string' || typeof highlightId !== 'string') return;
-      if (!revealPDFHighlight(editorRef.current!.view, sourceId, highlightId)) {
+      if (!revealPDFConversation(sourceId, highlightId)) {
         addToast('This PDF highlight is not linked in the Stream.', 'warning');
         return;
       }
@@ -1568,6 +1684,8 @@ export function RichStreamEditor({
     canStartAI,
     cancelDocumentAI,
     flushAll,
+    quoteAndDiscussPDF,
+    revealPDFConversation,
     startPDFSectionAI,
     stream.id,
   ]);

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -77,6 +77,7 @@ import {
   addProvenanceSpans,
   hashProvenanceText,
   provenanceSpanAt,
+  provenanceSpans,
   spanFromJSON,
   type ProvenanceSpanJSON,
 } from '../richtext/provenance';
@@ -97,6 +98,7 @@ import {
 } from '../utils/pdfAnchorSelection';
 import { computeSelectionMenuPlacement } from '../utils/selectionMenuPlacement';
 import { formatRelativeTime } from '../utils/relativeTime';
+import { manifestCitations } from '../threads/context';
 import {
   activeFormats,
   toggleBlockquote,
@@ -948,25 +950,51 @@ export function RichStreamEditor({
     const currentEditor = editorRef.current;
     const surface = currentEditor && conversationSurface(currentEditor.view.state);
     if (!currentEditor || !surface) return;
-    const inserted = promoteConversationMarkdown(
-      currentEditor.view,
-      conversationSurfacePosition(currentEditor.view.state.doc, surface.anchor)
-        ?? currentEditor.view.state.doc.content.size,
-      exchange.responseRaw,
-      { requestId: exchange.requestId, model: exchange.model, verb: exchange.verb },
-    );
-    window.setTimeout(() => {
-      if (currentEditor.view.isDestroyed) return;
-      const highlighted = aiWritingRange(currentEditor.view.state);
-      if (highlighted?.from !== inserted.from || highlighted.to !== inserted.to) return;
-      currentEditor.view.dispatch(
-        setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
+    try {
+      const priorPromotionEnd = provenanceSpans(currentEditor.view.state)
+        .filter((span) => span.origin === 'ai' && span.meta.threadId === surface.anchor.threadId)
+        .reduce((end, span) => Math.max(end, span.to), 0);
+      const inserted = promoteConversationMarkdown(
+        currentEditor.view,
+        priorPromotionEnd || conversationSurfacePosition(currentEditor.view.state.doc, surface.anchor)
+          || currentEditor.view.state.doc.content.size,
+        swapCitationMarkersWithMetadata(
+          exchange.responseRaw,
+          manifestCitations(exchange.sourceManifest),
+        ).text,
+        {
+          requestId: exchange.requestId,
+          model: exchange.model,
+          verb: exchange.verb,
+          threadId: surface.anchor.threadId,
+        },
       );
-    }, 1_200);
-    addToast('Added to the Stream.', 'success');
+      window.setTimeout(() => {
+        if (currentEditor.view.isDestroyed) return;
+        const highlighted = aiWritingRange(currentEditor.view.state);
+        if (highlighted?.from !== inserted.from || highlighted.to !== inserted.to) return;
+        currentEditor.view.dispatch(
+          setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
+        );
+      }, 1_200);
+      addToast('Added to the Stream.', 'success');
+    } catch {
+      addToast("Couldn't add the reply.", 'error');
+    }
   }, [addToast]);
 
+  const discardPDFQuote = useCallback((streamId: unknown, highlightId: unknown) => {
+    if (typeof highlightId === 'string') {
+      bridge.send({
+        type: 'deletePdfHighlight',
+        payload: { streamId: typeof streamId === 'string' ? streamId : stream.id, highlightId },
+      });
+    }
+    addToast("Couldn't add the quote", 'info');
+  }, [addToast, stream.id]);
+
   const quoteAndDiscussPDF = useCallback(async (selection: {
+    streamId: string;
     sourceId: string;
     sourceName: string;
     shortTitle: string;
@@ -975,31 +1003,34 @@ export function RichStreamEditor({
     quote: string;
   }) => {
     const currentEditor = editorRef.current;
-    if (!currentEditor) return;
-    const { view } = currentEditor;
-    const cursor = lastEditorCursorRef.current;
-    const cursorAnchor = cursor === null
-      ? null
-      : fullBlockConversationAnchor(view.state.doc, cursor, '');
-    const insertAt = cursorAnchor
-      ? conversationSurfacePosition(view.state.doc, cursorAnchor) ?? view.state.doc.content.size
-      : view.state.doc.content.size;
-    const linkURL = buildTickerPDFLinkURL(selection);
-    const inserted = insertMarkdownBlocks(view, insertAt, buildPDFQuoteSnippet({
-      quote: selection.quote,
-      linkLabel: `${selection.shortTitle || selection.sourceName || 'PDF'} p.${selection.page}`,
-      linkURL,
-    }));
-    const key = `pdf:${crypto.randomUUID()}`;
-    const anchor = fullBlockConversationAnchor(view.state.doc, inserted.from + 2, key);
-    if (!anchor) {
-      addToast('The PDF quote was added, but its conversation could not be anchored.', 'warning');
+    const session = sessionRef.current;
+    if (!currentEditor || !session) {
+      discardPDFQuote(selection.streamId, selection.highlightId);
       return;
     }
-    view.dispatch(setConversationAnchors(view.state.tr, [...conversationAnchors(view.state), anchor]));
-    view.dispatch(setConversationSurface(view.state.tr, { key, anchor }));
-
+    const { view } = currentEditor;
+    let key: string | undefined;
     try {
+      const cursor = lastEditorCursorRef.current;
+      const cursorAnchor = cursor === null
+        ? null
+        : fullBlockConversationAnchor(view.state.doc, cursor, '');
+      const insertAt = cursorAnchor
+        ? conversationSurfacePosition(view.state.doc, cursorAnchor) ?? view.state.doc.content.size
+        : view.state.doc.content.size;
+      const linkURL = buildTickerPDFLinkURL(selection);
+      const inserted = insertMarkdownBlocks(view, insertAt, buildPDFQuoteSnippet({
+        quote: selection.quote,
+        linkLabel: `${selection.shortTitle || selection.sourceName || 'PDF'} p.${selection.page}`,
+        linkURL,
+      }));
+      key = `pdf:${crypto.randomUUID()}`;
+      const anchor = fullBlockConversationAnchor(view.state.doc, inserted.from + 2, key);
+      if (!anchor) throw new Error('The PDF quote could not be anchored.');
+      view.dispatch(setConversationAnchors(view.state.tr, [...conversationAnchors(view.state), anchor]));
+      view.dispatch(setConversationSurface(view.state.tr, { key, anchor }));
+      if (!await session.saveNow()) throw new Error('The PDF quote could not be saved.');
+
       const thread = await persistConversation(
         { key, anchor },
         selection.quote.slice(0, 80),
@@ -1020,7 +1051,7 @@ export function RichStreamEditor({
       addToast('Added PDF quote and opened a conversation.', 'success');
     } catch {
       const liveEditor = editorRef.current;
-      if (liveEditor && !liveEditor.view.isDestroyed) {
+      if (key && liveEditor && !liveEditor.view.isDestroyed) {
         liveEditor.view.dispatch(setConversationAnchors(
           liveEditor.view.state.tr,
           conversationAnchors(liveEditor.view.state).filter((item) => item.threadId !== key),
@@ -1029,9 +1060,9 @@ export function RichStreamEditor({
           liveEditor.view.dispatch(setConversationSurface(liveEditor.view.state.tr, null));
         }
       }
-      addToast('The PDF quote was added, but its conversation could not be created.', 'error');
+      discardPDFQuote(selection.streamId, selection.highlightId);
     }
-  }, [addToast, expandConversation, persistConversation, updateConversationLiveState]);
+  }, [addToast, discardPDFQuote, expandConversation, persistConversation, updateConversationLiveState]);
 
   const toggleConversationList = useCallback(async () => {
     if (showConversationList) {
@@ -1246,6 +1277,10 @@ export function RichStreamEditor({
   }, [stream.sourceScope]);
 
   useEffect(() => {
+    lastEditorCursorRef.current = null;
+  }, [stream.id]);
+
+  useEffect(() => {
     if (!pendingSourceId) {
       consumedPendingSourceRef.current = null;
       return;
@@ -1385,9 +1420,42 @@ export function RichStreamEditor({
   }, [onDelete]);
 
   useEffect(() => bridge.onMessage((message) => {
+    const payload = message.payload as Record<string, unknown> | undefined;
+
+    if (message.type === 'pdfThreadRequested') {
+      const requestStreamId = payload?.streamId;
+      const sourceId = payload?.sourceId;
+      const sourceName = payload?.sourceName;
+      const shortTitle = payload?.shortTitle;
+      const highlightId = payload?.highlightId;
+      const quote = payload?.quote;
+      const page = Number(payload?.page);
+      if (requestStreamId !== stream.id
+        || typeof sourceId !== 'string'
+        || typeof sourceName !== 'string'
+        || typeof shortTitle !== 'string'
+        || typeof highlightId !== 'string'
+        || typeof quote !== 'string'
+        || !quote.trim()
+        || !Number.isInteger(page)
+        || page < 1) {
+        discardPDFQuote(requestStreamId, highlightId);
+        return;
+      }
+      void quoteAndDiscussPDF({
+        streamId: requestStreamId,
+        sourceId,
+        sourceName,
+        shortTitle,
+        highlightId,
+        page,
+        quote,
+      });
+      return;
+    }
+
     const session = sessionRef.current;
     if (!session) return;
-    const payload = message.payload as Record<string, unknown> | undefined;
 
     if (message.type === 'getEditorSelection') {
       const requestId = payload?.requestId;
@@ -1438,26 +1506,6 @@ export function RichStreamEditor({
       }));
       editorRef.current!.view.focus();
       addToast('Added PDF quote to stream.', 'success');
-      return;
-    }
-
-    if (message.type === 'pdfThreadRequested') {
-      if (payload?.streamId !== stream.id) return;
-      const sourceId = payload.sourceId;
-      const sourceName = payload.sourceName;
-      const shortTitle = payload.shortTitle;
-      const highlightId = payload.highlightId;
-      const quote = payload.quote;
-      const page = Number(payload.page);
-      if (typeof sourceId !== 'string'
-        || typeof sourceName !== 'string'
-        || typeof shortTitle !== 'string'
-        || typeof highlightId !== 'string'
-        || typeof quote !== 'string'
-        || !quote.trim()
-        || !Number.isInteger(page)
-        || page < 1) return;
-      void quoteAndDiscussPDF({ sourceId, sourceName, shortTitle, highlightId, page, quote });
       return;
     }
 
@@ -1683,6 +1731,7 @@ export function RichStreamEditor({
     addToast,
     canStartAI,
     cancelDocumentAI,
+    discardPDFQuote,
     flushAll,
     quoteAndDiscussPDF,
     revealPDFConversation,
@@ -1782,7 +1831,10 @@ export function RichStreamEditor({
     ...(pdfPaneState.visible
       && pdfPaneState.streamId === stream.id
       && pdfPaneState.sourceId
-      && pdfPaneState.selection ? [{
+      && pdfPaneState.selection
+      && pdfPaneState.selection.highlightId !== (expandedConversation
+        ? conversationLiveStates[expandedConversation.key]?.thread?.highlightId
+        : undefined) ? [{
         kind: 'pdf_quote' as const,
         quote: pdfPaneState.selection.quote,
         sourceId: pdfPaneState.sourceId,

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -11,6 +11,7 @@ import {
   conversationDecorationTargets,
   conversationMarkerBlockPositions,
   conversationRenderPosition,
+  conversationSurfacePosition,
   fullBlockConversationAnchor,
   hasConversationAnchorTextDrifted,
   refreshConversationViewport,
@@ -74,6 +75,15 @@ describe('conversation anchor lifecycle', () => {
     expect(anchor.to - anchor.from).toBe(4);
     expect(conversationAnchorText(ed.view.state.doc, anchor)).toBe('A🙂B');
     expect(conversationRenderPosition(ed.view.state.doc, anchor)).toBe(ed.view.state.doc.content.size);
+  });
+
+  it('renders a quote conversation after the blockquote container', () => {
+    const ed = open('> Quoted passage.\n\nAfter.');
+    const anchor = recordFullBlock(ed, 'Quoted passage.');
+    expect(conversationRenderPosition(ed.view.state.doc, anchor))
+      .toBeLessThan(conversationSurfacePosition(ed.view.state.doc, anchor)!);
+    expect(conversationSurfacePosition(ed.view.state.doc, anchor))
+      .toBe(ed.view.state.doc.child(0).nodeSize);
   });
 
   it('rule 2: a split spans both halves and renders after the second', () => {

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -156,6 +156,20 @@ export function conversationRenderPosition(
   return textBlockAt(doc, anchor.to - 1)?.to ?? null;
 }
 
+/** Keep a surface outside a containing quote so the conversation is not quoted too. */
+export function conversationSurfacePosition(
+  doc: ProseNode,
+  anchor: ConversationAnchor,
+): number | null {
+  const fallback = conversationRenderPosition(doc, anchor);
+  if (fallback === null) return null;
+  const $to = doc.resolve(anchor.to - 1);
+  for (let depth = $to.depth; depth > 0; depth -= 1) {
+    if ($to.node(depth).type.name === 'blockquote') return $to.after(depth);
+  }
+  return fallback;
+}
+
 export function conversationAnchorText(doc: ProseNode, anchor: ConversationAnchor): string {
   return anchor.from >= anchor.to ? '' : doc.textBetween(anchor.from, anchor.to, '\n', '\n');
 }
@@ -367,7 +381,7 @@ export function conversationAnchorField(
         const field = conversationAnchorKey.getState(view.state);
         const surface = field?.surface;
         const position = surface && (surface.renderAt
-          ?? conversationRenderPosition(view.state.doc, surface.anchor));
+          ?? conversationSurfacePosition(view.state.doc, surface.anchor));
         if (position !== null && position !== undefined && view.state.selection.empty) {
           const block = textBlockAt(view.state.doc, view.state.selection.head);
           const direction = event.key === 'ArrowDown' && block?.to === position
@@ -409,7 +423,7 @@ export function conversationAnchorField(
         ));
         const surface = field.surface;
         const position = surface && (surface.renderAt
-          ?? conversationRenderPosition(state.doc, surface.anchor)
+          ?? conversationSurfacePosition(state.doc, surface.anchor)
           ?? state.doc.content.size);
         if (surface && position !== null) {
           decorations.push(Decoration.widget(position, () => {

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -225,19 +225,24 @@
   color: var(--text-faint);
 }
 
-.conversation-turn-copy {
+.conversation-turn-controls {
+  display: flex;
+  gap: var(--space-2);
+  opacity: 0;
+}
+
+.conversation-turn-controls button {
   padding: 0;
   border: 0;
   background: transparent;
   color: var(--text-muted);
   font: inherit;
   font-size: var(--type-ui-caption);
-  opacity: 0;
   cursor: pointer;
 }
 
-.conversation-turn:hover .conversation-turn-copy,
-.conversation-turn-copy:focus-visible {
+.conversation-turn:hover .conversation-turn-controls,
+.conversation-turn-controls:focus-within {
   opacity: 1;
 }
 

--- a/Web/src/richtext/operations.test.ts
+++ b/Web/src/richtext/operations.test.ts
@@ -136,7 +136,7 @@ describe('applying what the AI wrote', () => {
 });
 
 describe('promoting a conversation answer', () => {
-  it('inserts formatted blocks with AI provenance and one exact undo step', () => {
+  it('isolates adjacent typing and undo removes both the promotion and its AI provenance', () => {
     const ed = open('Anchor block.\n\nAfter.');
     const before = ed.getDocumentJSON();
     const anchor = find(ed, 'Anchor block.');
@@ -144,7 +144,12 @@ describe('promoting a conversation answer', () => {
       ed.view,
       ed.view.state.doc.resolve(anchor.from).after(1),
       'First **paragraph**.\n\nSecond [citation](https://example.test).',
-      { requestId: 'conversation-request', model: 'test-model', verb: 'thread' },
+      {
+        requestId: 'conversation-request',
+        model: 'test-model',
+        verb: 'thread',
+        threadId: 'thread-1',
+      },
     );
 
     expect(ed.getMarkdownProjection()).toBe(
@@ -156,11 +161,19 @@ describe('promoting a conversation answer', () => {
         to: inserted.to,
         origin: 'ai',
         requestId: 'conversation-request',
-        meta: { model: 'test-model', verb: 'thread' },
+        meta: { model: 'test-model', verb: 'thread', threadId: 'thread-1' },
       }),
     ]);
+    const promoted = ed.getDocumentJSON();
+    const after = find(ed, 'After.');
+    ed.view.dispatch(ed.view.state.tr.insertText(' typed', after.to));
+
+    undo(ed);
+    expect(ed.getDocumentJSON()).toBe(promoted);
+    expect(provenanceSpans(ed.view.state)).toHaveLength(1);
     undo(ed);
     expect(ed.getDocumentJSON()).toBe(before);
+    expect(provenanceSpans(ed.view.state)).toEqual([]);
   });
 });
 

--- a/Web/src/richtext/operations.test.ts
+++ b/Web/src/richtext/operations.test.ts
@@ -8,12 +8,14 @@ import {
   applyAIMarkdown,
   focusAtEnd,
   insertImage,
+  promoteConversationMarkdown,
   removePDFHighlightLink,
   selectedPDFHighlight,
   selectText,
   setImageWidth,
   streamAIMarkdown,
 } from './operations';
+import { provenanceSpans } from './provenance';
 
 /**
  * ProseMirror measures the DOM to scroll a selection into view, and jsdom
@@ -130,6 +132,35 @@ describe('applying what the AI wrote', () => {
     applyAIMarkdown(ed.view, find(ed, 'Two.'), 'AI text.');
     expect(ed.getMarkdownProjection()).toBe('One. AI text. Three.');
     expect(ed.getMarkdownProjection()).not.toMatch(/richtext-ai-written|<span/);
+  });
+});
+
+describe('promoting a conversation answer', () => {
+  it('inserts formatted blocks with AI provenance and one exact undo step', () => {
+    const ed = open('Anchor block.\n\nAfter.');
+    const before = ed.getDocumentJSON();
+    const anchor = find(ed, 'Anchor block.');
+    const inserted = promoteConversationMarkdown(
+      ed.view,
+      ed.view.state.doc.resolve(anchor.from).after(1),
+      'First **paragraph**.\n\nSecond [citation](https://example.test).',
+      { requestId: 'conversation-request', model: 'test-model', verb: 'thread' },
+    );
+
+    expect(ed.getMarkdownProjection()).toBe(
+      'Anchor block.\n\nFirst **paragraph**.\n\nSecond [citation](https://example.test).\n\nAfter.',
+    );
+    expect(provenanceSpans(ed.view.state)).toEqual([
+      expect.objectContaining({
+        from: inserted.from,
+        to: inserted.to,
+        origin: 'ai',
+        requestId: 'conversation-request',
+        meta: { model: 'test-model', verb: 'thread' },
+      }),
+    ]);
+    undo(ed);
+    expect(ed.getDocumentJSON()).toBe(before);
   });
 });
 

--- a/Web/src/richtext/operations.ts
+++ b/Web/src/richtext/operations.ts
@@ -155,11 +155,7 @@ export function promoteConversationMarkdown(
   markdown: string,
   attribution: { requestId: string; model?: string | null; verb: string },
 ): { from: number; to: number } {
-  const parsed = parseMarkdown(markdown);
-  if (parsed.childCount === 0) throw new Error('There is no conversation answer to add.');
-  const from = Math.max(0, Math.min(pos, view.state.doc.content.size));
-  const tr = view.state.tr.replace(from, from, new Slice(Fragment.from(parsed.content), 0, 0));
-  const inserted = { from, to: from + parsed.content.size };
+  const { tr, inserted } = markdownBlockInsertion(view, pos, markdown);
   addProvenanceSpans(setAIWritingRange(tr, inserted), [{
     spanId: crypto.randomUUID(),
     ...inserted,
@@ -169,6 +165,27 @@ export function promoteConversationMarkdown(
     textHash: hashProvenanceText(tr.doc, inserted),
     createdAt: Date.now(),
   }]);
+  view.dispatch(tr.scrollIntoView());
+  return inserted;
+}
+
+function markdownBlockInsertion(view: EditorView, pos: number, markdown: string) {
+  const parsed = parseMarkdown(markdown);
+  if (parsed.childCount === 0) throw new Error('There is no content to add.');
+  const from = Math.max(0, Math.min(pos, view.state.doc.content.size));
+  return {
+    tr: view.state.tr.replace(from, from, new Slice(Fragment.from(parsed.content), 0, 0)),
+    inserted: { from, to: from + parsed.content.size },
+  };
+}
+
+/** Insert explicit user-authored markdown as intact blocks in one undo step. */
+export function insertMarkdownBlocks(
+  view: EditorView,
+  pos: number,
+  markdown: string,
+): { from: number; to: number } {
+  const { tr, inserted } = markdownBlockInsertion(view, pos, markdown);
   view.dispatch(tr.scrollIntoView());
   return inserted;
 }
@@ -302,6 +319,21 @@ export interface SelectedPDFHighlight {
   sourceId?: string;
 }
 
+/** The first document link for a persisted PDF highlight. */
+export function pdfHighlightRange(
+  state: EditorState,
+  sourceId: string,
+  highlightId: string,
+): { from: number; to: number } | null {
+  let found: { from: number; to: number } | null = null;
+  state.doc.descendants((node, pos) => {
+    if (found || !pdfHighlightMark(node, highlightId, sourceId)) return !found;
+    found = { from: pos, to: pos + node.nodeSize };
+    return false;
+  });
+  return found;
+}
+
 /** The one persisted PDF highlight touched by the current selection, if any. */
 export function selectedPDFHighlight(state: EditorState): SelectedPDFHighlight | null {
   const { from, to, empty } = state.selection;
@@ -353,20 +385,11 @@ export function revealPDFHighlight(
   sourceId: string,
   highlightId: string,
 ): boolean {
-  let from = -1;
-  let to = -1;
-
-  view.state.doc.descendants((node, pos) => {
-    if (from >= 0 || !pdfHighlightMark(node, highlightId, sourceId)) return from < 0;
-    from = pos;
-    to = pos + node.nodeSize;
-    return false;
-  });
-
-  if (from < 0) return false;
+  const range = pdfHighlightRange(view.state, sourceId, highlightId);
+  if (!range) return false;
   view.dispatch(
     view.state.tr
-      .setSelection(TextSelection.create(view.state.doc, from, to))
+      .setSelection(TextSelection.create(view.state.doc, range.from, range.to))
       .setMeta('addToHistory', false)
       .scrollIntoView(),
   );

--- a/Web/src/richtext/operations.ts
+++ b/Web/src/richtext/operations.ts
@@ -4,6 +4,7 @@ import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
 import { Fragment, Slice, type Mark, type Node as ProseNode } from 'prosemirror-model';
 import { parseTickerPDFURL } from '../extensions/PDFHighlightLink';
 import { parseMarkdown } from './markdown';
+import { addProvenanceSpans, hashProvenanceText } from './provenance';
 import { ASSET_URL_PREFIX, isValidImageWidth, tickerSchema } from './schema';
 
 /**
@@ -145,6 +146,31 @@ export function streamAIMarkdown(view: EditorView, range: { from: number; to: nu
       return buffer;
     },
   };
+}
+
+/** Insert one conversation answer as blocks, with its AI provenance, in one undo step. */
+export function promoteConversationMarkdown(
+  view: EditorView,
+  pos: number,
+  markdown: string,
+  attribution: { requestId: string; model?: string | null; verb: string },
+): { from: number; to: number } {
+  const parsed = parseMarkdown(markdown);
+  if (parsed.childCount === 0) throw new Error('There is no conversation answer to add.');
+  const from = Math.max(0, Math.min(pos, view.state.doc.content.size));
+  const tr = view.state.tr.replace(from, from, new Slice(Fragment.from(parsed.content), 0, 0));
+  const inserted = { from, to: from + parsed.content.size };
+  addProvenanceSpans(setAIWritingRange(tr, inserted), [{
+    spanId: crypto.randomUUID(),
+    ...inserted,
+    origin: 'ai',
+    requestId: attribution.requestId,
+    meta: { model: attribution.model ?? null, verb: attribution.verb },
+    textHash: hashProvenanceText(tr.doc, inserted),
+    createdAt: Date.now(),
+  }]);
+  view.dispatch(tr.scrollIntoView());
+  return inserted;
 }
 
 /* Images ---------------------------------------------------------------- */

--- a/Web/src/richtext/operations.ts
+++ b/Web/src/richtext/operations.ts
@@ -153,7 +153,7 @@ export function promoteConversationMarkdown(
   view: EditorView,
   pos: number,
   markdown: string,
-  attribution: { requestId: string; model?: string | null; verb: string },
+  attribution: { requestId: string; model?: string | null; verb: string; threadId: string },
 ): { from: number; to: number } {
   const { tr, inserted } = markdownBlockInsertion(view, pos, markdown);
   addProvenanceSpans(setAIWritingRange(tr, inserted), [{
@@ -161,7 +161,7 @@ export function promoteConversationMarkdown(
     ...inserted,
     origin: 'ai',
     requestId: attribution.requestId,
-    meta: { model: attribution.model ?? null, verb: attribution.verb },
+    meta: { model: attribution.model ?? null, verb: attribution.verb, threadId: attribution.threadId },
     textHash: hashProvenanceText(tr.doc, inserted),
     createdAt: Date.now(),
   }]);
@@ -173,8 +173,11 @@ function markdownBlockInsertion(view: EditorView, pos: number, markdown: string)
   const parsed = parseMarkdown(markdown);
   if (parsed.childCount === 0) throw new Error('There is no content to add.');
   const from = Math.max(0, Math.min(pos, view.state.doc.content.size));
+  const tr = view.state.tr.replace(from, from, new Slice(Fragment.from(parsed.content), 0, 0));
+  tr.setTime(1);
+  closeHistory(tr);
   return {
-    tr: view.state.tr.replace(from, from, new Slice(Fragment.from(parsed.content), 0, 0)),
+    tr,
     inserted: { from, to: from + parsed.content.size },
   };
 }

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -254,6 +254,8 @@ export function createStreamThread(input: {
   anchorStart: number;
   anchorEnd: number;
   anchorText: string;
+  sourceId?: string;
+  highlightId?: string;
 }): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('createStreamThread', {
     streamId: input.streamId,
@@ -261,6 +263,8 @@ export function createStreamThread(input: {
     anchorStart: input.anchorStart,
     anchorEnd: input.anchorEnd,
     anchorText: input.anchorText,
+    sourceId: input.sourceId,
+    highlightId: input.highlightId,
   });
 }
 

--- a/Web/src/utils/pdfAnchorSelection.test.ts
+++ b/Web/src/utils/pdfAnchorSelection.test.ts
@@ -37,7 +37,7 @@ describe('pdf anchor selection helpers', () => {
       linkLabel: 'Guide \\ [draft] p.7',
       linkURL: 'ticker-pdf://source?highlight=h1&page=7',
     })).toBe(
-      '\n> A wrapped PDF quote.\n[Guide \\\\ \\[draft\\] p.7](ticker-pdf://source?highlight=h1&page=7)\n'
+      '\n> A wrapped PDF quote. [Guide \\\\ \\[draft\\] p.7](ticker-pdf://source?highlight=h1&page=7)\n'
     );
   });
 });

--- a/Web/src/utils/pdfAnchorSelection.test.ts
+++ b/Web/src/utils/pdfAnchorSelection.test.ts
@@ -37,7 +37,17 @@ describe('pdf anchor selection helpers', () => {
       linkLabel: 'Guide \\ [draft] p.7',
       linkURL: 'ticker-pdf://source?highlight=h1&page=7',
     })).toBe(
-      '\n> A wrapped PDF quote. [Guide \\\\ \\[draft\\] p.7](ticker-pdf://source?highlight=h1&page=7)\n'
+      '\n> A wrapped PDF quote\\. [Guide \\\\ \\[draft\\] p.7](ticker-pdf://source?highlight=h1&page=7)\n'
+    );
+  });
+
+  it('escapes markdown syntax in the quoted PDF text', () => {
+    expect(buildPDFQuoteSnippet({
+      quote: '*literal* `code` [label](url)',
+      linkLabel: 'Paper p.1',
+      linkURL: 'ticker-pdf://source?highlight=h1&page=1',
+    })).toBe(
+      '\n> \\*literal\\* \\`code\\` \\[label\\]\\(url\\) [Paper p.1](ticker-pdf://source?highlight=h1&page=1)\n'
     );
   });
 });

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -32,7 +32,8 @@ export function buildPDFQuoteSnippet(args: { quote: string; linkLabel: string; l
     .replace(/\\/g, '\\\\')
     .replace(/\[/g, '\\[')
     .replace(/\]/g, '\\]');
-  return `\n${quote ? `> ${quote}\n` : ''}[${linkLabel}](${args.linkURL})\n`;
+  const link = `[${linkLabel}](${args.linkURL})`;
+  return `\n${quote ? `> ${quote} ${link}` : link}\n`;
 }
 
 export function beginPDFAnchorPick(streamId: string): void {

--- a/Web/src/utils/pdfAnchorSelection.ts
+++ b/Web/src/utils/pdfAnchorSelection.ts
@@ -27,7 +27,8 @@ export function buildTickerPDFLinkURL(args: { sourceId: string; highlightId: str
 }
 
 export function buildPDFQuoteSnippet(args: { quote: string; linkLabel: string; linkURL: string }): string {
-  const quote = args.quote.trim().replace(/\s+/g, ' ');
+  const quote = args.quote.trim().replace(/\s+/g, ' ')
+    .replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g, '\\$&');
   const linkLabel = args.linkLabel
     .replace(/\\/g, '\\\\')
     .replace(/\[/g, '\\[')

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -178,6 +178,7 @@
       },
       "createStreamThread": {
         "requiredPayloadKeys": ["streamId", "title", "anchorStart", "anchorEnd", "anchorText"],
+        "optionalPayloadKeys": ["sourceId", "highlightId"],
         "requiredCallbackId": true
       },
       "createStream": {


### PR DESCRIPTION
Phase C5 of `docs/CONVERSATIONS_PLAN.md` (D5/D6) — hover ↑ Add to Stream on AI turns (markdown-parsed insertion after the anchor block, one undo step with closeHistory boundary, AI provenance span riding the same transaction, citation markers swapped to real ticker-pdf:// links, order-preserving repeated promotions); Quote & discuss (PDF selection → escaped cited quote block + highlight + anchored conversation, atomic with immediate save-flush; undo detaches byte-identically; redo's doc-end fallback pinned by test); highlight/citation click navigates and expands.

**Review (Opus): pass-with-notes → fix round `0b06907`** incl. two live-breaking catches: raw 【n】 markers surviving promotion, and NSNull optional-decode rejecting every non-PDF conversation creation through the real bridge (now covered by a bridge-shaped Swift test). Also: orphaned-highlight compensation on all bail paths, self-pin filter for the primary highlight, history isolation from adjacent typing, quote-body markdown escaping.

**Gates (exit-code-verified):** build 0 · swift 0 · typecheck 0 · webtest 0 (587) · webbuild 0 · contract 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)