### PR TITLE
C6: slash commands + ephemeral chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: add slash chat and research conversations (phase C6)
 - editor: add conversation reply promotion and PDF Quote & discuss (phase C5)
 - editor: add complete AI context, persistent pins, and receipts to inline conversations (phase C4)
 - editor: open block-anchored conversations inline with streaming replies (phase C3)

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -109,6 +109,7 @@ struct ThreadAISentFacts: Codable, Equatable {
     let sourceContextMode: String
     let sources: [Source]
     let pinned: [Pinned]
+    let profile: String?
 
     var jsonString: String {
         let encoder = JSONEncoder()
@@ -135,6 +136,7 @@ typealias ThreadAIRoute = (
     _ streamMarkdown: String,
     _ pinnedContext: [ThreadAIPinnedContext],
     _ priorTurns: [ThreadAIConversationTurn],
+    _ researchProfile: Bool,
     _ onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
     _ onChunk: @escaping (String) -> Void,
     _ onComplete: @escaping (ThreadAIRequestReceipt) -> Void,
@@ -271,7 +273,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                 onModelSelected: onModelSelected
             )
         }
-        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, streamMarkdown, pinnedContext, priorTurns, onPrepared, onChunk, onComplete, onError, onModelSelected in
+        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, streamMarkdown, pinnedContext, priorTurns, researchProfile, onPrepared, onChunk, onComplete, onError, onModelSelected in
             await orchestrator.routeThread(
                 query: query,
                 retrievalQuery: retrievalQuery,
@@ -281,6 +283,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                 streamMarkdown: streamMarkdown,
                 pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
+                researchProfile: researchProfile,
                 onPrepared: onPrepared,
                 onChunk: onChunk,
                 onComplete: onComplete,
@@ -311,7 +314,7 @@ final class AIMessageHandler: BridgeMessageHandler {
             _ onError: @escaping (Error) -> Void,
             _ onModelSelected: ((String) -> Void)?
         ) async -> Void,
-        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, _, onError, _ in
+        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
             onError(OrchestratorError.noProviderAvailable)
         }
     ) {
@@ -588,6 +591,18 @@ final class AIMessageHandler: BridgeMessageHandler {
 
         let sourceScopeRaw = payload["sourceScope"]?.value as? String
         let sourceScope = SourceScope(rawValue: sourceScopeRaw ?? "") ?? .auto
+        let profile = payload["profile"]?.value as? String
+        guard profile == nil || profile == "research" else {
+            sendToWeb(BridgeMessage(
+                type: "documentAIError",
+                payload: [
+                    "requestId": AnyCodable(requestId),
+                    "error": AnyCodable("This conversation profile is invalid."),
+                    "errorCode": AnyCodable("invalid_thread_request")
+                ]
+            ))
+            return
+        }
         let sentAnchorContext = (payload["context"]?.value as? String ?? thread.anchorText)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let streamMarkdown = payload["streamMarkdown"]?.value as? String ?? storedStreamMarkdown
@@ -618,7 +633,8 @@ final class AIMessageHandler: BridgeMessageHandler {
                 anchorEnd: anchorEnd,
                 streamMarkdown: streamMarkdown,
                 anchors: pinnedAnchors,
-                receipt: receipt
+                receipt: receipt,
+                profile: profile
             )
             sentFacts = facts
             self.sendToWeb(BridgeMessage(
@@ -647,7 +663,8 @@ final class AIMessageHandler: BridgeMessageHandler {
                 anchorEnd: anchorEnd,
                 streamMarkdown: streamMarkdown,
                 anchors: pinnedAnchors,
-                receipt: receipt
+                receipt: receipt,
+                profile: profile
             )
             guard !responseRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 self.sendToWeb(BridgeMessage(
@@ -751,6 +768,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                 streamMarkdown,
                 pinnedContext,
                 priorTurns,
+                profile == "research",
                 onPrepared,
                 onChunk,
                 onComplete,
@@ -776,7 +794,8 @@ final class AIMessageHandler: BridgeMessageHandler {
         anchorEnd: Int?,
         streamMarkdown: String,
         anchors: [StreamThreadAnchor],
-        receipt: ThreadAIRequestReceipt
+        receipt: ThreadAIRequestReceipt,
+        profile: String?
     ) -> ThreadAISentFacts {
         var source: SourceReference?
         var highlight: PDFHighlightRecord?
@@ -869,7 +888,8 @@ final class AIMessageHandler: BridgeMessageHandler {
             ),
             sourceContextMode: Self.sourceContextMode(receipt.sourceContext),
             sources: sources,
-            pinned: pinned
+            pinned: pinned,
+            profile: profile
         )
     }
 

--- a/Sources/Ticker/App/Bridge/StreamCodec.swift
+++ b/Sources/Ticker/App/Bridge/StreamCodec.swift
@@ -142,6 +142,9 @@ enum StreamCodec {
             "createdAt": formatter.string(from: thread.createdAt),
             "updatedAt": formatter.string(from: thread.updatedAt)
         ]
+        if let profile = thread.profile {
+            payload["profile"] = profile
+        }
         if let docJSON = thread.docJSON, let docFormatVersion = thread.docFormatVersion {
             payload["docJSON"] = docJSON
             payload["docFormatVersion"] = docFormatVersion

--- a/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/StreamMessageHandler.swift
@@ -336,6 +336,7 @@ final class StreamMessageHandler: BridgeMessageHandler {
             await sendStreamLoadFailed(id: id, requestId: requestId, reason: "notFound")
             return
         }
+        _ = try persistence.deleteEphemeralThreads(streamId: id)
         delegate?.setCurrentStreamIdForFileDrops(id)
         await delegate?.closePDFPaneIfShowingDifferentStream(id)
         // The document, its spans and both append queues TOGETHER, in one

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -72,7 +72,10 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 return
             }
             let detached = payload["detached"]?.value as? Bool ?? (anchorStart == anchorEnd)
-            guard detached == (anchorStart == anchorEnd), detached || !anchorText.isEmpty else {
+            let profile = payload["profile"]?.value as? String
+            guard detached == (anchorStart == anchorEnd),
+                  detached || !anchorText.isEmpty,
+                  profile == nil || profile == "research" else {
                 respondWithError(callbackId, "Invalid createStreamThread payload")
                 return
             }
@@ -86,7 +89,8 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                     anchorStart: anchorStart,
                     anchorEnd: anchorEnd,
                     detached: detached,
-                    ephemeral: payload["ephemeral"]?.value as? Bool ?? false
+                    ephemeral: payload["ephemeral"]?.value as? Bool ?? false,
+                    profile: profile
                 ))
                 respond(callbackId, [
                     "thread": AnyCodable(try encodeThread(thread))
@@ -165,10 +169,9 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 return
             }
             do {
-                let highlightIds = try persistence.deleteStreamThread(
-                    threadId: threadId,
-                    streamId: streamId
-                )
+                let highlightIds = payload["ephemeralOnly"]?.value as? Bool == true
+                    ? try persistence.deleteEphemeralThread(threadId: threadId, streamId: streamId)
+                    : try persistence.deleteStreamThread(threadId: threadId, streamId: streamId)
                 respond(callbackId, [
                     "highlightIds": AnyCodable(highlightIds.map(\.uuidString))
                 ])

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -63,12 +63,16 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                   let streamId = decodeUUID(payload, key: "streamId"),
                   let title = payload["title"]?.value as? String,
                   let anchorText = payload["anchorText"]?.value as? String,
-                  !anchorText.isEmpty,
                   let anchorStart = payload["anchorStart"]?.intValue,
                   let anchorEnd = payload["anchorEnd"]?.intValue,
                   anchorStart >= 0,
-                  anchorEnd > anchorStart,
+                  anchorEnd >= anchorStart,
                   let references = Self.decodePrimaryPDFReferences(payload) else {
+                respondWithError(callbackId, "Invalid createStreamThread payload")
+                return
+            }
+            let detached = payload["detached"]?.value as? Bool ?? (anchorStart == anchorEnd)
+            guard detached == (anchorStart == anchorEnd), detached || !anchorText.isEmpty else {
                 respondWithError(callbackId, "Invalid createStreamThread payload")
                 return
             }
@@ -81,6 +85,7 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                     highlightId: references.highlightId,
                     anchorStart: anchorStart,
                     anchorEnd: anchorEnd,
+                    detached: detached,
                     ephemeral: payload["ephemeral"]?.value as? Bool ?? false
                 ))
                 respond(callbackId, [

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -80,7 +80,8 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                     sourceId: references.sourceId,
                     highlightId: references.highlightId,
                     anchorStart: anchorStart,
-                    anchorEnd: anchorEnd
+                    anchorEnd: anchorEnd,
+                    ephemeral: payload["ephemeral"]?.value as? Bool ?? false
                 ))
                 respond(callbackId, [
                     "thread": AnyCodable(try encodeThread(thread))
@@ -185,7 +186,8 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                     threadId: threadId,
                     streamId: streamId,
                     title: title,
-                    baseRevision: baseRevision
+                    baseRevision: baseRevision,
+                    ephemeral: payload["ephemeral"]?.value as? Bool
                 )
                 respond(callbackId, [
                     "conflict": AnyCodable(false),

--- a/Sources/Ticker/Models/StreamThread.swift
+++ b/Sources/Ticker/Models/StreamThread.swift
@@ -54,6 +54,7 @@ struct StreamThread: Codable, Equatable, Identifiable {
     let anchorEnd: Int?
     let detached: Bool
     let ephemeral: Bool
+    let profile: String?
     let revision: Int
     let createdAt: Date
     let updatedAt: Date
@@ -75,6 +76,7 @@ struct StreamThread: Codable, Equatable, Identifiable {
         anchorEnd: Int? = nil,
         detached: Bool = false,
         ephemeral: Bool = false,
+        profile: String? = nil,
         revision: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -93,6 +95,7 @@ struct StreamThread: Codable, Equatable, Identifiable {
         self.anchorEnd = anchorEnd
         self.detached = detached
         self.ephemeral = ephemeral
+        self.profile = profile
         self.revision = revision
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -204,6 +204,7 @@ final class AIOrchestrator {
         streamMarkdown: String,
         pinnedContext: [ThreadAIPinnedContext],
         priorTurns: [ThreadAIConversationTurn],
+        researchProfile: Bool,
         onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (ThreadAIRequestReceipt) -> Void,
@@ -238,7 +239,8 @@ final class AIOrchestrator {
                 streamMarkdown: streamMarkdown,
                 pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
-                sourceContext: sourceContext
+                sourceContext: sourceContext,
+                researchProfile: researchProfile
             )
             onPrepared(prepared.receipt)
             await proxyService.stream(
@@ -283,6 +285,7 @@ final class AIOrchestrator {
         pinnedContext: [ThreadAIPinnedContext] = [],
         priorTurns: [ThreadAIConversationTurn],
         sourceContext: SourceContext?,
+        researchProfile: Bool = false,
         tokenBudget: Int = LLMRequest.defaultTokenBudget
     ) throws -> PreparedThreadAIRequest {
         let cleanAnchor = TickerInternalURLSanitizer.sanitize(anchorText)
@@ -326,7 +329,7 @@ final class AIOrchestrator {
             if includeSources { messages.append(contentsOf: sourceMessages) }
             messages.append(prompt)
             return LLMRequest(
-                systemPrompt: Prompts.threadConversation,
+                systemPrompt: researchProfile ? Prompts.threadResearch : Prompts.threadConversation,
                 messages: messages,
                 temperature: 0.7,
                 maxTokens: 2048

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -1734,18 +1734,21 @@ final class PersistenceService {
         threadId: UUID,
         streamId: UUID,
         title: String,
-        baseRevision: Int
+        baseRevision: Int,
+        ephemeral: Bool? = nil
     ) throws -> StreamThread {
         return try dbQueue.write { db in
             let updatedAt = Date()
             try db.execute(
                 sql: """
                     UPDATE stream_threads
-                    SET title = ?, revision = revision + 1, updated_at = ?
+                    SET title = ?, ephemeral = COALESCE(?, ephemeral),
+                        revision = revision + 1, updated_at = ?
                     WHERE thread_id = ? AND stream_id = ? AND revision = ?
                 """,
                 arguments: [
                     title,
+                    ephemeral,
                     updatedAt.timeIntervalSince1970,
                     threadId.uuidString,
                     streamId.uuidString,

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -733,6 +733,13 @@ final class PersistenceService {
             """)
         }
 
+        migrator.registerMigration("v31_conversation_profiles") { db in
+            try db.execute(sql: """
+                ALTER TABLE stream_threads ADD COLUMN profile TEXT
+                    CHECK (profile IS NULL OR profile = 'research');
+            """)
+        }
+
         if didDatabaseExistOnInit {
             let hasPendingMigrations = try dbQueue.read { db in
                 try !migrator.hasCompletedMigrations(db)
@@ -1663,9 +1670,9 @@ final class PersistenceService {
                     INSERT INTO stream_threads
                         (thread_id, stream_id, title, working_text, doc_json, doc_format_version,
                          anchor_text, anchor_span_id, source_id, highlight_id,
-                         anchor_start, anchor_end, detached, ephemeral,
+                         anchor_start, anchor_end, detached, ephemeral, profile,
                          revision, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 arguments: [
                     thread.threadId.uuidString,
@@ -1682,6 +1689,7 @@ final class PersistenceService {
                     thread.anchorEnd,
                     thread.detached,
                     thread.ephemeral,
+                    thread.profile,
                     thread.revision,
                     thread.createdAt.timeIntervalSince1970,
                     thread.updatedAt.timeIntervalSince1970
@@ -1707,7 +1715,8 @@ final class PersistenceService {
                 sql: """
                     SELECT thread_id, stream_id, title, working_text, anchor_text, anchor_span_id,
                            source_id, highlight_id, revision, created_at, updated_at,
-                           doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral
+                           doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral,
+                           profile
                     FROM stream_threads
                     WHERE stream_id = ?
                     ORDER BY updated_at DESC, thread_id
@@ -1866,27 +1875,65 @@ final class PersistenceService {
             guard try fetchStreamThread(threadId: threadId, streamId: streamId, db: db) != nil else {
                 throw StreamThreadPersistenceError.threadNotFound
             }
-            let highlightIds = try String.fetchAll(
-                db,
-                sql: """
-                    SELECT highlight_id FROM stream_thread_anchors
-                    WHERE thread_id = ? AND highlight_id IS NOT NULL
-                """,
-                arguments: [threadId.uuidString]
-            ).compactMap(UUID.init(uuidString:))
-            try db.execute(
-                sql: "DELETE FROM ai_exchanges WHERE thread_id = ? AND stream_id = ?",
-                arguments: [threadId.uuidString, streamId.uuidString]
-            )
-            try db.execute(
-                sql: "DELETE FROM stream_threads WHERE thread_id = ? AND stream_id = ?",
-                arguments: [threadId.uuidString, streamId.uuidString]
-            )
-            for highlightId in highlightIds {
-                try deleteUnreferencedThreadHighlight(highlightId, db: db)
-            }
-            return highlightIds
+            return try deleteStreamThreadRows(threadId: threadId, streamId: streamId, db: db)
         }
+    }
+
+    func deleteEphemeralThread(threadId: UUID, streamId: UUID) throws -> [UUID] {
+        try dbQueue.write { db in
+            let ephemeral = try Bool.fetchOne(
+                db,
+                sql: "SELECT ephemeral FROM stream_threads WHERE thread_id = ? AND stream_id = ?",
+                arguments: [threadId.uuidString, streamId.uuidString]
+            )
+            guard ephemeral == true else {
+                DebugLog.log("[Persistence] Skipped automatic deletion of kept conversation \(threadId)")
+                return []
+            }
+            return try deleteStreamThreadRows(threadId: threadId, streamId: streamId, db: db)
+        }
+    }
+
+    @discardableResult
+    func deleteEphemeralThreads(streamId: UUID) throws -> Int {
+        try dbQueue.write { db in
+            let threadIds = try String.fetchAll(
+                db,
+                sql: "SELECT thread_id FROM stream_threads WHERE stream_id = ? AND ephemeral = 1",
+                arguments: [streamId.uuidString]
+            ).compactMap(UUID.init(uuidString:))
+            for threadId in threadIds {
+                _ = try deleteStreamThreadRows(threadId: threadId, streamId: streamId, db: db)
+            }
+            return threadIds.count
+        }
+    }
+
+    private func deleteStreamThreadRows(
+        threadId: UUID,
+        streamId: UUID,
+        db: Database
+    ) throws -> [UUID] {
+        let highlightIds = try String.fetchAll(
+            db,
+            sql: """
+                SELECT highlight_id FROM stream_thread_anchors
+                WHERE thread_id = ? AND highlight_id IS NOT NULL
+            """,
+            arguments: [threadId.uuidString]
+        ).compactMap(UUID.init(uuidString:))
+        try db.execute(
+            sql: "DELETE FROM ai_exchanges WHERE thread_id = ? AND stream_id = ?",
+            arguments: [threadId.uuidString, streamId.uuidString]
+        )
+        try db.execute(
+            sql: "DELETE FROM stream_threads WHERE thread_id = ? AND stream_id = ?",
+            arguments: [threadId.uuidString, streamId.uuidString]
+        )
+        for highlightId in highlightIds {
+            try deleteUnreferencedThreadHighlight(highlightId, db: db)
+        }
+        return highlightIds
     }
 
     func setThreadExchangeDisposition(
@@ -2062,7 +2109,8 @@ final class PersistenceService {
             sql: """
                 SELECT thread_id, stream_id, title, working_text, anchor_text, anchor_span_id,
                        source_id, highlight_id, revision, created_at, updated_at,
-                       doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral
+                       doc_json, doc_format_version, anchor_start, anchor_end, detached, ephemeral,
+                       profile
                 FROM stream_threads
                 WHERE thread_id = ? AND stream_id = ?
             """,
@@ -2153,6 +2201,7 @@ final class PersistenceService {
             anchorEnd: row["anchor_end"],
             detached: row["detached"],
             ephemeral: row["ephemeral"],
+            profile: row["profile"],
             revision: row["revision"],
             createdAt: Date(timeIntervalSince1970: row["created_at"]),
             updatedAt: Date(timeIntervalSince1970: row["updated_at"])

--- a/Sources/Ticker/Services/Prompts.swift
+++ b/Sources/Ticker/Services/Prompts.swift
@@ -134,4 +134,12 @@ enum Prompts {
     - Use Markdown only when it makes the answer easier to read.
     - Never claim that you changed, inserted, saved, or published Stream content.
     """
+
+    static let threadResearch = threadConversation + """
+
+    Research profile:
+    - Investigate thoroughly and ground the answer in sources.
+    - Use the available web_search tool when the supplied material does not settle the question.
+    - Distinguish sourced facts from inference and state material uncertainty.
+    """
 }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1864,7 +1864,7 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
-    func test_v30MigrationCreatesConversationAnchorColumns() throws {
+    func test_v31MigrationCreatesConversationColumns() throws {
         try withTempPersistenceServiceAndURL { _, dbURL, _ in
             let dbQueue = try DatabaseQueue(path: dbURL.path)
             let columns = try dbQueue.read { db in
@@ -1893,7 +1893,8 @@ final class StreamDocumentTests: XCTestCase {
                 [
                     "thread_id", "stream_id", "title", "working_text", "anchor_text",
                     "anchor_span_id", "source_id", "highlight_id", "revision", "created_at", "updated_at",
-                    "doc_json", "doc_format_version", "anchor_start", "anchor_end", "detached", "ephemeral"
+                    "doc_json", "doc_format_version", "anchor_start", "anchor_end", "detached", "ephemeral",
+                    "profile"
                 ]
             )
             XCTAssertEqual(
@@ -1927,11 +1928,13 @@ final class StreamDocumentTests: XCTestCase {
 
         var fixtureDB: DatabaseQueue? = try DatabaseQueue(path: dbURL.path)
         try fixtureDB?.write { db in
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN profile")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN ephemeral")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN detached")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_end")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_start")
             try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v30_conversation_anchors'")
+            try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v31_conversation_profiles'")
         }
         fixtureDB = nil
 
@@ -1942,6 +1945,10 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertNil(migrated.anchorEnd)
         XCTAssertTrue(migrated.detached)
         XCTAssertFalse(migrated.ephemeral)
+        XCTAssertNil(try service?.loadStreamThread(
+            threadId: thread.threadId,
+            streamId: stream.id
+        )?.profile)
     }
 
     func test_conversationAnchorProseMirrorPositionsRoundTripWithDocumentAndSkipMissingThread() throws {
@@ -2238,12 +2245,74 @@ final class StreamDocumentTests: XCTestCase {
             try service.createStreamThread(thread)
             try service.saveExchange(exchange)
 
-            XCTAssertEqual(try service.deleteStreamThread(
+            XCTAssertEqual(try service.deleteEphemeralThread(
                 threadId: thread.threadId,
                 streamId: stream.id
             ), [])
             XCTAssertNil(try service.loadStreamThread(threadId: thread.threadId, streamId: stream.id))
             XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
+    func test_nonEphemeralConversationIsNeverAutomaticallyDeleted() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Kept chat")
+            try service.saveStream(stream)
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "Kept premise",
+                anchorStart: 1,
+                anchorEnd: 13,
+                ephemeral: true
+            )
+            let exchange = AIExchange(
+                requestId: "kept-answer",
+                streamId: stream.id,
+                threadId: thread.threadId,
+                verb: "thread",
+                userInput: "Keep this?",
+                responseRaw: "Yes."
+            )
+            try service.createStreamThread(thread)
+            try service.saveExchange(exchange)
+            _ = try service.saveStreamThread(
+                threadId: thread.threadId,
+                streamId: stream.id,
+                title: thread.title,
+                baseRevision: 0,
+                ephemeral: false
+            )
+
+            XCTAssertEqual(try service.deleteEphemeralThread(
+                threadId: thread.threadId,
+                streamId: stream.id
+            ), [])
+            XCTAssertNotNil(try service.loadStreamThread(threadId: thread.threadId, streamId: stream.id))
+            XCTAssertNotNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
+    func test_streamOpenSweepRemovesOnlyEphemeralConversationsAndExchanges() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Crash recovery")
+            try service.saveStream(stream)
+            let scratch = StreamThread(streamId: stream.id, ephemeral: true)
+            let kept = StreamThread(streamId: stream.id)
+            try service.createStreamThread(scratch)
+            try service.createStreamThread(kept)
+            try service.saveExchange(AIExchange(
+                requestId: "scratch-exchange",
+                streamId: stream.id,
+                threadId: scratch.threadId,
+                verb: "thread",
+                userInput: "Scratch",
+                responseRaw: "Temporary"
+            ))
+
+            XCTAssertEqual(try service.deleteEphemeralThreads(streamId: stream.id), 1)
+            XCTAssertNil(try service.loadStreamThread(threadId: scratch.threadId, streamId: stream.id))
+            XCTAssertNil(try service.loadExchange(requestId: "scratch-exchange"))
+            XCTAssertNotNil(try service.loadStreamThread(threadId: kept.threadId, streamId: stream.id))
         }
     }
 
@@ -2525,7 +2594,8 @@ final class StreamDocumentTests: XCTestCase {
                     "anchorText": AnyCodable("Power budget"),
                     "sourceId": AnyCodable(NSNull()),
                     "highlightId": AnyCodable(NSNull()),
-                    "ephemeral": AnyCodable(true)
+                    "ephemeral": AnyCodable(true),
+                    "profile": AnyCodable("research")
                 ],
                 callbackId: "create"
             ))
@@ -2538,6 +2608,7 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(createdPayload["anchorEnd"] as? Int, 12)
             XCTAssertEqual(createdPayload["anchorText"] as? String, "Power budget")
             XCTAssertEqual(createdPayload["ephemeral"] as? Bool, true)
+            XCTAssertEqual(createdPayload["profile"] as? String, "research")
             XCTAssertEqual((createdPayload["exchanges"] as? [[String: Any]])?.count, 0)
 
             await handler.handle(BridgeMessage(
@@ -2631,6 +2702,7 @@ final class StreamDocumentTests: XCTestCase {
             )
             let loadedPayload = try XCTUnwrap(loadResponse.payload?["thread"]?.value as? [String: Any])
             let exchanges = try XCTUnwrap(loadedPayload["exchanges"] as? [[String: Any]])
+            XCTAssertEqual(loadedPayload["profile"] as? String, "research")
             XCTAssertEqual(exchanges.map { $0["requestId"] as? String }, ["conversation-turn"])
             XCTAssertEqual(exchanges.first?["responseRaw"] as? String, "Yes.")
 
@@ -2671,6 +2743,20 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(savedPayload["ephemeral"] as? Bool, false)
             XCTAssertNotNil(savedPayload["anchors"] as? [[String: Any]])
             XCTAssertNotNil(savedPayload["exchanges"] as? [[String: Any]])
+
+            await handler.handle(BridgeMessage(
+                type: "deleteStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "threadId": AnyCodable(thread.threadId.uuidString),
+                    "ephemeralOnly": AnyCodable(true)
+                ],
+                callbackId: "guarded-delete"
+            ))
+            XCTAssertNotNil(recorder.messages(ofType: "callback").first {
+                $0.callbackId == "guarded-delete"
+            })
+            XCTAssertNotNil(try service.loadStreamThread(threadId: thread.threadId, streamId: stream.id))
 
             await handler.handle(BridgeMessage(
                 type: "saveStreamThread",
@@ -6811,14 +6897,16 @@ final class StreamDocumentTests: XCTestCase {
         service = nil
 
         // Turn the fresh database into the exact released v29 shape while preserving
-        // representative prototype data. Reopening it must run the real v30 migrator.
+        // representative prototype data. Reopening it must run the real migrator.
         var dbQueue: DatabaseQueue? = try DatabaseQueue(path: dbURL.path)
         try dbQueue?.write { db in
+            try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN profile")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN ephemeral")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN detached")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_end")
             try db.execute(sql: "ALTER TABLE stream_threads DROP COLUMN anchor_start")
             try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v30_conversation_anchors'")
+            try db.execute(sql: "DELETE FROM grdb_migrations WHERE identifier = 'v31_conversation_profiles'")
         }
         dbQueue = nil
 
@@ -6843,6 +6931,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertNil(migratedThread.anchorEnd)
         XCTAssertTrue(migratedThread.detached)
         XCTAssertFalse(migratedThread.ephemeral)
+        XCTAssertNil(migratedThread.profile)
         XCTAssertEqual(
             try service?.loadStreamThreadAnchors(
                 threadId: prototypeThread.threadId,
@@ -6885,8 +6974,10 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertFalse(threadColumns.contains("anchor_end"))
             XCTAssertFalse(threadColumns.contains("detached"))
             XCTAssertFalse(threadColumns.contains("ephemeral"))
+            XCTAssertFalse(threadColumns.contains("profile"))
             XCTAssertTrue(migrations.contains("v29_sidenote_documents"))
             XCTAssertFalse(migrations.contains("v30_conversation_anchors"))
+            XCTAssertFalse(migrations.contains("v31_conversation_profiles"))
             XCTAssertEqual(storedAnswer, exchange.responseRaw)
             XCTAssertEqual(storedThreadTitle, prototypeThread.title)
         }

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1310,6 +1310,20 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertFalse(pinnedFrames.contains { $0.content.contains("Primary block") })
     }
 
+    func test_researchConversationUsesResearchPrompt() throws {
+        let prepared = try AIOrchestrator.prepareThreadRequest(
+            query: "Investigate this",
+            anchorText: "Primary block",
+            streamMarkdown: "Whole stream",
+            priorTurns: [],
+            sourceContext: nil,
+            researchProfile: true
+        )
+
+        XCTAssertEqual(prepared.request.systemPrompt, Prompts.threadResearch)
+        XCTAssertTrue(prepared.request.systemPrompt.contains("web_search"))
+    }
+
     func test_threadAIRequestRefusesOneTokenPastProtectedBoundary() throws {
         let fitted = try AIOrchestrator.prepareThreadRequest(
             query: "Question",
@@ -1578,7 +1592,7 @@ final class StreamDocumentTests: XCTestCase {
     }
 
     @MainActor
-    func test_conversationAISendsFullContextAndPersistsVersion2ReceiptWithoutChangingStream() async throws {
+    func test_researchConversationPersistsProfileInVersion2ReceiptWithoutChangingStream() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Thread AI")
             try service.saveStream(stream)
@@ -1664,13 +1678,14 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { query, retrievalQuery, _, _, anchorText, streamMarkdown, pinned, turns, onPrepared, onChunk, onComplete, _, onModelSelected in
+                routeThreadAI: { query, retrievalQuery, _, _, anchorText, streamMarkdown, pinned, turns, researchProfile, onPrepared, onChunk, onComplete, _, onModelSelected in
                     routedQuery = query
                     routedRetrievalQuery = retrievalQuery
                     XCTAssertEqual(anchorText, thread.anchorText)
                     XCTAssertEqual(streamMarkdown, "Stream stays unchanged.")
                     XCTAssertEqual(pinned.map(\.quote), ["A second constraint."])
                     XCTAssertEqual(turns.map(\.requestId), [prior.requestId])
+                    XCTAssertTrue(researchProfile)
                     let receipt = ThreadAIRequestReceipt(
                         sourceContext: SourceContext(
                             text: sentSource.extractedText ?? "",
@@ -1695,6 +1710,7 @@ final class StreamDocumentTests: XCTestCase {
                 "threadId": AnyCodable(thread.threadId.uuidString),
                 "query": AnyCodable(rawPrompt),
                 "sourceScope": AnyCodable("auto"),
+                "profile": AnyCodable("research"),
                 "imageURLs": AnyCodable([])
             ]))
 
@@ -1712,6 +1728,7 @@ final class StreamDocumentTests: XCTestCase {
             let receipt = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
             XCTAssertEqual(receipt["version"] as? Int, 2)
             XCTAssertEqual(receipt["kind"] as? String, "threadAI")
+            XCTAssertEqual(receipt["profile"] as? String, "research")
             let anchor = try XCTUnwrap(receipt["anchor"] as? [String: Any])
             XCTAssertEqual(anchor["text"] as? String, "Read the source.")
             XCTAssertEqual(anchor["kind"] as? String, "stream")
@@ -1752,7 +1769,7 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, _, onError, _ in
+                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
                     onError(ThreadAIRequestError.contextTooLarge(
                         largestBlock: "Your note",
                         protectedTokens: 98_000,
@@ -2522,6 +2539,32 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(createdPayload["anchorText"] as? String, "Power budget")
             XCTAssertEqual(createdPayload["ephemeral"] as? Bool, true)
             XCTAssertEqual((createdPayload["exchanges"] as? [[String: Any]])?.count, 0)
+
+            await handler.handle(BridgeMessage(
+                type: "createStreamThread",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "title": AnyCodable("Document start"),
+                    "anchorStart": AnyCodable(0),
+                    "anchorEnd": AnyCodable(0),
+                    "anchorText": AnyCodable(""),
+                    "detached": AnyCodable(true),
+                    "ephemeral": AnyCodable(true)
+                ],
+                callbackId: "create-detached"
+            ))
+            let detachedResponse = try XCTUnwrap(
+                recorder.messages(ofType: "callback").first { $0.callbackId == "create-detached" }
+            )
+            let detachedPayload = try XCTUnwrap(detachedResponse.payload?["thread"]?.value as? [String: Any])
+            XCTAssertEqual(detachedPayload["anchorStart"] as? Int, 0)
+            XCTAssertEqual(detachedPayload["anchorEnd"] as? Int, 0)
+            XCTAssertEqual(detachedPayload["detached"] as? Bool, true)
+            XCTAssertEqual(detachedPayload["ephemeral"] as? Bool, true)
+            let detachedThreadId = try XCTUnwrap(UUID(
+                uuidString: detachedPayload["threadId"] as? String ?? ""
+            ))
+            _ = try service.deleteStreamThread(threadId: detachedThreadId, streamId: stream.id)
 
             let pinnedAnchorPayload: [[String: Any]] = [[
                 "anchorId": "pinned-stream",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2198,6 +2198,38 @@ final class StreamDocumentTests: XCTestCase {
         }
     }
 
+    func test_ephemeralConversationDeletionRemovesThreadAndExchangesTransactionally() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Scratch chat")
+            try service.saveStream(stream)
+            let thread = StreamThread(
+                streamId: stream.id,
+                title: "Think out loud",
+                anchorText: "Scratch premise",
+                anchorStart: 1,
+                anchorEnd: 16,
+                ephemeral: true
+            )
+            let exchange = AIExchange(
+                requestId: "ephemeral-answer",
+                streamId: stream.id,
+                threadId: thread.threadId,
+                verb: "thread",
+                userInput: "What if?",
+                responseRaw: "Try it."
+            )
+            try service.createStreamThread(thread)
+            try service.saveExchange(exchange)
+
+            XCTAssertEqual(try service.deleteStreamThread(
+                threadId: thread.threadId,
+                streamId: stream.id
+            ), [])
+            XCTAssertNil(try service.loadStreamThread(threadId: thread.threadId, streamId: stream.id))
+            XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
     func test_streamThreadRejectsSourceAndHighlightOutsideItsStream() throws {
         try withTempPersistenceService { service in
             let firstStream = Stream(title: "First")
@@ -2475,7 +2507,8 @@ final class StreamDocumentTests: XCTestCase {
                     "anchorEnd": AnyCodable(12),
                     "anchorText": AnyCodable("Power budget"),
                     "sourceId": AnyCodable(NSNull()),
-                    "highlightId": AnyCodable(NSNull())
+                    "highlightId": AnyCodable(NSNull()),
+                    "ephemeral": AnyCodable(true)
                 ],
                 callbackId: "create"
             ))
@@ -2487,6 +2520,7 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(createdPayload["anchorStart"] as? Int, 1)
             XCTAssertEqual(createdPayload["anchorEnd"] as? Int, 12)
             XCTAssertEqual(createdPayload["anchorText"] as? String, "Power budget")
+            XCTAssertEqual(createdPayload["ephemeral"] as? Bool, true)
             XCTAssertEqual((createdPayload["exchanges"] as? [[String: Any]])?.count, 0)
 
             let pinnedAnchorPayload: [[String: Any]] = [[
@@ -2577,7 +2611,8 @@ final class StreamDocumentTests: XCTestCase {
                     "streamId": AnyCodable(stream.id.uuidString),
                     "threadId": AnyCodable(thread.threadId.uuidString),
                     "title": AnyCodable("Power budget"),
-                    "baseRevision": AnyCodable(0)
+                    "baseRevision": AnyCodable(0),
+                    "ephemeral": AnyCodable(false)
                 ],
                 callbackId: "save"
             ))
@@ -2590,6 +2625,7 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(savedPayload["workingText"] as? String, thread.workingText)
             XCTAssertEqual(savedPayload["docJSON"] as? String, docJSON)
             XCTAssertEqual(savedPayload["revision"] as? Int, 1)
+            XCTAssertEqual(savedPayload["ephemeral"] as? Bool, false)
             XCTAssertNotNil(savedPayload["anchors"] as? [[String: Any]])
             XCTAssertNotNil(savedPayload["exchanges"] as? [[String: Any]])
 

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -60,11 +60,14 @@ interface ConversationSurfaceProps {
   streamMarkdown: string;
   contextOptions: ConversationContextOption[];
   focusComposer: boolean;
+  ephemeral: boolean;
+  profile?: 'research';
   state: ConversationLiveState;
   updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
-  createThread: (query: string) => Promise<StreamThreadJSON>;
+  createThread: (query: string, ephemeral: boolean) => Promise<StreamThreadJSON>;
   hasDrifted: (anchorText: string) => boolean;
   onPromote: (exchange: AIExchangeJSON) => void;
+  onKeep: () => void;
   onCollapse: () => void;
 }
 
@@ -104,6 +107,7 @@ function ThreadContextDisclosure({ value }: { value: unknown }) {
             <span>{pin.kind === 'pdf_quote' ? 'Pinned PDF' : 'Pinned Stream'}</span> {pin.quote}
           </p>
         ))}
+        {receipt.profile === 'research' && <p><span>Research profile</span></p>}
         <p>
           <span>Sources</span> {retrieval}
           {receipt.sources.length > 0
@@ -156,11 +160,14 @@ export function ConversationSurface({
   streamMarkdown,
   contextOptions,
   focusComposer,
+  ephemeral,
+  profile,
   state,
   updateState,
   createThread,
   hasDrifted,
   onPromote,
+  onKeep,
   onCollapse,
 }: ConversationSurfaceProps) {
   const composerRef = useRef<HTMLTextAreaElement>(null);
@@ -253,7 +260,7 @@ export function ConversationSurface({
     if (!current && !threadId) {
       updateState(conversationKey, (value) => ({ ...value, creating: true, error: null }));
       try {
-        current = await createThread(query);
+        current = await createThread(query, ephemeral);
         updateState(conversationKey, (value) => ({ ...value, thread: current!, creating: false }));
       } catch {
         updateState(conversationKey, (value) => ({
@@ -273,6 +280,9 @@ export function ConversationSurface({
       error: null,
       active: { requestId, userInput: query, response: '', running: true },
     }));
+    const researchProfile = profile === 'research' || snapshot.exchanges.some(
+      (exchange) => parseThreadAISentFacts(exchange.sourceManifest)?.profile === 'research',
+    );
     bridge.send({
       type: 'thinkDocument',
       payload: {
@@ -287,6 +297,7 @@ export function ConversationSurface({
         imageURLs: [],
         sourceScope,
         verb: 'develop',
+        profile: researchProfile ? 'research' : undefined,
       },
     });
   };
@@ -364,6 +375,11 @@ export function ConversationSurface({
     <section className={`conversation-surface ${state.closing ? 'conversation-surface--closing' : ''}`}>
       <button type="button" className="conversation-rail" aria-label="Collapse conversation" onClick={onCollapse} />
       <div className="conversation-content">
+        {ephemeral && (
+          <div className="conversation-header">
+            <button type="button" className="conversation-keep" onClick={onKeep}>Keep</button>
+          </div>
+        )}
         {hasDrifted(originalAnchorText) && (
           <p className="conversation-drift-note">The passage has changed since this conversation started.</p>
         )}

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -30,6 +30,7 @@ export interface ConversationLiveState {
   loading: boolean;
   loadError: boolean;
   creating: boolean;
+  keeping: boolean;
   closing: boolean;
   error: string | null;
 }
@@ -42,6 +43,7 @@ export const initialConversationLiveState = (threadId?: string): ConversationLiv
   loading: Boolean(threadId),
   loadError: false,
   creating: false,
+  keeping: false,
   closing: false,
   error: null,
 });
@@ -64,7 +66,11 @@ interface ConversationSurfaceProps {
   profile?: 'research';
   state: ConversationLiveState;
   updateState: (key: string, updater: ConversationLiveStateUpdater) => void;
-  createThread: (query: string, ephemeral: boolean) => Promise<StreamThreadJSON>;
+  createThread: (
+    query: string,
+    ephemeral: boolean,
+    profile?: 'research',
+  ) => Promise<StreamThreadJSON>;
   hasDrifted: (anchorText: string) => boolean;
   onPromote: (exchange: AIExchangeJSON) => void;
   onKeep: () => void;
@@ -260,7 +266,7 @@ export function ConversationSurface({
     if (!current && !threadId) {
       updateState(conversationKey, (value) => ({ ...value, creating: true, error: null }));
       try {
-        current = await createThread(query, ephemeral);
+        current = await createThread(query, ephemeral, profile);
         updateState(conversationKey, (value) => ({ ...value, thread: current!, creating: false }));
       } catch {
         updateState(conversationKey, (value) => ({
@@ -280,9 +286,7 @@ export function ConversationSurface({
       error: null,
       active: { requestId, userInput: query, response: '', running: true },
     }));
-    const researchProfile = profile === 'research' || snapshot.exchanges.some(
-      (exchange) => parseThreadAISentFacts(exchange.sourceManifest)?.profile === 'research',
-    );
+    const researchProfile = current.profile === 'research' || profile === 'research';
     bridge.send({
       type: 'thinkDocument',
       payload: {
@@ -377,7 +381,14 @@ export function ConversationSurface({
       <div className="conversation-content">
         {ephemeral && (
           <div className="conversation-header">
-            <button type="button" className="conversation-keep" onClick={onKeep}>Keep</button>
+            <button
+              type="button"
+              className="conversation-keep"
+              disabled={state.keeping || state.creating}
+              onClick={onKeep}
+            >
+              Keep
+            </button>
           </div>
         )}
         {hasDrifted(originalAnchorText) && (

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -170,6 +170,63 @@ async function enterConversationMessage(input: HTMLTextAreaElement, value: strin
   });
 }
 
+async function renderSlashEditor(id: string, withAnchor = true): Promise<EditorView> {
+  let liveView: EditorView | null = null;
+  const updateState = EditorView.prototype.updateState;
+  vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+    this: EditorView,
+    state,
+  ) {
+    liveView = this;
+    return updateState.call(this, state);
+  });
+  await renderStream({
+    ...stream,
+    id,
+    document: {
+      ...stream.document,
+      streamId: id,
+      docJSON: JSON.stringify({
+        type: 'doc',
+        content: withAnchor ? [{
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Anchor paragraph.' }],
+        }, { type: 'paragraph' }] : [{ type: 'paragraph' }, {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Following paragraph.' }],
+        }],
+      }),
+      markdown: withAnchor ? 'Anchor paragraph.' : '\n\nFollowing paragraph.',
+    },
+  });
+  liveView = null;
+  if (withAnchor) {
+    await selectEditorText('Anchor');
+  } else {
+    await selectEditorText('Following');
+  }
+  expect(liveView).not.toBe(null);
+  return liveView!;
+}
+
+async function typeSlashCommand(view: EditorView, text: string) {
+  let emptyParagraph = -1;
+  view.state.doc.descendants((node, pos) => {
+    if (emptyParagraph < 0 && node.type.name === 'paragraph' && node.content.size === 0) {
+      emptyParagraph = pos + 1;
+    }
+  });
+  expect(emptyParagraph).toBeGreaterThan(0);
+  await act(async () => {
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, emptyParagraph)));
+    editor().dispatchEvent(new KeyboardEvent('keydown', {
+      key: '/', bubbles: true, cancelable: true,
+    }));
+    view.dispatch(view.state.tr.insertText(text));
+    await Promise.resolve();
+  });
+}
+
 function activeRequestId(): string {
   const messages = sent.filter((candidate) => candidate.type === 'thinkDocument');
   const message = messages[messages.length - 1];
@@ -871,7 +928,11 @@ describe('RichStreamEditor inline conversations', () => {
       block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
       await Promise.resolve();
     });
-    const composer = await vi.waitFor(() => document.querySelector('.conversation-composer') as HTMLTextAreaElement);
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
     await enterConversationMessage(composer, 'Do not duplicate this.');
     expect((document.querySelector('.conversation-send') as HTMLButtonElement).disabled).toBe(true);
     await act(async () => {
@@ -1162,6 +1223,297 @@ describe('RichStreamEditor inline conversations', () => {
       { streamId: stream.id, threadId: record.threadId },
     ]);
     expect(document.querySelector('.conversation-list-row')).toBe(null);
+  });
+});
+
+describe('RichStreamEditor slash conversations', () => {
+  it('opens only from an empty paragraph and dismisses without consuming the slash', async () => {
+    const view = await renderSlashEditor('slash-menu-stream');
+    await act(async () => {
+      view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 1)));
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+      view.dispatch(view.state.tr.insertText('/'));
+    });
+    expect(document.querySelector('.slash-command-menu')).toBe(null);
+
+    await act(async () => {
+      view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 5)));
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+      view.dispatch(view.state.tr.insertText('/'));
+    });
+    expect(document.querySelector('.slash-command-menu')).toBe(null);
+
+    await typeSlashCommand(view, '/');
+    expect([...document.querySelectorAll('.slash-command-menu button')].map((button) => button.textContent))
+      .toEqual([
+        'chat — think out loud, saved only if you keep it',
+        'research — ask with sources and web search',
+      ]);
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape', bubbles: true, cancelable: true,
+      }));
+    });
+    expect(document.querySelector('.slash-command-menu')).toBe(null);
+    expect(view.state.doc.textContent.endsWith('/')).toBe(true);
+
+    let slashFrom = -1;
+    view.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.textContent === '/') slashFrom = pos + 1;
+    });
+    await act(async () => { view.dispatch(view.state.tr.delete(slashFrom, slashFrom + 1)); });
+    await typeSlashCommand(view, '/');
+    await act(async () => {
+      (document.querySelector('.stream-header') as HTMLElement)
+        .dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    });
+    expect(document.querySelector('.slash-command-menu')).toBe(null);
+  });
+
+  it('/chat carries its draft, stays glyph-free, and deletes its row on collapse', async () => {
+    const id = 'ephemeral-slash-stream';
+    const updatedAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'ephemeral-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: String(payload?.anchorText), anchorStart: Number(payload?.anchorStart),
+          anchorEnd: Number(payload?.anchorEnd), detached: false, ephemeral: true, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      if (type === 'deleteStreamThread') return { highlightIds: [] };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/chat first idea');
+    expect(document.querySelector('.slash-command-menu')).not.toBe(null);
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', bubbles: true, cancelable: true,
+      }));
+    });
+    expect(view.state.doc.textContent).toBe('Anchor paragraph.');
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    expect(composer.value).toBe('first idea');
+    expect(document.querySelector('.conversation-keep')?.textContent).toBe('Keep');
+    expect(view.state.doc.textContent).toBe('Anchor paragraph.');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+    const documentAfterCommand = view.state.doc.toJSON();
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true }));
+    });
+    expect(view.state.doc.toJSON()).toEqual(documentAfterCommand);
+
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    expect(vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'createStreamThread')?.[1])
+      .toMatchObject({ ephemeral: true, detached: false });
+    expect(editor().querySelector('p')?.classList.contains('conversation-block-anchored')).toBe(false);
+    const requestId = activeRequestId();
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: {
+            requestId, streamId: id, threadId: 'ephemeral-thread', verb: 'thread',
+            userInput: 'first idea', sourceManifest: '[]', responseRaw: 'Try it.', createdAt: updatedAt,
+          },
+        },
+      });
+      (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+    });
+    expect(vi.mocked(bridge.sendAsync).mock.calls).toContainEqual([
+      'deleteStreamThread',
+      { streamId: id, threadId: 'ephemeral-thread' },
+    ]);
+    expect(document.querySelector('.conversation-surface')).toBe(null);
+    expect(editor().querySelector('p')?.classList.contains('conversation-block-anchored')).toBe(false);
+  });
+
+  it('Keep turns a document-start chat into a normal detached conversation', async () => {
+    const id = 'detached-kept-slash-stream';
+    const updatedAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'detached-kept-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: '', anchorStart: Number(payload?.anchorStart), anchorEnd: Number(payload?.anchorEnd),
+          detached: true, ephemeral: false, revision: 0, createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id, false);
+    await typeSlashCommand(view, '/chat opening thought');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    expect(composer.value).toBe('opening thought');
+    await act(async () => {
+      (document.querySelector('.conversation-keep') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(document.querySelector('.conversation-keep')).toBe(null);
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    const create = vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'createStreamThread')?.[1];
+    expect(create).toMatchObject({ ephemeral: false, detached: true, anchorText: '' });
+    expect(create?.anchorStart).toBe(create?.anchorEnd);
+  });
+
+  it('promotion keeps an ephemeral chat before inserting', async () => {
+    const id = 'kept-slash-stream';
+    const updatedAt = new Date(0).toISOString();
+    let ephemeral = true;
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'kept-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: String(payload?.anchorText), anchorStart: Number(payload?.anchorStart),
+          anchorEnd: Number(payload?.anchorEnd), detached: false, ephemeral, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      if (type === 'saveStreamThread') {
+        ephemeral = false;
+        return {
+          conflict: false,
+          thread: {
+            threadId: 'kept-thread', streamId: id, title: String(payload?.title), workingText: '',
+            anchorText: 'Anchor paragraph.', anchorStart: 1, anchorEnd: 18,
+            detached: false, ephemeral: false, revision: 1,
+            createdAt: updatedAt, updatedAt, exchanges: [],
+          },
+        };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/chat ask');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    const requestId = activeRequestId();
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: {
+            requestId, streamId: id, threadId: 'kept-thread', verb: 'thread', userInput: 'ask',
+            sourceManifest: '[]', responseRaw: 'A useful answer.', createdAt: updatedAt,
+          },
+        },
+      });
+    });
+    const promote = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find((button) => button.textContent === '↑ Add to Stream')!;
+    await act(async () => {
+      promote.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'saveStreamThread')?.[1])
+      .toMatchObject({ ephemeral: false });
+    expect(view.state.doc.textContent).toContain('A useful answer.');
+    expect(document.querySelector('.conversation-keep')).toBe(null);
+    await vi.waitFor(() => expect(
+      editor().querySelector('p')?.classList.contains('conversation-block-anchored'),
+    ).toBe(true));
+  });
+
+  it('/research selects by keyboard and renders its persisted research receipt', async () => {
+    const id = 'research-slash-stream';
+    const updatedAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'research-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: String(payload?.anchorText), anchorStart: Number(payload?.anchorStart),
+          anchorEnd: Number(payload?.anchorEnd), detached: false, ephemeral: false, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => document.querySelector('.conversation-composer') as HTMLTextAreaElement);
+    await enterConversationMessage(composer, 'Investigate the tradeoff');
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    expect(vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'createStreamThread')?.[1])
+      .toMatchObject({ ephemeral: false });
+    const request = sent.find((message) => message.type === 'thinkDocument')!;
+    expect(request.payload).toMatchObject({ profile: 'research' });
+    const requestId = String(request.payload?.requestId);
+    const receipt = {
+      version: 2, kind: 'threadAI', requestId,
+      anchor: { kind: 'stream', text: 'Anchor paragraph.', from: 1, to: 18 },
+      streamDocument: { sent: true, charCount: 17 }, note: { sent: false },
+      turns: { includedRequestIds: [], totalAtSend: 0 }, sourceContextMode: 'retrieved',
+      sources: [], pinned: [], profile: 'research',
+    };
+    await act(async () => {
+      bridge.receive({ type: 'threadAIContext', payload: { requestId, sentContext: receipt } });
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: {
+            requestId, streamId: id, threadId: 'research-thread', verb: 'thread',
+            userInput: 'Investigate the tradeoff', sourceManifest: JSON.stringify(receipt),
+            responseRaw: 'Grounded result.', createdAt: updatedAt,
+          },
+        },
+      });
+    });
+    const disclosure = document.querySelector('.conversation-receipt') as HTMLDetailsElement;
+    await act(async () => { (disclosure.querySelector('summary') as HTMLElement).click(); });
+    expect(disclosure.textContent).toContain('Research profile');
   });
 });
 

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -170,7 +170,7 @@ async function enterConversationMessage(input: HTMLTextAreaElement, value: strin
   });
 }
 
-async function renderSlashEditor(id: string, withAnchor = true): Promise<EditorView> {
+async function renderSlashEditor(id: string, withAnchor = true, slashInList = false): Promise<EditorView> {
   let liveView: EditorView | null = null;
   const updateState = EditorView.prototype.updateState;
   vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
@@ -188,7 +188,13 @@ async function renderSlashEditor(id: string, withAnchor = true): Promise<EditorV
       streamId: id,
       docJSON: JSON.stringify({
         type: 'doc',
-        content: withAnchor ? [{
+        content: slashInList ? [{
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Anchor paragraph.' }],
+        }, {
+          type: 'bullet_list',
+          content: [{ type: 'list_item', content: [{ type: 'paragraph' }] }],
+        }] : withAnchor ? [{
           type: 'paragraph',
           content: [{ type: 'text', text: 'Anchor paragraph.' }],
         }, { type: 'paragraph' }] : [{ type: 'paragraph' }, {
@@ -873,7 +879,7 @@ describe('RichStreamEditor inline conversations', () => {
     expect(document.querySelector('.conversation-pin')).toBe(null);
   });
 
-  it('keeps send disabled until a persisted conversation loads successfully', async () => {
+  it('keeps send disabled until load and restores a research profile without exchanges', async () => {
     const updatedAt = new Date().toISOString();
     const anchored: Stream = {
       ...stream,
@@ -908,6 +914,7 @@ describe('RichStreamEditor inline conversations', () => {
             anchorEnd: 20,
             detached: false,
             ephemeral: false,
+            profile: 'research',
             revision: 0,
             createdAt: updatedAt,
             updatedAt,
@@ -968,6 +975,7 @@ describe('RichStreamEditor inline conversations', () => {
     });
     await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
     expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type]) => type === 'createStreamThread')).toBe(false);
+    expect(sent.find((message) => message.type === 'thinkDocument')?.payload?.profile).toBe('research');
   });
 
   it('keeps a detached draft surface and its composer text at the document end', async () => {
@@ -1270,6 +1278,24 @@ describe('RichStreamEditor slash conversations', () => {
     expect(document.querySelector('.slash-command-menu')).toBe(null);
   });
 
+  it('does not arm slash commands inside a list item', async () => {
+    const view = await renderSlashEditor('nested-slash-stream', true, true);
+    await typeSlashCommand(view, '/');
+    expect(document.querySelector('.slash-command-menu')).toBe(null);
+    expect(view.state.doc.textContent).toBe('Anchor paragraph./');
+  });
+
+  it('does not select a slash command while IME composition is active', async () => {
+    const view = await renderSlashEditor('composing-slash-stream');
+    await typeSlashCommand(view, '/');
+    (view as unknown as { input: { composing: boolean } }).input.composing = true;
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    expect(document.querySelector('.slash-command-menu')).not.toBe(null);
+    expect(document.querySelector('.conversation-surface')).toBe(null);
+  });
+
   it('/chat carries its draft, stays glyph-free, and deletes its row on collapse', async () => {
     const id = 'ephemeral-slash-stream';
     const updatedAt = new Date(0).toISOString();
@@ -1336,7 +1362,7 @@ describe('RichStreamEditor slash conversations', () => {
     });
     expect(vi.mocked(bridge.sendAsync).mock.calls).toContainEqual([
       'deleteStreamThread',
-      { streamId: id, threadId: 'ephemeral-thread' },
+      { streamId: id, threadId: 'ephemeral-thread', ephemeralOnly: true },
     ]);
     expect(document.querySelector('.conversation-surface')).toBe(null);
     expect(editor().querySelector('p')?.classList.contains('conversation-block-anchored')).toBe(false);
@@ -1381,6 +1407,223 @@ describe('RichStreamEditor slash conversations', () => {
     const create = vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'createStreamThread')?.[1];
     expect(create).toMatchObject({ ephemeral: false, detached: true, anchorText: '' });
     expect(create?.anchorStart).toBe(create?.anchorEnd);
+  });
+
+  it('Keep then immediate collapse waits for the flip and never auto-deletes the row', async () => {
+    const id = 'keep-collapse-race-stream';
+    const updatedAt = new Date(0).toISOString();
+    let finishKeep: ((value: Record<string, unknown>) => void) | undefined;
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'keep-collapse-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: 'Anchor paragraph.', anchorStart: 1, anchorEnd: 18,
+          detached: false, ephemeral: true, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      if (type === 'saveStreamThread') {
+        return new Promise<Record<string, unknown>>((resolve) => { finishKeep = resolve; });
+      }
+      if (type === 'deleteStreamThread') return { highlightIds: [] };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/chat keep this');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    const keep = document.querySelector('.conversation-keep') as HTMLButtonElement;
+    const rail = document.querySelector('.conversation-rail') as HTMLButtonElement;
+    await act(async () => {
+      keep.click();
+      keep.click();
+      rail.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(finishKeep).toBeDefined());
+    expect((document.querySelector('.conversation-keep') as HTMLButtonElement).disabled).toBe(true);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.filter(([type]) => type === 'saveStreamThread')).toHaveLength(1);
+    await act(async () => {
+      finishKeep?.({
+        conflict: false,
+        thread: {
+          threadId: 'keep-collapse-thread', streamId: id, title: 'keep this', workingText: '',
+          anchorText: 'Anchor paragraph.', anchorStart: 1, anchorEnd: 18,
+          detached: false, ephemeral: false, revision: 1,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      });
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+    });
+    expect(document.querySelector('.conversation-surface')).toBe(null);
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(([type, payload]) => (
+      type === 'deleteStreamThread' && payload?.ephemeralOnly === true
+    ))).toBe(false);
+  });
+
+  it('switching blocks discards the outgoing ephemeral conversation', async () => {
+    const id = 'switch-ephemeral-stream';
+    const updatedAt = new Date(0).toISOString();
+    const rows = new Set<string>();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') {
+        rows.add('switch-ephemeral-thread');
+        return {
+          thread: {
+            threadId: 'switch-ephemeral-thread', streamId: id, title: String(payload?.title), workingText: '',
+            anchorText: 'Second paragraph.', anchorStart: 20, anchorEnd: 37,
+            detached: false, ephemeral: true, revision: 0,
+            createdAt: updatedAt, updatedAt, exchanges: [],
+          },
+        };
+      }
+      if (type === 'deleteStreamThread' && payload?.ephemeralOnly === true) {
+        rows.delete(String(payload.threadId));
+        return { highlightIds: [] };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    const second = view.state.schema.nodes.paragraph.create(
+      null,
+      view.state.schema.text('Second paragraph.'),
+    );
+    await act(async () => { view.dispatch(view.state.tr.insert(19, second)); });
+    await typeSlashCommand(view, '/chat switch me');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(rows.size).toBe(1));
+    const first = editor().querySelector('p') as HTMLParagraphElement;
+    vi.spyOn(first, 'getBoundingClientRect').mockReturnValue({
+      left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+      toJSON: () => ({}),
+    });
+    await act(async () => { view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 1))); });
+    await vi.waitFor(() => expect(first.classList.contains('conversation-block-active')).toBe(true));
+    await act(async () => {
+      first.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 0 }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(rows.size).toBe(0));
+    expect(document.querySelector('.conversation-composer')).not.toBe(null);
+  });
+
+  it('collapse during thread creation deletes the late ephemeral row', async () => {
+    const id = 'create-collapse-race-stream';
+    const updatedAt = new Date(0).toISOString();
+    const rows = new Set<string>();
+    let finishCreate: ((value: Record<string, unknown>) => void) | undefined;
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') {
+        return new Promise<Record<string, unknown>>((resolve) => { finishCreate = resolve; });
+      }
+      if (type === 'deleteStreamThread' && payload?.ephemeralOnly === true) {
+        rows.delete(String(payload.threadId));
+        return { highlightIds: [] };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/chat late row');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(finishCreate).toBeDefined());
+    await act(async () => {
+      (document.querySelector('.conversation-rail') as HTMLButtonElement).click();
+      rows.add('late-ephemeral-thread');
+      finishCreate?.({
+        thread: {
+          threadId: 'late-ephemeral-thread', streamId: id, title: String('late row'), workingText: '',
+          anchorText: 'Anchor paragraph.', anchorStart: 1, anchorEnd: 18,
+          detached: false, ephemeral: true, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      });
+      await new Promise((resolve) => window.setTimeout(resolve, 160));
+    });
+    expect(rows.size).toBe(0);
+    expect(document.querySelector('.conversation-surface')).toBe(null);
+  });
+
+  it('flush reports the document save even when scratch cleanup fails', async () => {
+    const id = 'flush-ephemeral-stream';
+    const updatedAt = new Date(0).toISOString();
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'flush-ephemeral-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: 'Anchor paragraph.', anchorStart: 1, anchorEnd: 18,
+          detached: false, ephemeral: true, revision: 0,
+          createdAt: updatedAt, updatedAt, exchanges: [],
+        },
+      };
+      if (type === 'deleteStreamThread' && payload?.ephemeralOnly === true) {
+        throw new Error('cleanup unavailable');
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const view = await renderSlashEditor(id);
+    await typeSlashCommand(view, '/chat scratch');
+    await act(async () => {
+      editor().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    const composer = await vi.waitFor(() => {
+      const found = document.querySelector('.conversation-composer') as HTMLTextAreaElement | null;
+      expect(found).not.toBe(null);
+      return found!;
+    });
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
+    await act(async () => {
+      bridge.receive({ type: 'flushEditor', payload: { requestId: 'flush-scratch' } });
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(sent).toContainEqual({
+      type: 'editorFlushed',
+      payload: { requestId: 'flush-scratch', saved: true },
+    }));
   });
 
   it('promotion keeps an ephemeral chat before inserting', async () => {
@@ -1486,7 +1729,7 @@ describe('RichStreamEditor slash conversations', () => {
     });
     await vi.waitFor(() => expect(sent.some((message) => message.type === 'thinkDocument')).toBe(true));
     expect(vi.mocked(bridge.sendAsync).mock.calls.find(([type]) => type === 'createStreamThread')?.[1])
-      .toMatchObject({ ephemeral: false });
+      .toMatchObject({ ephemeral: false, profile: 'research' });
     const request = sent.find((message) => message.type === 'thinkDocument')!;
     expect(request.payload).toMatchObject({ profile: 'research' });
     const requestId = String(request.payload?.requestId);

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -12,6 +12,7 @@ import { TextSelection, type Command, type Transaction } from 'prosemirror-state
 import {
   bridge,
   createStreamThread,
+  deleteEphemeralThread,
   deleteStreamThread,
   getExchange,
   listConversations,
@@ -215,7 +216,7 @@ const SLASH_COMMANDS: Array<{ command: SlashCommand; description: string }> = [
 function slashCommandInput(view: RichTextEditor['view']) {
   const { selection } = view.state;
   const { $head } = selection;
-  if (!selection.empty || $head.parent.type.name !== 'paragraph') return null;
+  if (!selection.empty || $head.depth !== 1 || $head.parent.type.name !== 'paragraph') return null;
   const text = $head.parent.textContent;
   if ($head.parentOffset !== text.length) return null;
   const match = /^\/([a-z]*)(?:\s(.*))?$/.exec(text);
@@ -289,6 +290,9 @@ export function RichStreamEditor({
   const expandedConversationRef = useRef<ExpandedConversation | null>(null);
   const conversationLiveStatesRef = useRef<Record<string, ConversationLiveState>>({});
   const conversationCollapseTimerRef = useRef<number>();
+  const conversationCreatePromisesRef = useRef(new Map<string, Promise<StreamThreadJSON>>());
+  const conversationKeepPromisesRef = useRef(new Map<string, Promise<boolean>>());
+  const closingConversationKeysRef = useRef(new Set<string>());
   const slashArmedRef = useRef(false);
   const slashMenuRef = useRef<SlashMenuState | null>(null);
 
@@ -511,22 +515,20 @@ export function RichStreamEditor({
     key: string,
     updater: ConversationLiveStateUpdater,
   ) => {
-    setConversationLiveStates((current) => {
-      const value = updater(current[key] ?? initialConversationLiveState());
-      if (value === current[key]) return current;
-      const next = { ...current, [key]: value };
-      conversationLiveStatesRef.current = next;
-      return next;
-    });
+    const current = conversationLiveStatesRef.current;
+    const value = updater(current[key] ?? initialConversationLiveState());
+    if (value === current[key]) return;
+    const next = { ...current, [key]: value };
+    conversationLiveStatesRef.current = next;
+    setConversationLiveStates(next);
   }, []);
 
   const ensureConversationLiveState = useCallback((key: string, threadId?: string) => {
-    setConversationLiveStates((current) => {
-      if (current[key]) return current;
-      const next = { ...current, [key]: initialConversationLiveState(threadId) };
-      conversationLiveStatesRef.current = next;
-      return next;
-    });
+    const current = conversationLiveStatesRef.current;
+    if (current[key]) return;
+    const next = { ...current, [key]: initialConversationLiveState(threadId) };
+    conversationLiveStatesRef.current = next;
+    setConversationLiveStates(next);
   }, []);
 
   const cancelConversationRequest = useCallback((key: string, updateUI = true) => {
@@ -543,10 +545,16 @@ export function RichStreamEditor({
   }, []);
 
   const discardEphemeralConversation = useCallback(async (key: string): Promise<boolean> => {
+    await conversationKeepPromisesRef.current.get(key);
+    try {
+      await conversationCreatePromisesRef.current.get(key);
+    } catch {
+      // Creation reports its own error; there is no row left to discard.
+    }
     const thread = conversationLiveStatesRef.current[key]?.thread;
     if (!thread?.ephemeral) return true;
     try {
-      await deleteStreamThread({ streamId: stream.id, threadId: thread.threadId });
+      await deleteEphemeralThread({ streamId: stream.id, threadId: thread.threadId });
       const records = conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId);
       conversationRecordsRef.current = records;
       setConversationRecords(records);
@@ -566,60 +574,77 @@ export function RichStreamEditor({
     }
   }, [stream.id, updateConversationLiveState]);
 
-  const keepExpandedConversation = useCallback(async (): Promise<boolean> => {
+  const keepExpandedConversation = useCallback((): Promise<boolean> => {
     const expanded = expandedConversationRef.current;
-    if (!expanded?.ephemeral) return true;
-    const current = conversationLiveStatesRef.current[expanded.key];
-    let thread = current?.thread;
-    try {
-      if (thread) {
-        const saved = await saveStreamThread({
-          streamId: stream.id,
-          threadId: thread.threadId,
-          title: thread.title,
-          baseRevision: thread.revision,
-          ephemeral: false,
-        });
-        thread = saved.thread;
-        if (thread.ephemeral) throw new Error('Keep conflicted');
-        updateConversationLiveState(expanded.key, (state) => ({ ...state, thread }));
-      }
-      const kept = { ...expanded, ephemeral: false };
-      expandedConversationRef.current = kept;
-      setExpandedConversation(kept);
-      const liveEditor = editorRef.current;
-      const surface = liveEditor && conversationSurface(liveEditor.view.state);
-      if (thread && liveEditor && surface?.key === expanded.key) {
-        const anchor = { ...surface.anchor, threadId: thread.threadId };
-        liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [
-          ...conversationAnchors(liveEditor.view.state)
-            .filter((candidate) => candidate.threadId !== thread!.threadId),
-          anchor,
-        ]));
-        const records = [
-          ...conversationRecordsRef.current.filter((record) => record.threadId !== thread!.threadId),
-          {
+    if (!expanded?.ephemeral) return Promise.resolve(true);
+    const pending = conversationKeepPromisesRef.current.get(expanded.key);
+    if (pending) return pending;
+    const task = (async () => {
+      updateConversationLiveState(expanded.key, (state) => ({ ...state, keeping: true }));
+      try {
+        try {
+          await conversationCreatePromisesRef.current.get(expanded.key);
+        } catch {
+          // A failed creation leaves this as an unsent draft, which can still be kept.
+        }
+        let thread = conversationLiveStatesRef.current[expanded.key]?.thread;
+        if (thread) {
+          const saved = await saveStreamThread({
+            streamId: stream.id,
             threadId: thread.threadId,
-            anchorStart: anchor.from,
-            anchorEnd: anchor.to,
-            anchorText: thread.anchorText,
-            detached: anchor.from >= anchor.to,
+            title: thread.title,
+            baseRevision: thread.revision,
             ephemeral: false,
-            updatedAt: thread.updatedAt,
-          },
-        ];
-        conversationRecordsRef.current = records;
-        setConversationRecords(records);
-        sessionRef.current?.documentChanged();
+          });
+          thread = saved.thread;
+          if (thread.ephemeral) throw new Error('Keep conflicted');
+          updateConversationLiveState(expanded.key, (state) => ({ ...state, thread }));
+        }
+        const currentExpanded = expandedConversationRef.current;
+        if (currentExpanded?.key === expanded.key) {
+          const kept = { ...currentExpanded, ephemeral: false };
+          expandedConversationRef.current = kept;
+          setExpandedConversation(kept);
+        }
+        const liveEditor = editorRef.current;
+        const surface = liveEditor && conversationSurface(liveEditor.view.state);
+        if (thread && liveEditor && surface?.key === expanded.key) {
+          const anchor = { ...surface.anchor, threadId: thread.threadId };
+          liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [
+            ...conversationAnchors(liveEditor.view.state)
+              .filter((candidate) => candidate.threadId !== thread!.threadId),
+            anchor,
+          ]));
+          const records = [
+            ...conversationRecordsRef.current.filter((record) => record.threadId !== thread!.threadId),
+            {
+              threadId: thread.threadId,
+              anchorStart: anchor.from,
+              anchorEnd: anchor.to,
+              anchorText: thread.anchorText,
+              detached: anchor.from >= anchor.to,
+              ephemeral: false,
+              updatedAt: thread.updatedAt,
+            },
+          ];
+          conversationRecordsRef.current = records;
+          setConversationRecords(records);
+          sessionRef.current?.documentChanged();
+        }
+        return true;
+      } catch {
+        updateConversationLiveState(expanded.key, (state) => ({
+          ...state,
+          error: 'This chat could not be kept.',
+        }));
+        return false;
+      } finally {
+        conversationKeepPromisesRef.current.delete(expanded.key);
+        updateConversationLiveState(expanded.key, (state) => ({ ...state, keeping: false }));
       }
-      return true;
-    } catch {
-      updateConversationLiveState(expanded.key, (state) => ({
-        ...state,
-        error: 'This chat could not be kept.',
-      }));
-      return false;
-    }
+    })();
+    conversationKeepPromisesRef.current.set(expanded.key, task);
+    return task;
   }, [stream.id, updateConversationLiveState]);
 
   const discardExpandedEphemeralConversation = useCallback(async (): Promise<boolean> => {
@@ -630,8 +655,12 @@ export function RichStreamEditor({
   const flushAll = useCallback(async () => {
     cancelDocumentAI();
     const expanded = expandedConversationRef.current;
-    if (expanded) cancelConversationRequest(expanded.key);
-    if (!await discardExpandedEphemeralConversation()) return false;
+    if (expanded) {
+      closingConversationKeysRef.current.add(expanded.key);
+      cancelConversationRequest(expanded.key);
+      await discardExpandedEphemeralConversation();
+      closingConversationKeysRef.current.delete(expanded.key);
+    }
     return sessionRef.current?.saveNow() ?? Promise.resolve(true);
   }, [cancelConversationRequest, cancelDocumentAI, discardExpandedEphemeralConversation]);
 
@@ -640,10 +669,24 @@ export function RichStreamEditor({
     return () => onFlushAvailable?.(null);
   }, [flushAll, onFlushAvailable]);
 
-  const expandConversation = useCallback((next: ExpandedConversation) => {
+  const prepareConversationClose = useCallback(async (expanded: ExpandedConversation) => {
+    closingConversationKeysRef.current.add(expanded.key);
+    cancelConversationRequest(expanded.key);
+    updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: true }));
+    const discarded = expanded.ephemeral !== true
+      || await discardEphemeralConversation(expanded.key);
+    closingConversationKeysRef.current.delete(expanded.key);
+    if (!discarded) {
+      updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: false }));
+    }
+    return discarded;
+  }, [cancelConversationRequest, discardEphemeralConversation, updateConversationLiveState]);
+
+  const expandConversation = useCallback(async (next: ExpandedConversation) => {
     const current = expandedConversationRef.current;
     if (current?.key !== next.key) {
-      if (current) cancelConversationRequest(current.key);
+      if (current && !await prepareConversationClose(current)) return;
+      if (current) updateConversationLiveState(current.key, (state) => ({ ...state, closing: false }));
       ensureConversationLiveState(next.key, next.threadId);
     }
     if (conversationCollapseTimerRef.current !== undefined) {
@@ -652,16 +695,14 @@ export function RichStreamEditor({
     }
     expandedConversationRef.current = next;
     setExpandedConversation(next);
-  }, [cancelConversationRequest, ensureConversationLiveState]);
+  }, [ensureConversationLiveState, prepareConversationClose, updateConversationLiveState]);
 
   const collapseConversation = useCallback(async () => {
     const expanded = expandedConversationRef.current;
     if (!expanded || conversationCollapseTimerRef.current !== undefined) return;
     const currentEditor = editorRef.current;
     const anchor = currentEditor && conversationSurface(currentEditor.view.state)?.anchor;
-    cancelConversationRequest(expanded.key);
-    if (!await discardEphemeralConversation(expanded.key)) return;
-    updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: true }));
+    if (!await prepareConversationClose(expanded)) return;
     conversationCollapseTimerRef.current = window.setTimeout(() => {
       conversationCollapseTimerRef.current = undefined;
       if (expandedConversationRef.current?.key !== expanded.key) return;
@@ -679,7 +720,7 @@ export function RichStreamEditor({
         currentEditor.view.focus();
       });
     }, 150);
-  }, [cancelConversationRequest, discardEphemeralConversation, updateConversationLiveState]);
+  }, [prepareConversationClose, updateConversationLiveState]);
 
   useEffect(() => () => {
     if (conversationCollapseTimerRef.current !== undefined) {
@@ -689,9 +730,10 @@ export function RichStreamEditor({
       cancelConversationRequest(key, false);
     }
     const expanded = expandedConversationRef.current;
+    if (expanded) closingConversationKeysRef.current.add(expanded.key);
     const thread = expanded && conversationLiveStatesRef.current[expanded.key]?.thread;
     if (expanded?.ephemeral && thread?.ephemeral) {
-      void deleteStreamThread({ streamId: stream.id, threadId: thread.threadId }).catch(() => undefined);
+      void deleteEphemeralThread({ streamId: stream.id, threadId: thread.threadId }).catch(() => undefined);
     }
   }, [cancelConversationRequest, stream.id]);
 
@@ -740,6 +782,7 @@ export function RichStreamEditor({
   }, [collapseConversation, expandConversation]);
 
   const updateSlashMenu = useCallback(() => {
+    if (!slashArmedRef.current && !slashMenuRef.current) return;
     const view = editorRef.current?.view;
     const input = view && slashCommandInput(view);
     if (!view || !input) {
@@ -750,7 +793,6 @@ export function RichStreamEditor({
       }
       return;
     }
-    if (!slashArmedRef.current && !slashMenuRef.current) return;
     slashArmedRef.current = false;
     let coords = { left: 0, bottom: 0 };
     try {
@@ -1069,6 +1111,7 @@ export function RichStreamEditor({
     title: string,
     pdf?: { sourceId: string; highlightId: string },
     ephemeral = false,
+    profile?: 'research',
   ): Promise<StreamThreadJSON> => {
     const currentEditor = editorRef.current;
     if (!currentEditor) throw new Error('Conversation closed');
@@ -1084,6 +1127,7 @@ export function RichStreamEditor({
       highlightId: pdf?.highlightId,
       detached: currentSurface.anchor.detached,
       ephemeral,
+      profile,
     });
 
     const liveEditor = editorRef.current;
@@ -1136,12 +1180,36 @@ export function RichStreamEditor({
   const createPersistedConversation = useCallback(async (
     query: string,
     ephemeral: boolean,
+    profile?: 'research',
   ): Promise<StreamThreadJSON> => {
     const currentEditor = editorRef.current;
     const currentSurface = currentEditor && conversationSurface(currentEditor.view.state);
     if (!currentSurface) throw new Error('Conversation closed');
-    return persistConversation(currentSurface, query.split(/\r?\n/, 1)[0], undefined, ephemeral);
-  }, [persistConversation]);
+    const key = currentSurface.key;
+    let task: Promise<StreamThreadJSON>;
+    task = persistConversation(
+      currentSurface,
+      query.split(/\r?\n/, 1)[0],
+      undefined,
+      ephemeral,
+      profile,
+    ).then(async (thread) => {
+      if (closingConversationKeysRef.current.has(key)) {
+        if (thread.ephemeral) {
+          await deleteEphemeralThread({ streamId: stream.id, threadId: thread.threadId });
+        }
+        throw new Error('Conversation closed');
+      }
+      updateConversationLiveState(key, (state) => ({ ...state, thread }));
+      return thread;
+    }).finally(() => {
+      if (conversationCreatePromisesRef.current.get(key) === task) {
+        conversationCreatePromisesRef.current.delete(key);
+      }
+    });
+    conversationCreatePromisesRef.current.set(key, task);
+    return task;
+  }, [persistConversation, stream.id, updateConversationLiveState]);
 
   const conversationHasDrifted = useCallback((anchorText: string) => {
     const currentEditor = editorRef.current;
@@ -1446,6 +1514,7 @@ export function RichStreamEditor({
   useEffect(() => {
     if (!editor) return undefined;
     const keydown = (event: KeyboardEvent) => {
+      if (editor.view.composing) return;
       const menu = slashMenuRef.current;
       if (menu) {
         if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
@@ -1653,9 +1722,8 @@ export function RichStreamEditor({
   const leave = useCallback(async () => {
     cancelDocumentAI();
     const expanded = expandedConversationRef.current;
-    if (expanded) cancelConversationRequest(expanded.key);
     setLeaving(true);
-    if (!await discardExpandedEphemeralConversation()) {
+    if (expanded && !await prepareConversationClose(expanded)) {
       setLeaving(false);
       addToast('This chat could not be discarded, so the stream stayed open.', 'error');
       return;
@@ -1663,13 +1731,16 @@ export function RichStreamEditor({
     const documentSaved = await (sessionRef.current?.destroy() ?? Promise.resolve(true));
     if (documentSaved) return onBack();
     setLeaving(false);
+    if (expanded) {
+      updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: false }));
+    }
     addToast('Your changes could not be saved, so this stream stayed open.', 'error');
   }, [
     addToast,
-    cancelConversationRequest,
     cancelDocumentAI,
-    discardExpandedEphemeralConversation,
     onBack,
+    prepareConversationClose,
+    updateConversationLiveState,
   ]);
 
   const remove = useCallback(() => {

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -15,6 +15,7 @@ import {
   deleteStreamThread,
   getExchange,
   listConversations,
+  saveStreamThread,
   type DocumentAIVerb,
   type SourceTitlePayload,
   type StreamDocumentConflictPayload,
@@ -194,6 +195,39 @@ interface ExpandedConversation {
   renderAt?: number;
   anchorText: string;
   focusComposer: boolean;
+  ephemeral?: boolean;
+  profile?: 'research';
+}
+
+type SlashCommand = 'chat' | 'research';
+
+interface SlashMenuState {
+  left: number;
+  top: number;
+  selected: number;
+}
+
+const SLASH_COMMANDS: Array<{ command: SlashCommand; description: string }> = [
+  { command: 'chat', description: 'think out loud, saved only if you keep it' },
+  { command: 'research', description: 'ask with sources and web search' },
+];
+
+function slashCommandInput(view: RichTextEditor['view']) {
+  const { selection } = view.state;
+  const { $head } = selection;
+  if (!selection.empty || $head.parent.type.name !== 'paragraph') return null;
+  const text = $head.parent.textContent;
+  if ($head.parentOffset !== text.length) return null;
+  const match = /^\/([a-z]*)(?:\s(.*))?$/.exec(text);
+  if (!match) return null;
+  const commandName = match[1];
+  if (commandName && !SLASH_COMMANDS.some(({ command }) => command.startsWith(commandName))) return null;
+  return {
+    from: $head.before(),
+    to: $head.after(),
+    commandName,
+    draft: match[2] ?? '',
+  };
 }
 
 type ConversationLiveStateUpdater = (current: ConversationLiveState) => ConversationLiveState;
@@ -249,10 +283,14 @@ export function RichStreamEditor({
   // PDF jobs ever become a supported workflow.
   const pdfAIInFlightRef = useRef(false);
   const consumedPendingSourceRef = useRef<string | null>(null);
-  const conversationRecordsRef = useRef<ConversationAnchorJSON[]>(stream.conversationAnchors ?? []);
+  const conversationRecordsRef = useRef<ConversationAnchorJSON[]>(
+    (stream.conversationAnchors ?? []).filter((record) => !record.ephemeral),
+  );
   const expandedConversationRef = useRef<ExpandedConversation | null>(null);
   const conversationLiveStatesRef = useRef<Record<string, ConversationLiveState>>({});
   const conversationCollapseTimerRef = useRef<number>();
+  const slashArmedRef = useRef(false);
+  const slashMenuRef = useRef<SlashMenuState | null>(null);
 
   const [editor, setEditor] = useState<RichTextEditor | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('saved');
@@ -288,12 +326,14 @@ export function RichStreamEditor({
   const [conversationLiveStates, setConversationLiveStates] = useState<Record<string, ConversationLiveState>>({});
   const [conversationWidgetTarget, setConversationWidgetTarget] = useState<HTMLElement | null>(null);
   const [conversationRecords, setConversationRecords] = useState<ConversationAnchorJSON[]>(
-    stream.conversationAnchors ?? [],
+    (stream.conversationAnchors ?? []).filter((record) => !record.ephemeral),
   );
   const [showConversationList, setShowConversationList] = useState(false);
   const [conversationListLoading, setConversationListLoading] = useState(false);
   const [conversationListError, setConversationListError] = useState(false);
   const [conversationPendingDelete, setConversationPendingDelete] = useState<ConversationAnchorJSON | null>(null);
+  const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
+  slashMenuRef.current = slashMenu;
   const addToast = useToastStore((state) => state.addToast);
   const { sources, setSources } = useBridgeMessages({
     streamId: stream.id,
@@ -325,16 +365,6 @@ export function RichStreamEditor({
     setAIDetail(null);
     setSourceIndexNotice(null);
   }, []);
-
-  const flushAll = useCallback(async () => {
-    cancelDocumentAI();
-    return sessionRef.current?.saveNow() ?? Promise.resolve(true);
-  }, [cancelDocumentAI]);
-
-  useEffect(() => {
-    onFlushAvailable?.(flushAll);
-    return () => onFlushAvailable?.(null);
-  }, [flushAll, onFlushAvailable]);
 
   useEffect(() => {
     if (saveState === 'saving') {
@@ -512,6 +542,104 @@ export function RichStreamEditor({
     if (updateUI) setConversationLiveStates(next);
   }, []);
 
+  const discardEphemeralConversation = useCallback(async (key: string): Promise<boolean> => {
+    const thread = conversationLiveStatesRef.current[key]?.thread;
+    if (!thread?.ephemeral) return true;
+    try {
+      await deleteStreamThread({ streamId: stream.id, threadId: thread.threadId });
+      const records = conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId);
+      conversationRecordsRef.current = records;
+      setConversationRecords(records);
+      updateConversationLiveState(key, (current) => ({
+        ...current,
+        thread: null,
+        exchanges: [],
+        active: null,
+      }));
+      return true;
+    } catch {
+      updateConversationLiveState(key, (current) => ({
+        ...current,
+        error: 'This chat could not be discarded.',
+      }));
+      return false;
+    }
+  }, [stream.id, updateConversationLiveState]);
+
+  const keepExpandedConversation = useCallback(async (): Promise<boolean> => {
+    const expanded = expandedConversationRef.current;
+    if (!expanded?.ephemeral) return true;
+    const current = conversationLiveStatesRef.current[expanded.key];
+    let thread = current?.thread;
+    try {
+      if (thread) {
+        const saved = await saveStreamThread({
+          streamId: stream.id,
+          threadId: thread.threadId,
+          title: thread.title,
+          baseRevision: thread.revision,
+          ephemeral: false,
+        });
+        thread = saved.thread;
+        if (thread.ephemeral) throw new Error('Keep conflicted');
+        updateConversationLiveState(expanded.key, (state) => ({ ...state, thread }));
+      }
+      const kept = { ...expanded, ephemeral: false };
+      expandedConversationRef.current = kept;
+      setExpandedConversation(kept);
+      const liveEditor = editorRef.current;
+      const surface = liveEditor && conversationSurface(liveEditor.view.state);
+      if (thread && liveEditor && surface?.key === expanded.key) {
+        const anchor = { ...surface.anchor, threadId: thread.threadId };
+        liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [
+          ...conversationAnchors(liveEditor.view.state)
+            .filter((candidate) => candidate.threadId !== thread!.threadId),
+          anchor,
+        ]));
+        const records = [
+          ...conversationRecordsRef.current.filter((record) => record.threadId !== thread!.threadId),
+          {
+            threadId: thread.threadId,
+            anchorStart: anchor.from,
+            anchorEnd: anchor.to,
+            anchorText: thread.anchorText,
+            detached: anchor.from >= anchor.to,
+            ephemeral: false,
+            updatedAt: thread.updatedAt,
+          },
+        ];
+        conversationRecordsRef.current = records;
+        setConversationRecords(records);
+        sessionRef.current?.documentChanged();
+      }
+      return true;
+    } catch {
+      updateConversationLiveState(expanded.key, (state) => ({
+        ...state,
+        error: 'This chat could not be kept.',
+      }));
+      return false;
+    }
+  }, [stream.id, updateConversationLiveState]);
+
+  const discardExpandedEphemeralConversation = useCallback(async (): Promise<boolean> => {
+    const expanded = expandedConversationRef.current;
+    return expanded?.ephemeral ? discardEphemeralConversation(expanded.key) : true;
+  }, [discardEphemeralConversation]);
+
+  const flushAll = useCallback(async () => {
+    cancelDocumentAI();
+    const expanded = expandedConversationRef.current;
+    if (expanded) cancelConversationRequest(expanded.key);
+    if (!await discardExpandedEphemeralConversation()) return false;
+    return sessionRef.current?.saveNow() ?? Promise.resolve(true);
+  }, [cancelConversationRequest, cancelDocumentAI, discardExpandedEphemeralConversation]);
+
+  useEffect(() => {
+    onFlushAvailable?.(flushAll);
+    return () => onFlushAvailable?.(null);
+  }, [flushAll, onFlushAvailable]);
+
   const expandConversation = useCallback((next: ExpandedConversation) => {
     const current = expandedConversationRef.current;
     if (current?.key !== next.key) {
@@ -526,12 +654,13 @@ export function RichStreamEditor({
     setExpandedConversation(next);
   }, [cancelConversationRequest, ensureConversationLiveState]);
 
-  const collapseConversation = useCallback(() => {
+  const collapseConversation = useCallback(async () => {
     const expanded = expandedConversationRef.current;
     if (!expanded || conversationCollapseTimerRef.current !== undefined) return;
     const currentEditor = editorRef.current;
     const anchor = currentEditor && conversationSurface(currentEditor.view.state)?.anchor;
     cancelConversationRequest(expanded.key);
+    if (!await discardEphemeralConversation(expanded.key)) return;
     updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: true }));
     conversationCollapseTimerRef.current = window.setTimeout(() => {
       conversationCollapseTimerRef.current = undefined;
@@ -550,7 +679,7 @@ export function RichStreamEditor({
         currentEditor.view.focus();
       });
     }, 150);
-  }, [cancelConversationRequest, updateConversationLiveState]);
+  }, [cancelConversationRequest, discardEphemeralConversation, updateConversationLiveState]);
 
   useEffect(() => () => {
     if (conversationCollapseTimerRef.current !== undefined) {
@@ -559,7 +688,12 @@ export function RichStreamEditor({
     for (const key of Object.keys(conversationLiveStatesRef.current)) {
       cancelConversationRequest(key, false);
     }
-  }, [cancelConversationRequest]);
+    const expanded = expandedConversationRef.current;
+    const thread = expanded && conversationLiveStatesRef.current[expanded.key]?.thread;
+    if (expanded?.ephemeral && thread?.ephemeral) {
+      void deleteStreamThread({ streamId: stream.id, threadId: thread.threadId }).catch(() => undefined);
+    }
+  }, [cancelConversationRequest, stream.id]);
 
   const openConversationFromGlyph = useCallback((threadId: string) => {
     const view = editorRef.current?.view;
@@ -605,13 +739,74 @@ export function RichStreamEditor({
     });
   }, [collapseConversation, expandConversation]);
 
+  const updateSlashMenu = useCallback(() => {
+    const view = editorRef.current?.view;
+    const input = view && slashCommandInput(view);
+    if (!view || !input) {
+      slashArmedRef.current = false;
+      if (slashMenuRef.current) {
+        slashMenuRef.current = null;
+        setSlashMenu(null);
+      }
+      return;
+    }
+    if (!slashArmedRef.current && !slashMenuRef.current) return;
+    slashArmedRef.current = false;
+    let coords = { left: 0, bottom: 0 };
+    try {
+      coords = view.coordsAtPos(view.state.selection.head);
+    } catch {
+      // jsdom and first WebKit layout can have no caret rectangle yet.
+    }
+    const matched = input.commandName
+      ? SLASH_COMMANDS.findIndex(({ command }) => command.startsWith(input.commandName))
+      : -1;
+    const next = {
+      left: coords.left,
+      top: coords.bottom + 6,
+      selected: matched >= 0 ? matched : slashMenuRef.current?.selected ?? 0,
+    };
+    slashMenuRef.current = next;
+    setSlashMenu(next);
+  }, []);
+
+  const runSlashCommand = useCallback((command: SlashCommand) => {
+    const view = editorRef.current?.view;
+    const input = view && slashCommandInput(view);
+    if (!view || !input) return;
+    const key = `slash:${crypto.randomUUID()}`;
+    const previous = input.from > 0
+      ? fullBlockConversationAnchor(view.state.doc, input.from - 1, key)
+      : null;
+    view.dispatch(view.state.tr.delete(input.from, input.to).setMeta('addToHistory', false));
+    const anchor = previous ?? {
+      threadId: key,
+      from: view.state.doc.content.size,
+      to: view.state.doc.content.size,
+      detached: true,
+    };
+    slashMenuRef.current = null;
+    setSlashMenu(null);
+    updateConversationLiveState(key, (current) => ({ ...current, composer: input.draft }));
+    expandConversation({
+      key,
+      anchor,
+      renderAt: anchor.detached ? view.state.doc.content.size : undefined,
+      anchorText: conversationAnchorTextForStorage(view.state.doc, anchor),
+      focusComposer: true,
+      ephemeral: command === 'chat',
+      profile: command === 'research' ? 'research' : undefined,
+    });
+  }, [expandConversation, updateConversationLiveState]);
+
   // Which formatting buttons are lit depends on the SELECTION, so the menu has to
   // redraw on every transaction and not only on edits.
   const onUpdate = useCallback(() => {
     redraw((n) => n + 1);
     updateSelectionMenu();
+    updateSlashMenu();
     if (editorRef.current) refreshConversationViewport(editorRef.current.view);
-  }, [updateSelectionMenu]);
+  }, [updateSelectionMenu, updateSlashMenu]);
 
   useLayoutEffect(() => {
     if (!selectionMenu.visible) return;
@@ -739,7 +934,9 @@ export function RichStreamEditor({
       editor: created,
       revision: stream.document?.revision ?? 0,
       spans: (stream.spans ?? []).map(spanFromJSON),
-      conversationAnchors: (stream.conversationAnchors ?? []).map(conversationAnchorFromJSON),
+      conversationAnchors: (stream.conversationAnchors ?? [])
+        .filter((record) => !record.ephemeral)
+        .map(conversationAnchorFromJSON),
       pendingAppends: decodePendingAppends(stream.pendingAppends),
       inboxAppends: stream.appendInbox ?? [],
       transport: {
@@ -862,7 +1059,7 @@ export function RichStreamEditor({
   ]);
 
   useEffect(() => {
-    const records = stream.conversationAnchors ?? [];
+    const records = (stream.conversationAnchors ?? []).filter((record) => !record.ephemeral);
     conversationRecordsRef.current = records;
     setConversationRecords(records);
   }, [stream.conversationAnchors]);
@@ -871,11 +1068,12 @@ export function RichStreamEditor({
     currentSurface: { key: string; anchor: ConversationAnchor },
     title: string,
     pdf?: { sourceId: string; highlightId: string },
+    ephemeral = false,
   ): Promise<StreamThreadJSON> => {
     const currentEditor = editorRef.current;
     if (!currentEditor) throw new Error('Conversation closed');
     const anchorText = conversationAnchorTextForStorage(currentEditor.view.state.doc, currentSurface.anchor);
-    if (!anchorText) throw new Error('Anchor deleted');
+    if (!anchorText && !currentSurface.anchor.detached) throw new Error('Anchor deleted');
     const { thread } = await createStreamThread({
       streamId: stream.id,
       title,
@@ -884,6 +1082,8 @@ export function RichStreamEditor({
       anchorText,
       sourceId: pdf?.sourceId,
       highlightId: pdf?.highlightId,
+      detached: currentSurface.anchor.detached,
+      ephemeral,
     });
 
     const liveEditor = editorRef.current;
@@ -898,7 +1098,9 @@ export function RichStreamEditor({
     const anchors = conversationAnchors(liveEditor.view.state)
       .filter((anchor) => anchor.threadId !== thread.threadId
         && anchor.threadId !== currentSurface.anchor.threadId);
-    liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [...anchors, persisted]));
+    if (!thread.ephemeral) {
+      liveEditor.view.dispatch(setConversationAnchors(liveEditor.view.state.tr, [...anchors, persisted]));
+    }
     if (liveSurface?.key === currentSurface.key) {
       liveEditor.view.dispatch(setConversationSurface(liveEditor.view.state.tr, {
         key: currentSurface.key,
@@ -911,29 +1113,34 @@ export function RichStreamEditor({
         setExpandedConversation(next);
       }
     }
-    const records = [
-      ...conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId),
-      {
-        threadId: thread.threadId,
-        anchorStart: persisted.from,
-        anchorEnd: persisted.to,
-        anchorText,
-        detached: persisted.detached,
-        ephemeral: false,
-        updatedAt: thread.updatedAt,
-      },
-    ];
-    conversationRecordsRef.current = records;
-    setConversationRecords(records);
-    sessionRef.current?.documentChanged();
+    if (!thread.ephemeral) {
+      const records = [
+        ...conversationRecordsRef.current.filter((record) => record.threadId !== thread.threadId),
+        {
+          threadId: thread.threadId,
+          anchorStart: persisted.from,
+          anchorEnd: persisted.to,
+          anchorText,
+          detached: persisted.detached,
+          ephemeral: false,
+          updatedAt: thread.updatedAt,
+        },
+      ];
+      conversationRecordsRef.current = records;
+      setConversationRecords(records);
+      sessionRef.current?.documentChanged();
+    }
     return thread;
   }, [stream.id]);
 
-  const createPersistedConversation = useCallback(async (query: string): Promise<StreamThreadJSON> => {
+  const createPersistedConversation = useCallback(async (
+    query: string,
+    ephemeral: boolean,
+  ): Promise<StreamThreadJSON> => {
     const currentEditor = editorRef.current;
     const currentSurface = currentEditor && conversationSurface(currentEditor.view.state);
     if (!currentSurface) throw new Error('Conversation closed');
-    return persistConversation(currentSurface, query.split(/\r?\n/, 1)[0]);
+    return persistConversation(currentSurface, query.split(/\r?\n/, 1)[0], undefined, ephemeral);
   }, [persistConversation]);
 
   const conversationHasDrifted = useCallback((anchorText: string) => {
@@ -946,7 +1153,8 @@ export function RichStreamEditor({
     );
   }, []);
 
-  const promoteConversationTurn = useCallback((exchange: AIExchangeJSON) => {
+  const promoteConversationTurn = useCallback(async (exchange: AIExchangeJSON) => {
+    if (expandedConversationRef.current?.ephemeral && !await keepExpandedConversation()) return;
     const currentEditor = editorRef.current;
     const surface = currentEditor && conversationSurface(currentEditor.view.state);
     if (!currentEditor || !surface) return;
@@ -981,7 +1189,7 @@ export function RichStreamEditor({
     } catch {
       addToast("Couldn't add the reply.", 'error');
     }
-  }, [addToast]);
+  }, [addToast, keepExpandedConversation]);
 
   const discardPDFQuote = useCallback((streamId: unknown, highlightId: unknown) => {
     if (typeof highlightId === 'string') {
@@ -1074,8 +1282,9 @@ export function RichStreamEditor({
     setConversationListError(false);
     try {
       const { conversations } = await listConversations(stream.id);
-      conversationRecordsRef.current = conversations;
-      setConversationRecords(conversations);
+      const kept = conversations.filter((record) => !record.ephemeral);
+      conversationRecordsRef.current = kept;
+      setConversationRecords(kept);
     } catch {
       setConversationListError(true);
     } finally {
@@ -1233,6 +1442,42 @@ export function RichStreamEditor({
   useEffect(() => {
     editor?.view.dom.parentElement?.classList.toggle('richtext-xray', xray);
   }, [editor, xray]);
+
+  useEffect(() => {
+    if (!editor) return undefined;
+    const keydown = (event: KeyboardEvent) => {
+      const menu = slashMenuRef.current;
+      if (menu) {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          const direction = event.key === 'ArrowDown' ? 1 : -1;
+          const next = {
+            ...menu,
+            selected: (menu.selected + direction + SLASH_COMMANDS.length) % SLASH_COMMANDS.length,
+          };
+          slashMenuRef.current = next;
+          setSlashMenu(next);
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          runSlashCommand(SLASH_COMMANDS[menu.selected].command);
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          slashMenuRef.current = null;
+          setSlashMenu(null);
+        }
+        return;
+      }
+      const { selection } = editor.view.state;
+      if (event.key === '/'
+        && selection.empty
+        && selection.$head.parent.type.name === 'paragraph'
+        && selection.$head.parent.content.size === 0) {
+        slashArmedRef.current = true;
+      }
+    };
+    editor.view.dom.addEventListener('keydown', keydown, true);
+    return () => editor.view.dom.removeEventListener('keydown', keydown, true);
+  }, [editor, runSlashCommand]);
 
   useEffect(() => {
     if (!editor || !xray) return undefined;
@@ -1407,12 +1652,25 @@ export function RichStreamEditor({
    */
   const leave = useCallback(async () => {
     cancelDocumentAI();
+    const expanded = expandedConversationRef.current;
+    if (expanded) cancelConversationRequest(expanded.key);
     setLeaving(true);
+    if (!await discardExpandedEphemeralConversation()) {
+      setLeaving(false);
+      addToast('This chat could not be discarded, so the stream stayed open.', 'error');
+      return;
+    }
     const documentSaved = await (sessionRef.current?.destroy() ?? Promise.resolve(true));
     if (documentSaved) return onBack();
     setLeaving(false);
     addToast('Your changes could not be saved, so this stream stayed open.', 'error');
-  }, [addToast, cancelDocumentAI, onBack]);
+  }, [
+    addToast,
+    cancelConversationRequest,
+    cancelDocumentAI,
+    discardExpandedEphemeralConversation,
+    onBack,
+  ]);
 
   const remove = useCallback(() => {
     deleting.current = true;
@@ -1703,7 +1961,9 @@ export function RichStreamEditor({
         markdown: String(conflict?.markdown ?? ''),
         revision: Number(conflict?.revision),
         spans: conflict?.spans?.map(spanFromJSON),
-        conversationAnchors: conflict?.conversationAnchors?.map(conversationAnchorFromJSON),
+        conversationAnchors: conflict?.conversationAnchors
+          ?.filter((record) => !record.ephemeral)
+          .map(conversationAnchorFromJSON),
         pendingAppends: decodePendingAppends(
           Array.isArray(conflict?.pendingAppends) ? conflict.pendingAppends : [],
         ),
@@ -1762,7 +2022,9 @@ export function RichStreamEditor({
       markdown: document.markdown,
       revision: document.revision,
       spans: (stream.spans ?? []).map(spanFromJSON),
-      conversationAnchors: (stream.conversationAnchors ?? []).map(conversationAnchorFromJSON),
+      conversationAnchors: (stream.conversationAnchors ?? [])
+        .filter((record) => !record.ephemeral)
+        .map(conversationAnchorFromJSON),
       // The reloaded document brings its own rows. Without them the session could
       // never let the store forget another one, and a row that outlives the
       // revision it was recorded at can never be replayed.
@@ -1935,6 +2197,10 @@ export function RichStreamEditor({
       onPointerDownCapture={(event) => {
         const menu = streamOverflowMenuRef.current;
         if (menu?.open && !menu.contains(event.target as Node)) menu.open = false;
+        if (slashMenuRef.current && !(event.target as Element).closest?.('.slash-command-menu')) {
+          slashMenuRef.current = null;
+          setSlashMenu(null);
+        }
       }}
       onKeyDownCapture={(event) => {
         if (event.key === 'Escape' && streamOverflowMenuRef.current?.open) {
@@ -2212,16 +2478,42 @@ export function RichStreamEditor({
           streamMarkdown={editor?.getMarkdownProjection() ?? stream.document.markdown}
           contextOptions={conversationContextOptions}
           focusComposer={expandedConversation.focusComposer}
+          ephemeral={expandedConversation.ephemeral === true}
+          profile={expandedConversation.profile}
           state={conversationLiveStates[expandedConversation.key]
             ?? initialConversationLiveState(expandedConversation.threadId)}
           updateState={updateConversationLiveState}
           createThread={createPersistedConversation}
           hasDrifted={conversationHasDrifted}
           onPromote={promoteConversationTurn}
+          onKeep={() => { void keepExpandedConversation(); }}
           onCollapse={collapseConversation}
         />,
         conversationWidgetTarget,
         expandedConversation.key,
+      )}
+
+      {slashMenu && (
+        <div
+          className="slash-command-menu"
+          role="listbox"
+          aria-label="Slash commands"
+          style={{ left: `${slashMenu.left}px`, top: `${slashMenu.top}px` }}
+        >
+          {SLASH_COMMANDS.map((item, index) => (
+            <button
+              type="button"
+              role="option"
+              aria-selected={index === slashMenu.selected}
+              className={index === slashMenu.selected ? 'slash-command-item--selected' : ''}
+              key={item.command}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => runSlashCommand(item.command)}
+            >
+              <span>{item.command}</span> — {item.description}
+            </button>
+          ))}
+        </div>
       )}
 
       {formats && selectionMenu.visible && (

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -139,6 +139,56 @@
   gap: var(--space-3);
 }
 
+.conversation-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.conversation-keep {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--type-ui-small);
+  cursor: pointer;
+}
+
+.conversation-keep:hover {
+  color: var(--text);
+}
+
+.slash-command-menu {
+  position: fixed;
+  z-index: 920;
+  display: grid;
+  width: min(420px, calc(100vw - var(--space-4)));
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--overlay-shadow);
+  font-size: var(--type-ui-small);
+  line-height: var(--type-ui-line-height);
+}
+
+.slash-command-menu button {
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.slash-command-menu button:hover,
+.slash-command-menu .slash-command-item--selected {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
 .conversation-drift-note,
 .conversation-status,
 .conversation-load-error,

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -158,6 +158,11 @@
   color: var(--text);
 }
 
+.conversation-keep:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .slash-command-menu {
   position: fixed;
   z-index: 920;

--- a/Web/src/threads/context.test.ts
+++ b/Web/src/threads/context.test.ts
@@ -26,6 +26,7 @@ const receiptV2 = {
     kind: 'pdf_quote', quote: 'Pinned PDF text.', sourceId: 'source-2',
     sourceName: 'Datasheet', highlightId: 'highlight-2', page: 12,
   }],
+  profile: 'research',
 };
 
 describe('thread AI context receipts', () => {
@@ -46,6 +47,7 @@ describe('thread AI context receipts', () => {
       anchor: { text: 'Start here.', from: 5, to: 16 },
       streamDocument: { sent: true, charCount: 1200 },
       pinned: receiptV2.pinned,
+      profile: 'research',
     });
     expect(parseThreadAISentFacts({
       ...receiptV2,
@@ -61,6 +63,7 @@ describe('thread AI context receipts', () => {
       ...receiptV2,
       pinned: [{ kind: 'stream_quote', quote: 'Bad range', from: '', to: 4 }],
     })?.pinned).toEqual([]);
+    expect(parseThreadAISentFacts({ ...receiptV2, profile: 'unknown' })).toBe(null);
   });
 
   it('keeps released citation-array manifests readable', () => {

--- a/Web/src/threads/context.ts
+++ b/Web/src/threads/context.ts
@@ -40,6 +40,7 @@ export interface ThreadAISentFacts {
   sourceContextMode: 'none' | 'passthrough' | 'retrieved' | 'unavailable';
   sources: ThreadAISourceFact[];
   pinned: ThreadAIPinnedFact[];
+  profile?: 'research';
 }
 
 function object(value: unknown): Record<string, unknown> | null {
@@ -138,6 +139,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
     ? receipt.pinned.flatMap((pin) => parsePinned(pin) ?? [])
     : [];
   if (receipt.version === 2 && !Array.isArray(receipt.pinned)) return null;
+  if (receipt.profile !== undefined && receipt.profile !== 'research') return null;
 
   return {
     version: receipt.version,
@@ -166,6 +168,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
       ? receipt.sources.flatMap((source) => parseSource(source) ?? [])
       : [],
     pinned,
+    profile: receipt.profile,
   };
 }
 

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -256,6 +256,7 @@ export function createStreamThread(input: {
   anchorText: string;
   sourceId?: string;
   highlightId?: string;
+  ephemeral?: boolean;
 }): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('createStreamThread', {
     streamId: input.streamId,
@@ -265,6 +266,7 @@ export function createStreamThread(input: {
     anchorText: input.anchorText,
     sourceId: input.sourceId,
     highlightId: input.highlightId,
+    ephemeral: input.ephemeral,
   });
 }
 
@@ -326,12 +328,14 @@ export function saveStreamThread(input: {
   threadId: string;
   title: string;
   baseRevision: number;
+  ephemeral?: boolean;
 }): Promise<{ conflict: boolean; thread: StreamThreadJSON }> {
   return bridge.sendAsync('saveStreamThread', {
     streamId: input.streamId,
     threadId: input.threadId,
     title: input.title,
     baseRevision: input.baseRevision,
+    ephemeral: input.ephemeral,
   });
 }
 

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -258,6 +258,7 @@ export function createStreamThread(input: {
   highlightId?: string;
   ephemeral?: boolean;
   detached?: boolean;
+  profile?: 'research';
 }): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('createStreamThread', {
     streamId: input.streamId,
@@ -269,6 +270,7 @@ export function createStreamThread(input: {
     highlightId: input.highlightId,
     ephemeral: input.ephemeral,
     detached: input.detached,
+    profile: input.profile,
   });
 }
 
@@ -312,6 +314,17 @@ export function deleteStreamThread(input: {
   return bridge.sendAsync('deleteStreamThread', {
     streamId: input.streamId,
     threadId: input.threadId,
+  });
+}
+
+export function deleteEphemeralThread(input: {
+  streamId: string;
+  threadId: string;
+}): Promise<{ highlightIds: string[] }> {
+  return bridge.sendAsync('deleteStreamThread', {
+    streamId: input.streamId,
+    threadId: input.threadId,
+    ephemeralOnly: true,
   });
 }
 

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -257,6 +257,7 @@ export function createStreamThread(input: {
   sourceId?: string;
   highlightId?: string;
   ephemeral?: boolean;
+  detached?: boolean;
 }): Promise<{ thread: StreamThreadJSON }> {
   return bridge.sendAsync('createStreamThread', {
     streamId: input.streamId,
@@ -267,6 +268,7 @@ export function createStreamThread(input: {
     sourceId: input.sourceId,
     highlightId: input.highlightId,
     ephemeral: input.ephemeral,
+    detached: input.detached,
   });
 }
 

--- a/Web/src/types/models.ts
+++ b/Web/src/types/models.ts
@@ -141,6 +141,7 @@ export interface StreamThreadJSON {
   anchorEnd?: number;
   detached?: boolean;
   ephemeral?: boolean;
+  profile?: 'research';
   revision: number;
   createdAt: string;
   updatedAt: string;

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -178,7 +178,7 @@
       },
       "createStreamThread": {
         "requiredPayloadKeys": ["streamId", "title", "anchorStart", "anchorEnd", "anchorText"],
-        "optionalPayloadKeys": ["sourceId", "highlightId", "ephemeral"],
+        "optionalPayloadKeys": ["sourceId", "highlightId", "ephemeral", "detached"],
         "requiredCallbackId": true
       },
       "createStream": {
@@ -316,7 +316,7 @@
       },
       "thinkDocument": {
         "requiredPayloadKeys": ["requestId", "streamId", "query", "imageURLs"],
-        "optionalPayloadKeys": ["context", "sourceScope", "verb", "parentRequestId", "threadId", "anchorStart", "anchorEnd", "streamMarkdown"]
+        "optionalPayloadKeys": ["context", "sourceScope", "verb", "parentRequestId", "threadId", "anchorStart", "anchorEnd", "streamMarkdown", "profile"]
       },
       "updateMarginNote": {
         "requiredPayloadKeys": ["noteId", "status"]

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -178,7 +178,7 @@
       },
       "createStreamThread": {
         "requiredPayloadKeys": ["streamId", "title", "anchorStart", "anchorEnd", "anchorText"],
-        "optionalPayloadKeys": ["sourceId", "highlightId"],
+        "optionalPayloadKeys": ["sourceId", "highlightId", "ephemeral"],
         "requiredCallbackId": true
       },
       "createStream": {
@@ -292,6 +292,7 @@
       },
       "saveStreamThread": {
         "requiredPayloadKeys": ["streamId", "threadId", "title", "baseRevision"],
+        "optionalPayloadKeys": ["ephemeral"],
         "requiredCallbackId": true
       },
       "saveScrollPosition": {

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -164,6 +164,7 @@
       },
       "deleteStreamThread": {
         "requiredPayloadKeys": ["streamId", "threadId"],
+        "optionalPayloadKeys": ["ephemeralOnly"],
         "requiredCallbackId": true
       },
       "cancelDocumentAI": {
@@ -178,7 +179,7 @@
       },
       "createStreamThread": {
         "requiredPayloadKeys": ["streamId", "title", "anchorStart", "anchorEnd", "anchorText"],
-        "optionalPayloadKeys": ["sourceId", "highlightId", "ephemeral", "detached"],
+        "optionalPayloadKeys": ["sourceId", "highlightId", "ephemeral", "detached", "profile"],
         "requiredCallbackId": true
       },
       "createStream": {


### PR DESCRIPTION
Phase C6 of `docs/CONVERSATIONS_PLAN.md` (D7/D9) — `/` on an empty top-level paragraph opens a two-item menu (chat / research); `/chat` = ephemeral conversation (no glyph, no persistence unless kept or promoted; delete-on-collapse is transactional and host-guarded to ephemeral-only rows; crash-sweep at stream open); `/research` = research prompt profile persisted on the thread (v31, append-only) and recorded end-to-end in receipts + disclosure.

**Review (Opus): pass-with-notes → fix round `438968f`:** Keep/collapse race (could delete a kept conversation — now three-layer guarded incl. host-side `deleteEphemeralThread`), switch-away ephemeral leak, collapse-during-create leak, crash sweep, list-item slash guard, IME composition guard, per-keystroke cost hoist, research-profile persistence + Keep double-press.

**Gates (exit-code-verified):** build 0 · swift 0 · typecheck 0 · webtest 0 (598) · webbuild 0 · contract 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)