### PR TITLE
C7: scoped update_block tool (+ proxy tool passthrough)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-facing changes to Ticker are documented here.
 ## Unreleased
 
 ### Changed
+- editor: let anchored conversations apply scoped AI block edits with one-step undo (phase C7)
 - editor: add slash chat and research conversations (phase C6)
 - editor: add conversation reply promotion and PDF Quote & discuss (phase C5)
 - editor: add complete AI context, persistent pins, and receipts to inline conversations (phase C4)

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -99,6 +99,13 @@ struct ThreadAISentFacts: Codable, Equatable {
         let page: Int?
     }
 
+    struct UpdateBlock: Codable, Equatable {
+        let before: String
+        let after: String
+        let applied: Bool?
+        let failure: String?
+    }
+
     let version: Int
     let kind: String
     let requestId: String
@@ -110,6 +117,7 @@ struct ThreadAISentFacts: Codable, Equatable {
     let sources: [Source]
     let pinned: [Pinned]
     let profile: String?
+    let updateBlock: UpdateBlock?
 
     var jsonString: String {
         let encoder = JSONEncoder()
@@ -137,12 +145,19 @@ typealias ThreadAIRoute = (
     _ pinnedContext: [ThreadAIPinnedContext],
     _ priorTurns: [ThreadAIConversationTurn],
     _ researchProfile: Bool,
+    _ offerUpdateBlock: Bool,
     _ onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
     _ onChunk: @escaping (String) -> Void,
-    _ onComplete: @escaping (ThreadAIRequestReceipt) -> Void,
+    _ onComplete: @escaping (ThreadAIRequestReceipt, ProxyLLMCompletion) -> Void,
     _ onError: @escaping (Error) -> Void,
     _ onModelSelected: ((String) -> Void)?
 ) async -> Void
+
+private struct ThreadAIUpdateBlockCall {
+    let id: String
+    let argumentsJSON: String
+    let content: String
+}
 
 private enum DocumentAIVerb: String {
     case develop
@@ -273,7 +288,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                 onModelSelected: onModelSelected
             )
         }
-        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, streamMarkdown, pinnedContext, priorTurns, researchProfile, onPrepared, onChunk, onComplete, onError, onModelSelected in
+        self.routeThreadAI = { [orchestrator = container.orchestrator] query, retrievalQuery, streamId, sourceScope, anchorText, streamMarkdown, pinnedContext, priorTurns, researchProfile, offerUpdateBlock, onPrepared, onChunk, onComplete, onError, onModelSelected in
             await orchestrator.routeThread(
                 query: query,
                 retrievalQuery: retrievalQuery,
@@ -284,6 +299,7 @@ final class AIMessageHandler: BridgeMessageHandler {
                 pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
                 researchProfile: researchProfile,
+                offerUpdateBlock: offerUpdateBlock,
                 onPrepared: onPrepared,
                 onChunk: onChunk,
                 onComplete: onComplete,
@@ -314,7 +330,7 @@ final class AIMessageHandler: BridgeMessageHandler {
             _ onError: @escaping (Error) -> Void,
             _ onModelSelected: ((String) -> Void)?
         ) async -> Void,
-        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
+        routeThreadAI: @escaping ThreadAIRoute = { _, _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
             onError(OrchestratorError.noProviderAvailable)
         }
     ) {
@@ -622,7 +638,6 @@ final class AIMessageHandler: BridgeMessageHandler {
 
         var responseRaw = ""
         var selectedModel: String?
-        var sentFacts: ThreadAISentFacts?
         let onPrepared: (ThreadAIRequestReceipt) -> Void = { [weak self] receipt in
             guard let self, !Task.isCancelled else { return }
             let facts = self.threadSentFacts(
@@ -636,7 +651,6 @@ final class AIMessageHandler: BridgeMessageHandler {
                 receipt: receipt,
                 profile: profile
             )
-            sentFacts = facts
             self.sendToWeb(BridgeMessage(
                 type: "threadAIContext",
                 payload: [
@@ -653,9 +667,10 @@ final class AIMessageHandler: BridgeMessageHandler {
                 payload: ["requestId": AnyCodable(requestId), "chunk": AnyCodable(chunk)]
             ))
         }
-        let onComplete: (ThreadAIRequestReceipt) -> Void = { [weak self] receipt in
+        let onComplete: (ThreadAIRequestReceipt, ProxyLLMCompletion) -> Void = { [weak self] receipt, completion in
             guard let self, !Task.isCancelled else { return }
-            let facts = sentFacts ?? self.threadSentFacts(
+            let toolCall = completion.toolCalls.lazy.compactMap(Self.updateBlockCall).first
+            let facts = self.threadSentFacts(
                 requestId: requestId,
                 thread: thread,
                 anchorText: sentAnchorContext,
@@ -664,9 +679,20 @@ final class AIMessageHandler: BridgeMessageHandler {
                 streamMarkdown: streamMarkdown,
                 anchors: pinnedAnchors,
                 receipt: receipt,
-                profile: profile
+                profile: profile,
+                updateBlock: toolCall.map {
+                    ThreadAISentFacts.UpdateBlock(
+                        before: sentAnchorContext,
+                        after: $0.content,
+                        applied: nil,
+                        failure: nil
+                    )
+                }
             )
-            guard !responseRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            let visibleResponse = responseRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? toolCall.map { $0.content.isEmpty ? "Clear this block." : $0.content } ?? ""
+                : responseRaw
+            guard !visibleResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 self.sendToWeb(BridgeMessage(
                     type: "documentAIError",
                     payload: [
@@ -685,19 +711,28 @@ final class AIMessageHandler: BridgeMessageHandler {
                 verb: "thread",
                 userInput: query,
                 sourceManifest: facts.jsonString,
-                responseRaw: responseRaw,
+                responseRaw: visibleResponse,
                 model: selectedModel,
                 threadDisposition: "pending"
             )
             do {
                 try persistence.saveExchange(exchange)
+                var completionPayload: [String: AnyCodable] = [
+                    "requestId": AnyCodable(requestId),
+                    "exchange": AnyCodable(StreamCodec.encodeExchange(exchange)),
+                    "sentContext": AnyCodable(facts.bridgePayload),
+                    "toolCalls": AnyCodable(completion.reportedToolCalls)
+                ]
+                if let toolCall {
+                    completionPayload["toolCall"] = AnyCodable([
+                        "id": toolCall.id,
+                        "name": "update_block",
+                        "arguments": toolCall.argumentsJSON
+                    ])
+                }
                 self.sendToWeb(BridgeMessage(
                     type: "documentAIComplete",
-                    payload: [
-                        "requestId": AnyCodable(requestId),
-                        "exchange": AnyCodable(StreamCodec.encodeExchange(exchange)),
-                        "sentContext": AnyCodable(facts.bridgePayload)
-                    ]
+                    payload: completionPayload
                 ))
             } catch {
                 DebugLog.log("[AIMessageHandler] Failed to save thread exchange (\(DebugLog.errorSummary(error)))")
@@ -769,6 +804,11 @@ final class AIMessageHandler: BridgeMessageHandler {
                 pinnedContext,
                 priorTurns,
                 profile == "research",
+                Self.shouldOfferUpdateBlock(
+                    thread: thread,
+                    anchorStart: anchorStart,
+                    anchorEnd: anchorEnd
+                ),
                 onPrepared,
                 onChunk,
                 onComplete,
@@ -795,7 +835,8 @@ final class AIMessageHandler: BridgeMessageHandler {
         streamMarkdown: String,
         anchors: [StreamThreadAnchor],
         receipt: ThreadAIRequestReceipt,
-        profile: String?
+        profile: String?,
+        updateBlock: ThreadAISentFacts.UpdateBlock? = nil
     ) -> ThreadAISentFacts {
         var source: SourceReference?
         var highlight: PDFHighlightRecord?
@@ -889,8 +930,28 @@ final class AIMessageHandler: BridgeMessageHandler {
             sourceContextMode: Self.sourceContextMode(receipt.sourceContext),
             sources: sources,
             pinned: pinned,
-            profile: profile
+            profile: profile,
+            updateBlock: updateBlock
         )
+    }
+
+    private static func updateBlockCall(_ call: LLMToolCall) -> ThreadAIUpdateBlockCall? {
+        guard call.name == "update_block",
+              let data = call.argumentsJSON.data(using: .utf8),
+              let arguments = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = arguments["content"] as? String else {
+            DebugLog.log("[AIMessageHandler] Dropped unsupported or malformed conversation tool call")
+            return nil
+        }
+        return ThreadAIUpdateBlockCall(id: call.id, argumentsJSON: call.argumentsJSON, content: content)
+    }
+
+    static func shouldOfferUpdateBlock(
+        thread: StreamThread,
+        anchorStart: Int?,
+        anchorEnd: Int?
+    ) -> Bool {
+        !thread.ephemeral && (anchorStart ?? 0) < (anchorEnd ?? 0)
     }
 
     private static func sentPinnedAnchors(

--- a/Sources/Ticker/App/Bridge/AIMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/AIMessageHandler.swift
@@ -936,11 +936,14 @@ final class AIMessageHandler: BridgeMessageHandler {
     }
 
     private static func updateBlockCall(_ call: LLMToolCall) -> ThreadAIUpdateBlockCall? {
-        guard call.name == "update_block",
-              let data = call.argumentsJSON.data(using: .utf8),
+        guard call.name == "update_block" else {
+            DebugLog.log("[AIMessageHandler] Ignored unsupported conversation tool call '\(call.name)'")
+            return nil
+        }
+        guard let data = call.argumentsJSON.data(using: .utf8),
               let arguments = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let content = arguments["content"] as? String else {
-            DebugLog.log("[AIMessageHandler] Dropped unsupported or malformed conversation tool call")
+            DebugLog.log("[AIMessageHandler] Dropped malformed update_block tool call")
             return nil
         }
         return ThreadAIUpdateBlockCall(id: call.id, argumentsJSON: call.argumentsJSON, content: content)
@@ -951,7 +954,16 @@ final class AIMessageHandler: BridgeMessageHandler {
         anchorStart: Int?,
         anchorEnd: Int?
     ) -> Bool {
-        !thread.ephemeral && (anchorStart ?? 0) < (anchorEnd ?? 0)
+        guard thread.sourceId == nil,
+              thread.highlightId == nil,
+              !thread.detached,
+              !thread.ephemeral,
+              let persistedStart = thread.anchorStart,
+              let persistedEnd = thread.anchorEnd,
+              persistedStart < persistedEnd else {
+            return false
+        }
+        return (anchorStart ?? 0) < (anchorEnd ?? 0)
     }
 
     private static func sentPinnedAnchors(

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -2,6 +2,10 @@ import Foundation
 
 @MainActor
 final class ThreadMessageHandler: BridgeMessageHandler {
+    private static let updateBlockFailures: Set<String> = [
+        "passage_changed", "partial_anchor", "surface_closed", "thread_mismatch", "apply_error"
+    ]
+
     let handledTypes: Set<String> = [
         "addStreamThreadAnchor",
         "listConversations",
@@ -226,7 +230,9 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 return
             }
             let failure = payload["failure"]?.value as? String
-            guard (applied && failure == nil) || (!applied && failure == "passage_changed") else {
+            let validFailure = failure.map { Self.updateBlockFailures.contains($0) } ?? false
+            guard (applied && failure == nil)
+                    || (!applied && validFailure) else {
                 respondWithError(callbackId, "Invalid recordThreadToolApplication payload")
                 return
             }

--- a/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
+++ b/Sources/Ticker/App/Bridge/ThreadMessageHandler.swift
@@ -8,6 +8,7 @@ final class ThreadMessageHandler: BridgeMessageHandler {
         "createStreamThread",
         "deleteStreamThread",
         "loadStreamThread",
+        "recordThreadToolApplication",
         "removeStreamThreadAnchor",
         "saveStreamThread"
     ]
@@ -210,6 +211,37 @@ final class ThreadMessageHandler: BridgeMessageHandler {
                 } catch {
                     respondWithError(callbackId, error.localizedDescription)
                 }
+            } catch {
+                respondWithError(callbackId, error.localizedDescription)
+            }
+
+        case "recordThreadToolApplication":
+            guard let payload = message.payload,
+                  let streamId = decodeUUID(payload, key: "streamId"),
+                  let requestId = payload["requestId"]?.value as? String,
+                  !requestId.isEmpty,
+                  let before = payload["before"]?.value as? String,
+                  let applied = payload["applied"]?.value as? Bool else {
+                respondWithError(callbackId, "Invalid recordThreadToolApplication payload")
+                return
+            }
+            let failure = payload["failure"]?.value as? String
+            guard (applied && failure == nil) || (!applied && failure == "passage_changed") else {
+                respondWithError(callbackId, "Invalid recordThreadToolApplication payload")
+                return
+            }
+            do {
+                respond(callbackId, [
+                    "exchange": AnyCodable(StreamCodec.encodeExchange(
+                        try persistence.recordThreadToolApplication(
+                            requestId: requestId,
+                            streamId: streamId,
+                            before: before,
+                            applied: applied,
+                            failure: failure
+                        )
+                    ))
+                ])
             } catch {
                 respondWithError(callbackId, error.localizedDescription)
             }

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -415,7 +415,7 @@ final class AIOrchestrator {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func buildRequest(
+    func buildRequest(
         query: String,
         queryImages: [String],
         priorCells: [[String: Any]],

--- a/Sources/Ticker/Services/AIOrchestrator.swift
+++ b/Sources/Ticker/Services/AIOrchestrator.swift
@@ -71,6 +71,19 @@ enum TickerInternalURLSanitizer {
 /// Freshness is the answering model's call: the proxy offers it a web_search
 /// tool on every request, so no client-side intent classification exists.
 final class AIOrchestrator {
+    private static let updateBlockTool = LLMFunctionTool(
+        name: "update_block",
+        description: "Rewrite the passage this conversation is anchored to when the user asks for a rewrite or edit. Provide the full replacement markdown for the anchored block or blocks.",
+        parameters: [
+            "type": "object",
+            "properties": [
+                "content": ["type": "string"]
+            ],
+            "required": ["content"],
+            "additionalProperties": false
+        ]
+    )
+
     private var retrievalService: RetrievalService?
 
     /// Proxy service - the sole LLM provider in proxy-only mode
@@ -186,7 +199,7 @@ final class AIOrchestrator {
                 onModelSelected?(displayModel)
             },
             onChunk: onChunk,
-            onComplete: {
+            onComplete: { _ in
                 onComplete(contextToUse)
             },
             onError: onError
@@ -205,9 +218,10 @@ final class AIOrchestrator {
         pinnedContext: [ThreadAIPinnedContext],
         priorTurns: [ThreadAIConversationTurn],
         researchProfile: Bool,
+        offerUpdateBlock: Bool,
         onPrepared: @escaping (ThreadAIRequestReceipt) -> Void,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping (ThreadAIRequestReceipt) -> Void,
+        onComplete: @escaping (ThreadAIRequestReceipt, ProxyLLMCompletion) -> Void,
         onError: @escaping (Error) -> Void,
         onModelSelected: ((String) -> Void)? = nil
     ) async {
@@ -240,7 +254,8 @@ final class AIOrchestrator {
                 pinnedContext: pinnedContext,
                 priorTurns: priorTurns,
                 sourceContext: sourceContext,
-                researchProfile: researchProfile
+                researchProfile: researchProfile,
+                offerUpdateBlock: offerUpdateBlock
             )
             onPrepared(prepared.receipt)
             await proxyService.stream(
@@ -249,7 +264,7 @@ final class AIOrchestrator {
                     onModelSelected?("\(provider)/\(model)")
                 },
                 onChunk: onChunk,
-                onComplete: { onComplete(prepared.receipt) },
+                onComplete: { onComplete(prepared.receipt, $0) },
                 onError: onError
             )
         } catch {
@@ -286,6 +301,7 @@ final class AIOrchestrator {
         priorTurns: [ThreadAIConversationTurn],
         sourceContext: SourceContext?,
         researchProfile: Bool = false,
+        offerUpdateBlock: Bool = false,
         tokenBudget: Int = LLMRequest.defaultTokenBudget
     ) throws -> PreparedThreadAIRequest {
         let cleanAnchor = TickerInternalURLSanitizer.sanitize(anchorText)
@@ -332,7 +348,9 @@ final class AIOrchestrator {
                 systemPrompt: researchProfile ? Prompts.threadResearch : Prompts.threadConversation,
                 messages: messages,
                 temperature: 0.7,
-                maxTokens: 2048
+                maxTokens: 2048,
+                tools: offerUpdateBlock ? [Self.updateBlockTool] : [],
+                toolChoice: offerUpdateBlock ? "auto" : nil
             )
         }
 

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -2237,6 +2237,56 @@ final class PersistenceService {
         }
     }
 
+    func recordThreadToolApplication(
+        requestId: String,
+        streamId: UUID,
+        before: String,
+        applied: Bool,
+        failure: String?
+    ) throws -> AIExchange {
+        try dbQueue.write { db in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT request_id, stream_id, thread_id, verb, user_input,
+                           source_manifest, response_raw, model, thread_disposition, created_at
+                    FROM ai_exchanges
+                    WHERE request_id = ? AND stream_id = ? AND thread_id IS NOT NULL
+                """,
+                arguments: [requestId, streamId.uuidString]
+            ),
+            let exchange = Self.decodeExchange(row),
+            let data = exchange.sourceManifest.data(using: .utf8),
+            var receipt = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            var updateBlock = receipt["updateBlock"] as? [String: Any],
+            updateBlock["after"] is String else {
+                throw StreamThreadPersistenceError.exchangeOutsideThread
+            }
+            updateBlock["before"] = before
+            updateBlock["applied"] = applied
+            updateBlock["failure"] = failure ?? NSNull()
+            receipt["updateBlock"] = updateBlock
+            let manifestData = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
+            let sourceManifest = String(decoding: manifestData, as: UTF8.self)
+            try db.execute(
+                sql: "UPDATE ai_exchanges SET source_manifest = ? WHERE request_id = ?",
+                arguments: [sourceManifest, requestId]
+            )
+            return AIExchange(
+                requestId: exchange.requestId,
+                streamId: exchange.streamId,
+                threadId: exchange.threadId,
+                verb: exchange.verb,
+                userInput: exchange.userInput,
+                sourceManifest: sourceManifest,
+                responseRaw: exchange.responseRaw,
+                model: exchange.model,
+                threadDisposition: exchange.threadDisposition,
+                createdAt: exchange.createdAt
+            )
+        }
+    }
+
     func saveExchange(_ exchange: AIExchange) throws {
         try dbQueue.write { db in
             try saveExchange(exchange, db: db)

--- a/Sources/Ticker/Services/PersistenceService.swift
+++ b/Sources/Ticker/Services/PersistenceService.swift
@@ -2266,6 +2266,7 @@ final class PersistenceService {
             updateBlock["applied"] = applied
             updateBlock["failure"] = failure ?? NSNull()
             receipt["updateBlock"] = updateBlock
+            // Receipt identity is semantic, not JSON key order; sorting only stabilizes stored/debug output.
             let manifestData = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
             let sourceManifest = String(decoding: manifestData, as: UTF8.self)
             try db.execute(

--- a/Sources/Ticker/Services/Providers/LLMProvider.swift
+++ b/Sources/Ticker/Services/Providers/LLMProvider.swift
@@ -16,6 +16,32 @@ struct LLMMessage {
     var hasImages: Bool { !imageURLs.isEmpty }
 }
 
+struct LLMFunctionTool {
+    let name: String
+    let description: String
+    let parameters: [String: Any]
+
+    var proxyPayload: [String: Any] {
+        [
+            "type": "function",
+            "name": name,
+            "description": description,
+            "parameters": parameters
+        ]
+    }
+}
+
+struct LLMToolCall: Equatable {
+    let id: String
+    let name: String
+    let argumentsJSON: String
+}
+
+struct ProxyLLMCompletion: Equatable {
+    let toolCalls: [LLMToolCall]
+    let reportedToolCalls: Bool
+}
+
 /// A standardized request to an LLM provider
 struct LLMRequest {
     static let defaultTokenBudget = 100_000
@@ -32,16 +58,24 @@ struct LLMRequest {
     /// Maximum tokens to generate (nil for provider default)
     var maxTokens: Int?
 
+    /// Optional function tools. Empty preserves the legacy proxy request byte shape.
+    var tools: [LLMFunctionTool]
+    var toolChoice: String?
+
     init(
         systemPrompt: String,
         messages: [LLMMessage],
         temperature: Double = 0.7,
-        maxTokens: Int? = nil
+        maxTokens: Int? = nil,
+        tools: [LLMFunctionTool] = [],
+        toolChoice: String? = nil
     ) {
         self.systemPrompt = systemPrompt
         self.messages = messages
         self.temperature = temperature
         self.maxTokens = maxTokens
+        self.tools = tools
+        self.toolChoice = toolChoice
     }
 
     /// Convenience initializer for text-only messages
@@ -49,12 +83,16 @@ struct LLMRequest {
         systemPrompt: String,
         textMessages: [(role: String, content: String)],
         temperature: Double = 0.7,
-        maxTokens: Int? = nil
+        maxTokens: Int? = nil,
+        tools: [LLMFunctionTool] = [],
+        toolChoice: String? = nil
     ) {
         self.systemPrompt = systemPrompt
         self.messages = textMessages.map { LLMMessage(role: $0.role, content: $0.content) }
         self.temperature = temperature
         self.maxTokens = maxTokens
+        self.tools = tools
+        self.toolChoice = toolChoice
     }
 
     /// Whether any message in the request contains images
@@ -111,7 +149,9 @@ struct LLMRequest {
                 systemPrompt: systemPrompt,
                 messages: [],
                 temperature: temperature,
-                maxTokens: maxTokens
+                maxTokens: maxTokens,
+                tools: tools,
+                toolChoice: toolChoice
             )
         }
 
@@ -140,7 +180,9 @@ struct LLMRequest {
             systemPrompt: systemPrompt,
             messages: keptMessages,
             temperature: temperature,
-            maxTokens: maxTokens
+            maxTokens: maxTokens,
+            tools: tools,
+            toolChoice: toolChoice
         )
     }
 }

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -80,18 +80,8 @@ final class ProxyLLMService {
         }
 
         // Build request body in proxy format
-        let messages = buildProxyMessages(from: request)
         let provider = SettingsService.shared.defaultModel.provider
-        var requestBody: [String: Any] = [
-            "model": SettingsService.shared.defaultModel.proxyModel,
-            "messages": messages,
-            "provider": provider,
-            "stream": true
-        ]
-        if !request.tools.isEmpty {
-            requestBody["tools"] = request.tools.map(\.proxyPayload)
-            requestBody["tool_choice"] = request.toolChoice ?? "auto"
-        }
+        let requestBody = buildStreamingRequestBody(from: request)
 
         guard let bodyData = try? JSONSerialization.data(withJSONObject: requestBody) else {
             await MainActor.run {
@@ -320,6 +310,20 @@ final class ProxyLLMService {
                 onError(ProxyLLMError.unreachable)
             }
         }
+    }
+
+    func buildStreamingRequestBody(from request: LLMRequest) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": SettingsService.shared.defaultModel.proxyModel,
+            "messages": buildProxyMessages(from: request),
+            "provider": SettingsService.shared.defaultModel.provider,
+            "stream": true
+        ]
+        if !request.tools.isEmpty {
+            body["tools"] = request.tools.map(\.proxyPayload)
+            body["tool_choice"] = request.toolChoice ?? "auto"
+        }
+        return body
     }
 
     // MARK: - Non-Streaming Methods

--- a/Sources/Ticker/Services/ProxyLLMService.swift
+++ b/Sources/Ticker/Services/ProxyLLMService.swift
@@ -59,7 +59,7 @@ final class ProxyLLMService {
         request: LLMRequest,
         onModelSelected: ((String, String) -> Void)? = nil,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping () -> Void,
+        onComplete: @escaping (ProxyLLMCompletion) -> Void,
         onError: @escaping (Error) -> Void
     ) async {
         // Get credentials from device key service
@@ -82,12 +82,16 @@ final class ProxyLLMService {
         // Build request body in proxy format
         let messages = buildProxyMessages(from: request)
         let provider = SettingsService.shared.defaultModel.provider
-        let requestBody: [String: Any] = [
+        var requestBody: [String: Any] = [
             "model": SettingsService.shared.defaultModel.proxyModel,
             "messages": messages,
             "provider": provider,
             "stream": true
         ]
+        if !request.tools.isEmpty {
+            requestBody["tools"] = request.tools.map(\.proxyPayload)
+            requestBody["tool_choice"] = request.toolChoice ?? "auto"
+        }
 
         guard let bodyData = try? JSONSerialization.data(withJSONObject: requestBody) else {
             await MainActor.run {
@@ -195,6 +199,7 @@ final class ProxyLLMService {
             var currentEventType: String?
             var dataLines: [String] = []
             var didReceiveAnyEvent = false
+            var toolCalls: [LLMToolCall] = []
 
             func dispatchEventIfReady() async -> Bool {
                 guard let eventType = currentEventType else {
@@ -210,7 +215,13 @@ final class ProxyLLMService {
                     dataLine: dataLine,
                     requestId: responseRequestId ?? "unknown",
                     onChunk: onChunk,
-                    onComplete: onComplete,
+                    onToolCall: { toolCalls.append($0) },
+                    onComplete: { reportedToolCalls in
+                        onComplete(ProxyLLMCompletion(
+                            toolCalls: toolCalls,
+                            reportedToolCalls: reportedToolCalls
+                        ))
+                    },
                     onError: onError
                 )
 
@@ -249,7 +260,7 @@ final class ProxyLLMService {
                     // isn't delivered, dispatch immediately once we have a complete data line.
                     if let eventType = currentEventType,
                        dataLines.count == 1,
-                       ["delta", "done", "error"].contains(eventType),
+                       ["delta", "tool_call", "done", "error"].contains(eventType),
                        data.hasPrefix("{"),
                        data.hasSuffix("}") {
                         if await dispatchEventIfReady() {
@@ -276,7 +287,9 @@ final class ProxyLLMService {
             }
 
             // Stream ended without done event
-            await MainActor.run { onComplete() }
+            await MainActor.run {
+                onComplete(ProxyLLMCompletion(toolCalls: toolCalls, reportedToolCalls: false))
+            }
 
         } catch let urlError as URLError {
             headerWatchdog.cancel()
@@ -487,7 +500,8 @@ final class ProxyLLMService {
         dataLine: String,
         requestId: String,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping () -> Void,
+        onToolCall: (LLMToolCall) -> Void,
+        onComplete: @escaping (Bool) -> Void,
         onError: @escaping (Error) -> Void
     ) async {
         switch eventType {
@@ -501,10 +515,17 @@ final class ProxyLLMService {
                 await MainActor.run { onChunk(text) }
             }
 
+        case "tool_call":
+            guard let call = Self.parseToolCallEvent(dataLine) else {
+                DebugLog.log("[ProxyLLMService] Dropped malformed tool_call event")
+                return
+            }
+            onToolCall(call)
+
         case "done":
-            // data: {"usage": {...}}
+            // data: {"usage": {...}, "tool_calls": true}
             debugLog("Done event received; completing stream")
-            await MainActor.run { onComplete() }
+            await MainActor.run { onComplete(Self.parseToolCallsFlag(dataLine)) }
 
         case "error":
             // data: {"error": {"code": "...", "message": "...", "details": {...}}}
@@ -540,6 +561,29 @@ final class ProxyLLMService {
         default:
             break
         }
+    }
+
+    static func parseToolCallEvent(_ dataLine: String) -> LLMToolCall? {
+        guard let data = dataLine.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = payload["id"] as? String,
+              !id.isEmpty,
+              let name = payload["name"] as? String,
+              !name.isEmpty,
+              let arguments = payload["arguments"] as? String,
+              let argumentData = arguments.data(using: .utf8),
+              (try? JSONSerialization.jsonObject(with: argumentData)) is [String: Any] else {
+            return nil
+        }
+        return LLMToolCall(id: id, name: name, argumentsJSON: arguments)
+    }
+
+    static func parseToolCallsFlag(_ dataLine: String) -> Bool {
+        guard let data = dataLine.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return payload["tool_calls"] as? Bool ?? false
     }
 
     // MARK: - Error Handling

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1324,6 +1324,7 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertTrue(prepared.request.systemPrompt.contains("web_search"))
     }
 
+    @MainActor
     func test_conversationUpdateBlockToolUsesTheProxyFunctionSchemaOnlyWhenEligible() throws {
         let legacy = try AIOrchestrator.prepareThreadRequest(
             query: "Rewrite this",

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1324,6 +1324,64 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertTrue(prepared.request.systemPrompt.contains("web_search"))
     }
 
+    func test_conversationUpdateBlockToolUsesTheProxyFunctionSchemaOnlyWhenEligible() throws {
+        let legacy = try AIOrchestrator.prepareThreadRequest(
+            query: "Rewrite this",
+            anchorText: "Primary block",
+            streamMarkdown: "Whole stream",
+            priorTurns: [],
+            sourceContext: nil
+        )
+        XCTAssertTrue(legacy.request.tools.isEmpty)
+        XCTAssertNil(legacy.request.toolChoice)
+
+        let prepared = try AIOrchestrator.prepareThreadRequest(
+            query: "Rewrite this",
+            anchorText: "Primary block",
+            streamMarkdown: "Whole stream",
+            priorTurns: [],
+            sourceContext: nil,
+            offerUpdateBlock: true
+        )
+        let tool = try XCTUnwrap(prepared.request.tools.first)
+        XCTAssertEqual(tool.name, "update_block")
+        XCTAssertTrue(tool.description.contains("full replacement markdown"))
+        XCTAssertEqual(prepared.request.toolChoice, "auto")
+        let properties = try XCTUnwrap(tool.parameters["properties"] as? [String: [String: String]])
+        XCTAssertEqual(properties, ["content": ["type": "string"]])
+        XCTAssertEqual(tool.parameters["required"] as? [String], ["content"])
+        XCTAssertEqual(tool.parameters["additionalProperties"] as? Bool, false)
+        XCTAssertEqual(prepared.request.truncated().tools.first?.name, "update_block")
+
+        let streamId = UUID()
+        let normal = StreamThread(streamId: streamId, anchorStart: 1, anchorEnd: 4)
+        let detached = StreamThread(streamId: streamId, anchorStart: 2, anchorEnd: 2, detached: true)
+        let ephemeral = StreamThread(streamId: streamId, anchorStart: 1, anchorEnd: 4, ephemeral: true)
+        XCTAssertTrue(AIMessageHandler.shouldOfferUpdateBlock(thread: normal, anchorStart: 1, anchorEnd: 4))
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: detached, anchorStart: 2, anchorEnd: 2))
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: ephemeral, anchorStart: 1, anchorEnd: 4))
+    }
+
+    func test_proxyParsesCompleteToolCallsAndDropsMalformedArguments() {
+        let valid = #"{"id":"call-1","name":"update_block","arguments":"{\"content\":\"New text.\"}"}"#
+        XCTAssertEqual(
+            ProxyLLMService.parseToolCallEvent(valid),
+            LLMToolCall(
+                id: "call-1",
+                name: "update_block",
+                argumentsJSON: #"{"content":"New text."}"#
+            )
+        )
+        XCTAssertNil(ProxyLLMService.parseToolCallEvent(
+            #"{"id":"call-1","name":"update_block","arguments":"{bad"}"#
+        ))
+        XCTAssertNil(ProxyLLMService.parseToolCallEvent(
+            #"{"id":"call-1","name":"update_block","arguments":"[]"}"#
+        ))
+        XCTAssertTrue(ProxyLLMService.parseToolCallsFlag(#"{"usage":{},"tool_calls":true}"#))
+        XCTAssertFalse(ProxyLLMService.parseToolCallsFlag(#"{"usage":{}}"#))
+    }
+
     func test_threadAIRequestRefusesOneTokenPastProtectedBoundary() throws {
         let fitted = try AIOrchestrator.prepareThreadRequest(
             query: "Question",
@@ -1678,7 +1736,7 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { query, retrievalQuery, _, _, anchorText, streamMarkdown, pinned, turns, researchProfile, onPrepared, onChunk, onComplete, _, onModelSelected in
+                routeThreadAI: { query, retrievalQuery, _, _, anchorText, streamMarkdown, pinned, turns, researchProfile, offerUpdateBlock, onPrepared, onChunk, onComplete, _, onModelSelected in
                     routedQuery = query
                     routedRetrievalQuery = retrievalQuery
                     XCTAssertEqual(anchorText, thread.anchorText)
@@ -1686,6 +1744,7 @@ final class StreamDocumentTests: XCTestCase {
                     XCTAssertEqual(pinned.map(\.quote), ["A second constraint."])
                     XCTAssertEqual(turns.map(\.requestId), [prior.requestId])
                     XCTAssertTrue(researchProfile)
+                    XCTAssertTrue(offerUpdateBlock)
                     let receipt = ThreadAIRequestReceipt(
                         sourceContext: SourceContext(
                             text: sentSource.extractedText ?? "",
@@ -1699,7 +1758,7 @@ final class StreamDocumentTests: XCTestCase {
                     onPrepared(receipt)
                     onModelSelected?("provider/model")
                     onChunk("A grounded reply.")
-                    onComplete(receipt)
+                    onComplete(receipt, ProxyLLMCompletion(toolCalls: [], reportedToolCalls: false))
                 }
             )
             let rawPrompt = "Use [this thread](ticker-thread://private-prompt)."
@@ -1753,6 +1812,73 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(afterDocument.revision, beforeDocument.revision)
             XCTAssertEqual(recorder.messages(ofType: "threadAIContext").count, 1)
             XCTAssertEqual(recorder.messages(ofType: "documentAIComplete").count, 1)
+            let completion = try XCTUnwrap(recorder.messages(ofType: "documentAIComplete").last)
+            XCTAssertEqual(completion.payload?["toolCalls"]?.value as? Bool, false)
+            XCTAssertNil(completion.payload?["toolCall"])
+        }
+    }
+
+    @MainActor
+    func test_conversationToolCallPersistsAVisibleTurnAndCompletesWithTheCall() async throws {
+        try await withTempPersistenceService { service in
+            let stream = Stream(title: "Tool call")
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "Original passage.",
+                anchorStart: 1,
+                anchorEnd: 18
+            )
+            try service.saveStream(stream)
+            try service.createStreamThread(thread)
+            let recorder = BridgeMessageRecorder()
+            let receipt = ThreadAIRequestReceipt(
+                sourceContext: nil,
+                includedPriorRequestIds: [],
+                totalPriorExchangeCount: 0
+            )
+            let handler = AIMessageHandler(
+                persistence: service,
+                sendToWeb: { recorder.send($0) },
+                routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
+                routeThreadAI: { _, _, _, _, _, _, _, _, _, offerUpdateBlock, onPrepared, _, onComplete, _, _ in
+                    XCTAssertTrue(offerUpdateBlock)
+                    onPrepared(receipt)
+                    onComplete(receipt, ProxyLLMCompletion(
+                        toolCalls: [LLMToolCall(
+                            id: "call-1",
+                            name: "update_block",
+                            argumentsJSON: #"{"content":"Rewritten passage.","from":0,"to":999999}"#
+                        )],
+                        reportedToolCalls: true
+                    ))
+                }
+            )
+
+            await handler.handle(BridgeMessage(type: "thinkDocument", payload: [
+                "requestId": AnyCodable("tool-request"),
+                "streamId": AnyCodable(stream.id.uuidString),
+                "threadId": AnyCodable(thread.threadId.uuidString),
+                "query": AnyCodable("Rewrite this"),
+                "anchorStart": AnyCodable(1),
+                "anchorEnd": AnyCodable(18),
+                "imageURLs": AnyCodable([])
+            ]))
+
+            try await waitUntil { (try? service.loadExchange(requestId: "tool-request")) != nil }
+            let exchange = try XCTUnwrap(try service.loadExchange(requestId: "tool-request"))
+            XCTAssertEqual(exchange.responseRaw, "Rewritten passage.")
+            let factsData = try XCTUnwrap(exchange.sourceManifest.data(using: .utf8))
+            let facts = try XCTUnwrap(JSONSerialization.jsonObject(with: factsData) as? [String: Any])
+            let edit = try XCTUnwrap(facts["updateBlock"] as? [String: Any])
+            XCTAssertEqual(edit["before"] as? String, "Original passage.")
+            XCTAssertEqual(edit["after"] as? String, "Rewritten passage.")
+            XCTAssertNil(edit["applied"])
+
+            let completion = try XCTUnwrap(recorder.messages(ofType: "documentAIComplete").last)
+            XCTAssertEqual(completion.payload?["toolCalls"]?.value as? Bool, true)
+            let call = try XCTUnwrap(completion.payload?["toolCall"]?.value as? [String: Any])
+            XCTAssertEqual(call["name"] as? String, "update_block")
+            XCTAssertEqual(call["arguments"] as? String, #"{"content":"Rewritten passage.","from":0,"to":999999}"#)
         }
     }
 
@@ -1769,7 +1895,7 @@ final class StreamDocumentTests: XCTestCase {
                 persistence: service,
                 sendToWeb: { recorder.send($0) },
                 routeDocumentAI: { _, _, _, _, _, _, _, _, _, _, _ in },
-                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
+                routeThreadAI: { _, _, _, _, _, _, _, _, _, _, _, _, _, onError, _ in
                     onError(ThreadAIRequestError.contextTooLarge(
                         largestBlock: "Your note",
                         protectedTokens: 98_000,
@@ -2251,6 +2377,45 @@ final class StreamDocumentTests: XCTestCase {
             ), [])
             XCTAssertNil(try service.loadStreamThread(threadId: thread.threadId, streamId: stream.id))
             XCTAssertNil(try service.loadExchange(requestId: exchange.requestId))
+        }
+    }
+
+    func test_threadToolApplicationUpdatesThePersistedReceipt() throws {
+        try withTempPersistenceService { service in
+            let stream = Stream(title: "Tool receipt")
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "Original passage.",
+                anchorStart: 1,
+                anchorEnd: 18
+            )
+            try service.saveStream(stream)
+            try service.createStreamThread(thread)
+            try service.saveExchange(AIExchange(
+                requestId: "tool-result",
+                streamId: stream.id,
+                threadId: thread.threadId,
+                verb: "thread",
+                userInput: "Rewrite this",
+                sourceManifest: #"{"version":2,"kind":"threadAI","updateBlock":{"before":"Sent passage.","after":"Rewritten passage."}}"#,
+                responseRaw: "Rewritten passage."
+            ))
+
+            let updated = try service.recordThreadToolApplication(
+                requestId: "tool-result",
+                streamId: stream.id,
+                before: "Original passage.",
+                applied: true,
+                failure: nil
+            )
+            let data = try XCTUnwrap(updated.sourceManifest.data(using: .utf8))
+            let receipt = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let edit = try XCTUnwrap(receipt["updateBlock"] as? [String: Any])
+            XCTAssertEqual(edit["before"] as? String, "Original passage.")
+            XCTAssertEqual(edit["after"] as? String, "Rewritten passage.")
+            XCTAssertEqual(edit["applied"] as? Bool, true)
+            XCTAssertNil(edit["failure"] as? String)
+            XCTAssertEqual(try service.loadExchange(requestId: "tool-result")?.sourceManifest, updated.sourceManifest)
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -1353,14 +1353,70 @@ final class StreamDocumentTests: XCTestCase {
         XCTAssertEqual(tool.parameters["required"] as? [String], ["content"])
         XCTAssertEqual(tool.parameters["additionalProperties"] as? Bool, false)
         XCTAssertEqual(prepared.request.truncated().tools.first?.name, "update_block")
+        let toolBody = ProxyLLMService().buildStreamingRequestBody(from: prepared.request)
+        XCTAssertEqual((toolBody["tools"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(toolBody["tool_choice"] as? String, "auto")
 
         let streamId = UUID()
         let normal = StreamThread(streamId: streamId, anchorStart: 1, anchorEnd: 4)
-        let detached = StreamThread(streamId: streamId, anchorStart: 2, anchorEnd: 2, detached: true)
+        let detached = StreamThread(streamId: streamId, anchorStart: 1, anchorEnd: 4, detached: true)
         let ephemeral = StreamThread(streamId: streamId, anchorStart: 1, anchorEnd: 4, ephemeral: true)
+        let missingAnchor = StreamThread(streamId: streamId)
         XCTAssertTrue(AIMessageHandler.shouldOfferUpdateBlock(thread: normal, anchorStart: 1, anchorEnd: 4))
-        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: detached, anchorStart: 2, anchorEnd: 2))
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: normal, anchorStart: 2, anchorEnd: 2))
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: detached, anchorStart: 1, anchorEnd: 4))
         XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: ephemeral, anchorStart: 1, anchorEnd: 4))
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: missingAnchor, anchorStart: 1, anchorEnd: 4))
+    }
+
+    @MainActor
+    func test_pdfQuoteConversationRequestCarriesNoUpdateBlockTool() throws {
+        let pdfQuote = StreamThread(
+            streamId: UUID(),
+            sourceId: UUID(),
+            highlightId: UUID(),
+            anchorStart: 1,
+            anchorEnd: 4
+        )
+        XCTAssertFalse(AIMessageHandler.shouldOfferUpdateBlock(thread: pdfQuote, anchorStart: 1, anchorEnd: 4))
+        let pdfRequest = try AIOrchestrator.prepareThreadRequest(
+            query: "Rewrite this",
+            anchorText: "Verbatim quote",
+            streamMarkdown: "Whole stream",
+            priorTurns: [],
+            sourceContext: nil,
+            offerUpdateBlock: AIMessageHandler.shouldOfferUpdateBlock(
+                thread: pdfQuote,
+                anchorStart: 1,
+                anchorEnd: 4
+            )
+        )
+        XCTAssertTrue(pdfRequest.request.tools.isEmpty)
+        XCTAssertNil(ProxyLLMService().buildStreamingRequestBody(from: pdfRequest.request)["tools"])
+    }
+
+    @MainActor
+    func test_documentAndQuickPanelOutgoingProxyPayloadsOmitConversationTools() {
+        let proxy = ProxyLLMService()
+        let orchestrator = AIOrchestrator(proxyService: proxy)
+        let document = orchestrator.buildRequest(
+            query: "Develop this",
+            queryImages: [],
+            priorCells: [],
+            sourceContext: nil
+        )
+        let quickPanel = orchestrator.buildRequest(
+            query: "Think out loud",
+            queryImages: [],
+            priorCells: [],
+            sourceContext: nil,
+            systemPromptOverride: Prompts.quickPanelChat
+        )
+        for (path, request) in [("document AI", document), ("quick panel", quickPanel)] {
+            let body = proxy.buildStreamingRequestBody(from: request)
+            XCTAssertNil(body["tools"], "\(path) must not send conversation tools")
+            XCTAssertNil(body["tool_choice"], "\(path) must not send conversation tool choice")
+        }
     }
 
     func test_proxyParsesCompleteToolCallsAndDropsMalformedArguments() {
@@ -1820,7 +1876,7 @@ final class StreamDocumentTests: XCTestCase {
     }
 
     @MainActor
-    func test_conversationToolCallPersistsAVisibleTurnAndCompletesWithTheCall() async throws {
+    func test_conversationUsesFirstUpdateBlockCallAndPersistsAVisibleTurn() async throws {
         try await withTempPersistenceService { service in
             let stream = Stream(title: "Tool call")
             let thread = StreamThread(
@@ -1845,11 +1901,18 @@ final class StreamDocumentTests: XCTestCase {
                     XCTAssertTrue(offerUpdateBlock)
                     onPrepared(receipt)
                     onComplete(receipt, ProxyLLMCompletion(
-                        toolCalls: [LLMToolCall(
-                            id: "call-1",
-                            name: "update_block",
-                            argumentsJSON: #"{"content":"Rewritten passage.","from":0,"to":999999}"#
-                        )],
+                        toolCalls: [
+                            LLMToolCall(
+                                id: "call-1",
+                                name: "update_block",
+                                argumentsJSON: #"{"content":"Rewritten passage.","from":0,"to":999999}"#
+                            ),
+                            LLMToolCall(
+                                id: "call-2",
+                                name: "update_block",
+                                argumentsJSON: #"{"content":"Second replacement must be ignored."}"#
+                            )
+                        ],
                         reportedToolCalls: true
                     ))
                 }
@@ -2417,6 +2480,72 @@ final class StreamDocumentTests: XCTestCase {
             XCTAssertEqual(edit["applied"] as? Bool, true)
             XCTAssertNil(edit["failure"] as? String)
             XCTAssertEqual(try service.loadExchange(requestId: "tool-result")?.sourceManifest, updated.sourceManifest)
+        }
+    }
+
+    @MainActor
+    func test_threadToolApplicationBridgeAcceptsOnlyTheClosedFailureSet() async throws {
+        try await withTempPersistenceService { service in
+            let stream = Stream(title: "Tool failures")
+            let thread = StreamThread(
+                streamId: stream.id,
+                anchorText: "Original passage.",
+                anchorStart: 1,
+                anchorEnd: 18
+            )
+            try service.saveStream(stream)
+            try service.createStreamThread(thread)
+            try service.saveExchange(AIExchange(
+                requestId: "failed-tool-result",
+                streamId: stream.id,
+                threadId: thread.threadId,
+                verb: "thread",
+                userInput: "Rewrite this",
+                sourceManifest: #"{"updateBlock":{"before":"Sent.","after":"Proposal."}}"#,
+                responseRaw: "Proposal."
+            ))
+            let recorder = BridgeMessageRecorder()
+            let handler = ThreadMessageHandler(persistence: service, sendToWeb: recorder.send)
+            let failures = [
+                "passage_changed", "partial_anchor", "surface_closed", "thread_mismatch", "apply_error"
+            ]
+            for failure in failures {
+                await handler.handle(BridgeMessage(
+                    type: "recordThreadToolApplication",
+                    payload: [
+                        "streamId": AnyCodable(stream.id.uuidString),
+                        "requestId": AnyCodable("failed-tool-result"),
+                        "before": AnyCodable("Current passage."),
+                        "applied": AnyCodable(false),
+                        "failure": AnyCodable(failure)
+                    ],
+                    callbackId: failure
+                ))
+                let response = try XCTUnwrap(
+                    recorder.messages(ofType: "callback").first { $0.callbackId == failure }
+                )
+                XCTAssertNil(response.payload?["error"])
+                let exchange = try XCTUnwrap(try service.loadExchange(requestId: "failed-tool-result"))
+                let data = try XCTUnwrap(exchange.sourceManifest.data(using: .utf8))
+                let receipt = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                let update = try XCTUnwrap(receipt["updateBlock"] as? [String: Any])
+                XCTAssertEqual(update["failure"] as? String, failure)
+            }
+
+            await handler.handle(BridgeMessage(
+                type: "recordThreadToolApplication",
+                payload: [
+                    "streamId": AnyCodable(stream.id.uuidString),
+                    "requestId": AnyCodable("failed-tool-result"),
+                    "before": AnyCodable("Current passage."),
+                    "applied": AnyCodable(false),
+                    "failure": AnyCodable("made_up")
+                ],
+                callbackId: "made-up"
+            ))
+            XCTAssertNotNil(recorder.messages(ofType: "callback").first {
+                $0.callbackId == "made-up"
+            }?.payload?["error"])
         }
     }
 

--- a/Tests/TickerTests/StreamDocumentTests.swift
+++ b/Tests/TickerTests/StreamDocumentTests.swift
@@ -2704,6 +2704,7 @@ final class StreamDocumentTests: XCTestCase {
                 "createStreamThread",
                 "deleteStreamThread",
                 "loadStreamThread",
+                "recordThreadToolApplication",
                 "removeStreamThreadAnchor",
                 "saveStreamThread"
             ])

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -5,6 +5,7 @@ import {
   loadStreamThread,
   removeStreamThreadAnchor,
   type ConversationToolCall,
+  type ConversationToolFailure,
 } from '../types/bridge';
 import type {
   AIExchangeJSON,
@@ -95,6 +96,14 @@ export interface ConversationContextOption {
 
 const copy = (text: string) => void navigator.clipboard?.writeText(text);
 
+const toolFailureCopy: Record<ConversationToolFailure, string> = {
+  passage_changed: "couldn't apply — passage changed",
+  partial_anchor: "couldn't apply — select the whole passage",
+  surface_closed: "couldn't apply — conversation closed",
+  thread_mismatch: "couldn't apply — conversation changed",
+  apply_error: "couldn't apply — edit failed",
+};
+
 function ThreadContextDisclosure({ value }: { value: unknown }) {
   const receipt = parseThreadAISentFacts(value);
   if (!receipt) return null;
@@ -149,7 +158,7 @@ const Turn = memo(function Turn({
 }) {
   const facts = parseThreadAISentFacts(receipt);
   const update = facts?.updateBlock;
-  const visibleText = update?.applied === false
+  const visibleText = update && update.applied !== true
     ? update.after || 'Clear this block.'
     : text;
   return (
@@ -159,15 +168,18 @@ const Turn = memo(function Turn({
       {update?.applied === true && (
         <p className="conversation-tool-note">AI edited this block · ⌘Z undoes it</p>
       )}
+      {update && update.applied === undefined && (
+        <p className="conversation-tool-note">Proposed edit (not applied)</p>
+      )}
       {update?.applied === false && (
-        <p className="conversation-tool-note">couldn't apply — passage changed</p>
+        <p className="conversation-tool-note">{toolFailureCopy[update.failure!]}</p>
       )}
       {who === 'AI' && <ThreadContextDisclosure value={receipt} />}
       <div className="conversation-turn-controls">
         {exchange && onPromote && (
           <button type="button" onClick={() => onPromote(exchange)}>↑ Add to Stream</button>
         )}
-        <button type="button" onClick={() => copy(text)}>Copy</button>
+        <button type="button" onClick={() => copy(visibleText)}>Copy</button>
       </div>
     </div>
   );
@@ -252,17 +264,21 @@ export function ConversationSurface({
       activeRequestId.current = null;
       const exchange = payload.exchange as AIExchangeJSON | undefined;
       const toolCall = payload.toolCall as ConversationToolCall | null | undefined;
+      updateState(conversationKey, (current) => ({
+        ...current,
+        exchanges: exchange?.requestId === requestId
+          ? [...current.exchanges, exchange]
+          : current.exchanges,
+        active: null,
+      }));
       void (async () => {
-        const completed = exchange?.requestId === requestId
-          && toolCall?.name === 'update_block'
-          ? await onUpdateBlock(exchange, toolCall).catch(() => exchange)
-          : exchange;
+        if (exchange?.requestId !== requestId || toolCall?.name !== 'update_block') return;
+        const completed = await onUpdateBlock(exchange, toolCall).catch(() => exchange);
         updateState(conversationKey, (current) => ({
           ...current,
-          exchanges: completed?.requestId === requestId
-            ? [...current.exchanges, completed]
-            : current.exchanges,
-          active: null,
+          exchanges: current.exchanges.map((candidate) => (
+            candidate.requestId === requestId ? completed : candidate
+          )),
         }));
       })();
       return;

--- a/Web/src/components/ConversationSurface.tsx
+++ b/Web/src/components/ConversationSurface.tsx
@@ -4,6 +4,7 @@ import {
   bridge,
   loadStreamThread,
   removeStreamThreadAnchor,
+  type ConversationToolCall,
 } from '../types/bridge';
 import type {
   AIExchangeJSON,
@@ -73,6 +74,7 @@ interface ConversationSurfaceProps {
   ) => Promise<StreamThreadJSON>;
   hasDrifted: (anchorText: string) => boolean;
   onPromote: (exchange: AIExchangeJSON) => void;
+  onUpdateBlock: (exchange: AIExchangeJSON, toolCall: ConversationToolCall) => Promise<AIExchangeJSON>;
   onKeep: () => void;
   onCollapse: () => void;
 }
@@ -114,6 +116,12 @@ function ThreadContextDisclosure({ value }: { value: unknown }) {
           </p>
         ))}
         {receipt.profile === 'research' && <p><span>Research profile</span></p>}
+        {receipt.updateBlock && (
+          <>
+            <p><span>Before edit</span> {receipt.updateBlock.before || 'Empty'}</p>
+            <p><span>After edit</span> {receipt.updateBlock.after || 'Empty'}</p>
+          </>
+        )}
         <p>
           <span>Sources</span> {retrieval}
           {receipt.sources.length > 0
@@ -139,10 +147,21 @@ const Turn = memo(function Turn({
   exchange?: AIExchangeJSON;
   onPromote?: (exchange: AIExchangeJSON) => void;
 }) {
+  const facts = parseThreadAISentFacts(receipt);
+  const update = facts?.updateBlock;
+  const visibleText = update?.applied === false
+    ? update.after || 'Clear this block.'
+    : text;
   return (
     <div className={`conversation-turn conversation-turn--${who === 'You' ? 'you' : 'ai'}`}>
       <span className="conversation-turn-label">{who}</span>
-      <div className="conversation-turn-text">{text}</div>
+      <div className="conversation-turn-text">{visibleText}</div>
+      {update?.applied === true && (
+        <p className="conversation-tool-note">AI edited this block · ⌘Z undoes it</p>
+      )}
+      {update?.applied === false && (
+        <p className="conversation-tool-note">couldn't apply — passage changed</p>
+      )}
       {who === 'AI' && <ThreadContextDisclosure value={receipt} />}
       <div className="conversation-turn-controls">
         {exchange && onPromote && (
@@ -173,6 +192,7 @@ export function ConversationSurface({
   createThread,
   hasDrifted,
   onPromote,
+  onUpdateBlock,
   onKeep,
   onCollapse,
 }: ConversationSurfaceProps) {
@@ -231,13 +251,20 @@ export function ConversationSurface({
     if (message.type === 'documentAIComplete') {
       activeRequestId.current = null;
       const exchange = payload.exchange as AIExchangeJSON | undefined;
-      updateState(conversationKey, (current) => ({
-        ...current,
-        exchanges: exchange?.requestId === requestId
-          ? [...current.exchanges, exchange]
-          : current.exchanges,
-        active: null,
-      }));
+      const toolCall = payload.toolCall as ConversationToolCall | null | undefined;
+      void (async () => {
+        const completed = exchange?.requestId === requestId
+          && toolCall?.name === 'update_block'
+          ? await onUpdateBlock(exchange, toolCall).catch(() => exchange)
+          : exchange;
+        updateState(conversationKey, (current) => ({
+          ...current,
+          exchanges: completed?.requestId === requestId
+            ? [...current.exchanges, completed]
+            : current.exchanges,
+          active: null,
+        }));
+      })();
       return;
     }
     if (message.type === 'documentAIError') {
@@ -255,7 +282,7 @@ export function ConversationSurface({
         }
         : current);
     }
-  }), [conversationKey, updateState]);
+  }), [conversationKey, onUpdateBlock, updateState]);
 
   const send = async () => {
     const snapshot = stateRef.current;

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -16,7 +16,9 @@ import type {
   StreamThreadJSON,
 } from '../types/models';
 import { DocumentSession } from '../richtext/session';
-import { parseMarkdown } from '../richtext/markdown';
+import { parseMarkdown, serializeMarkdown } from '../richtext/markdown';
+import { aiWritingRange } from '../richtext/operations';
+import { provenanceSpans } from '../richtext/provenance';
 import { useToastStore } from '../store/toastStore';
 import { fnv1a } from '../utils/fnv1a';
 import { RichStreamEditor } from './RichStreamEditor';
@@ -143,8 +145,8 @@ async function enterPrompt(value: string) {
   });
 }
 
-async function openDraftConversation(): Promise<HTMLTextAreaElement> {
-  const block = editor().querySelector('p') as HTMLParagraphElement;
+async function openDraftConversation(blockIndex = 0): Promise<HTMLTextAreaElement> {
+  const block = editor().querySelectorAll('p')[blockIndex] as HTMLParagraphElement;
   await vi.waitFor(() => expect(block.classList.contains('conversation-block-active')).toBe(true));
   vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
     left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
@@ -527,7 +529,7 @@ describe('RichStreamEditor inline conversations', () => {
     await vi.waitFor(() => expect(document.activeElement).toBe(editor()));
   });
 
-  it('round-trips the v2 receipt from send through completion and disclosure rendering', async () => {
+  it('round-trips the v2 receipt and completes normally when the proxy emits no tool call', async () => {
     const createdAt = new Date(0).toISOString();
     vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
       if (type === 'createStreamThread') {
@@ -641,12 +643,251 @@ describe('RichStreamEditor inline conversations', () => {
     expect(disclosure.textContent).toContain('Pinned Stream Pinned constraint.');
     expect(disclosure.textContent).toContain('Retrieved passages · Manual p.4');
     expect(disclosure.textContent).toContain('Prior turns 0 of 0');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.some(
+      ([type]) => type === 'recordThreadToolApplication',
+    )).toBe(false);
 
     await vi.waitFor(() => {
       const save = vi.mocked(bridge.sendAsync).mock.calls
         .find(([type]) => type === 'saveRichStreamDocument');
       expect(save?.[1]?.docJSON).not.toContain('Does this hold?');
       expect(save?.[1]?.docJSON).not.toContain('It streams.');
+    });
+  });
+
+  it('applies update_block only to the live anchor despite adversarial offsets and undoes byte-exactly', async () => {
+    const id = 'update-block-stream';
+    const createdAt = new Date(0).toISOString();
+    let liveView: EditorView | null = null;
+    let completedExchange: AIExchangeJSON | null = null;
+    const updateState = EditorView.prototype.updateState;
+    vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+      this: EditorView,
+      state,
+    ) {
+      liveView = this;
+      return updateState.call(this, state);
+    });
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'update-thread', streamId: id, title: String(payload?.title), workingText: '',
+          anchorText: String(payload?.anchorText), anchorStart: Number(payload?.anchorStart),
+          anchorEnd: Number(payload?.anchorEnd), detached: false, ephemeral: false, revision: 0,
+          createdAt, updatedAt: createdAt, exchanges: [],
+        },
+      };
+      if (type === 'recordThreadToolApplication') {
+        const sourceManifest = JSON.stringify({
+          ...JSON.parse(completedExchange!.sourceManifest) as Record<string, unknown>,
+          updateBlock: {
+            before: payload?.before,
+            after: '# Replacement\n\nFirst.\n\n- one\n- two',
+            applied: payload?.applied,
+            failure: payload?.failure ?? null,
+          },
+        });
+        return { exchange: { ...completedExchange!, sourceManifest } };
+      }
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    await renderStream({
+      ...stream,
+      id,
+      document: {
+        ...stream.document,
+        streamId: id,
+        docJSON: docJSON('Outside before.\n\nTarget text.\n\nOutside after.'),
+        markdown: 'Outside before.\n\nTarget text.\n\nOutside after.',
+      },
+    });
+    await selectEditorText('Target');
+    const composer = await openDraftConversation(1);
+    await enterConversationMessage(composer, 'Rewrite this block');
+    const beforeMarkdown = serializeMarkdown(liveView!.state.doc);
+    const beforeJSON = JSON.stringify(liveView!.state.doc.toJSON());
+    const beforeFirst = liveView!.state.doc.firstChild!.toJSON();
+    const beforeLast = liveView!.state.doc.lastChild!.toJSON();
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    const requestId = activeRequestId();
+    const pendingReceipt = {
+      version: 2,
+      kind: 'threadAI',
+      requestId,
+      anchor: { kind: 'stream', text: 'Target text.', from: 18, to: 30 },
+      streamDocument: { sent: true, charCount: beforeMarkdown.length },
+      note: { sent: false },
+      turns: { includedRequestIds: [], totalAtSend: 0 },
+      sourceContextMode: 'none',
+      sources: [],
+      pinned: [],
+      updateBlock: { before: 'Target text.', after: '# Replacement\n\nFirst.\n\n- one\n- two' },
+    };
+    completedExchange = {
+      requestId,
+      streamId: id,
+      threadId: 'update-thread',
+      verb: 'thread',
+      userInput: 'Rewrite this block',
+      sourceManifest: JSON.stringify(pendingReceipt),
+      responseRaw: '# Replacement\n\nFirst.\n\n- one\n- two',
+      createdAt,
+    };
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: completedExchange!,
+          toolCalls: true,
+          toolCall: {
+            id: 'call-1',
+            name: 'update_block',
+            arguments: JSON.stringify({
+              content: '# Replacement\n\nFirst.\n\n- one\n- two',
+              from: 0,
+              to: 999_999,
+            }),
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(vi.mocked(bridge.sendAsync).mock.calls.some(
+      ([type]) => type === 'recordThreadToolApplication',
+    )).toBe(true));
+
+    expect(serializeMarkdown(liveView!.state.doc)).toBe(
+      'Outside before.\n\n# Replacement\n\nFirst.\n\n* one\n* two\n\nOutside after.',
+    );
+    expect(liveView!.state.doc.firstChild!.toJSON()).toEqual(beforeFirst);
+    expect(liveView!.state.doc.lastChild!.toJSON()).toEqual(beforeLast);
+    expect(aiWritingRange(liveView!.state)).not.toBe(null);
+    expect(provenanceSpans(liveView!.state)).toEqual([
+      expect.objectContaining({ origin: 'ai', requestId, meta: expect.objectContaining({ threadId: 'update-thread' }) }),
+    ]);
+    expect(document.querySelector('.conversation-tool-note')?.textContent)
+      .toBe('AI edited this block · ⌘Z undoes it');
+    const disclosure = document.querySelector('.conversation-receipt') as HTMLDetailsElement;
+    await act(async () => { (disclosure.querySelector('summary') as HTMLElement).click(); });
+    expect(disclosure.textContent).toContain('Before edit Target text.');
+    expect(disclosure.textContent).toContain('After edit # Replacement');
+
+    await act(async () => {
+      const undoEvent = new KeyboardEvent('keydown', {
+        key: 'z', ctrlKey: true, bubbles: true, cancelable: true,
+      });
+      liveView!.someProp('handleKeyDown', (handler) => handler(liveView!, undoEvent));
+    });
+    expect(serializeMarkdown(liveView!.state.doc)).toBe(beforeMarkdown);
+    expect(JSON.stringify(liveView!.state.doc.toJSON())).toBe(beforeJSON);
+    expect(provenanceSpans(liveView!.state)).toEqual([]);
+  });
+
+  it('renders an update_block proposal without applying when the live passage drifted', async () => {
+    const createdAt = new Date(0).toISOString();
+    let liveView: EditorView | null = null;
+    let completedExchange: AIExchangeJSON | null = null;
+    const updateState = EditorView.prototype.updateState;
+    vi.spyOn(EditorView.prototype, 'updateState').mockImplementation(function captureView(
+      this: EditorView,
+      state,
+    ) {
+      liveView = this;
+      return updateState.call(this, state);
+    });
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type, payload) => {
+      if (type === 'createStreamThread') return {
+        thread: {
+          threadId: 'drift-thread', streamId: stream.id, title: String(payload?.title), workingText: '',
+          anchorText: 'Original paragraph.', anchorStart: 1, anchorEnd: 20,
+          detached: false, ephemeral: false, revision: 0,
+          createdAt, updatedAt: createdAt, exchanges: [],
+        },
+      };
+      if (type === 'recordThreadToolApplication') return {
+        exchange: {
+          ...completedExchange!,
+          sourceManifest: JSON.stringify({
+            ...JSON.parse(completedExchange!.sourceManifest) as Record<string, unknown>,
+            updateBlock: {
+              before: payload?.before,
+              after: 'Proposed replacement.',
+              applied: false,
+              failure: 'passage_changed',
+            },
+          }),
+        },
+      };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    const composer = await openDraftConversation();
+    await enterConversationMessage(composer, 'Rewrite this block');
+    await act(async () => {
+      composer.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    const requestId = activeRequestId();
+    await act(async () => {
+      liveView!.dispatch(liveView!.state.tr.insertText('Altered', 1, 9));
+    });
+    const changed = serializeMarkdown(liveView!.state.doc);
+    const receipt = {
+      version: 2,
+      kind: 'threadAI',
+      requestId,
+      anchor: { kind: 'stream', text: 'Original paragraph.', from: 1, to: 20 },
+      streamDocument: { sent: true, charCount: 19 },
+      note: { sent: false },
+      turns: { includedRequestIds: [], totalAtSend: 0 },
+      sourceContextMode: 'none',
+      sources: [],
+      pinned: [],
+      updateBlock: { before: 'Original paragraph.', after: 'Proposed replacement.' },
+    };
+    completedExchange = {
+      requestId,
+      streamId: stream.id,
+      threadId: 'drift-thread',
+      verb: 'thread',
+      userInput: 'Rewrite this block',
+      sourceManifest: JSON.stringify(receipt),
+      responseRaw: 'I proposed an edit.',
+      createdAt,
+    };
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId,
+          exchange: completedExchange!,
+          toolCalls: true,
+          toolCall: {
+            id: 'call-2', name: 'update_block',
+            arguments: JSON.stringify({ content: 'Proposed replacement.' }),
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(document.querySelector('.conversation-tool-note')?.textContent)
+      .toBe("couldn't apply — passage changed"));
+    expect(serializeMarkdown(liveView!.state.doc)).toBe(changed);
+    expect(document.querySelector('.conversation-turn--ai .conversation-turn-text')?.textContent)
+      .toBe('Proposed replacement.');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.find(
+      ([type]) => type === 'recordThreadToolApplication',
+    )?.[1]).toMatchObject({
+      before: 'Altered paragraph.',
+      applied: false,
+      failure: 'passage_changed',
     });
   });
 

--- a/Web/src/components/RichStreamEditor.test.tsx
+++ b/Web/src/components/RichStreamEditor.test.tsx
@@ -687,6 +687,7 @@ describe('RichStreamEditor inline conversations', () => {
             failure: payload?.failure ?? null,
           },
         });
+        await new Promise((resolve) => window.setTimeout(resolve, 50));
         return { exchange: { ...completedExchange!, sourceManifest } };
       }
       return { revision: 2 };
@@ -697,8 +698,8 @@ describe('RichStreamEditor inline conversations', () => {
       document: {
         ...stream.document,
         streamId: id,
-        docJSON: docJSON('Outside before.\n\nTarget text.\n\nOutside after.'),
-        markdown: 'Outside before.\n\nTarget text.\n\nOutside after.',
+        docJSON: docJSON('Outside before.\n\nTarget **text**.\n\nOutside after.'),
+        markdown: 'Outside before.\n\nTarget **text**.\n\nOutside after.',
       },
     });
     await selectEditorText('Target');
@@ -761,6 +762,7 @@ describe('RichStreamEditor inline conversations', () => {
     await vi.waitFor(() => expect(vi.mocked(bridge.sendAsync).mock.calls.some(
       ([type]) => type === 'recordThreadToolApplication',
     )).toBe(true));
+    expect(document.querySelector('.conversation-stop')).toBe(null);
 
     expect(serializeMarkdown(liveView!.state.doc)).toBe(
       'Outside before.\n\n# Replacement\n\nFirst.\n\n* one\n* two\n\nOutside after.',
@@ -771,12 +773,16 @@ describe('RichStreamEditor inline conversations', () => {
     expect(provenanceSpans(liveView!.state)).toEqual([
       expect.objectContaining({ origin: 'ai', requestId, meta: expect.objectContaining({ threadId: 'update-thread' }) }),
     ]);
+    await act(async () => { await new Promise((resolve) => window.setTimeout(resolve, 60)); });
     expect(document.querySelector('.conversation-tool-note')?.textContent)
       .toBe('AI edited this block · ⌘Z undoes it');
     const disclosure = document.querySelector('.conversation-receipt') as HTMLDetailsElement;
     await act(async () => { (disclosure.querySelector('summary') as HTMLElement).click(); });
-    expect(disclosure.textContent).toContain('Before edit Target text.');
+    expect(disclosure.textContent).toContain('Before edit Target **text**.');
     expect(disclosure.textContent).toContain('After edit # Replacement');
+    expect(vi.mocked(bridge.sendAsync).mock.calls.find(
+      ([type]) => type === 'recordThreadToolApplication',
+    )?.[1]?.before).toBe('Target **text**.');
 
     await act(async () => {
       const undoEvent = new KeyboardEvent('keydown', {
@@ -789,7 +795,7 @@ describe('RichStreamEditor inline conversations', () => {
     expect(provenanceSpans(liveView!.state)).toEqual([]);
   });
 
-  it('renders an update_block proposal without applying when the live passage drifted', async () => {
+  it('renders update_block proposals without applying for drifted passages or mismatched threads', async () => {
     const createdAt = new Date(0).toISOString();
     let liveView: EditorView | null = null;
     let completedExchange: AIExchangeJSON | null = null;
@@ -818,8 +824,8 @@ describe('RichStreamEditor inline conversations', () => {
             updateBlock: {
               before: payload?.before,
               after: 'Proposed replacement.',
-              applied: false,
-              failure: 'passage_changed',
+              applied: payload?.applied,
+              failure: payload?.failure,
             },
           }),
         },
@@ -889,6 +895,112 @@ describe('RichStreamEditor inline conversations', () => {
       applied: false,
       failure: 'passage_changed',
     });
+
+    const composerAgain = document.querySelector('.conversation-composer') as HTMLTextAreaElement;
+    await enterConversationMessage(composerAgain, 'Try the wrong thread');
+    await act(async () => {
+      composerAgain.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter', metaKey: true, bubbles: true, cancelable: true,
+      }));
+      await Promise.resolve();
+    });
+    const mismatchedRequestId = activeRequestId();
+    completedExchange = {
+      ...completedExchange,
+      requestId: mismatchedRequestId,
+      threadId: 'another-thread',
+      userInput: 'Try the wrong thread',
+      sourceManifest: JSON.stringify({
+        ...receipt,
+        requestId: mismatchedRequestId,
+      }),
+    };
+    await act(async () => {
+      bridge.receive({
+        type: 'documentAIComplete',
+        payload: {
+          requestId: mismatchedRequestId,
+          exchange: completedExchange!,
+          toolCalls: true,
+          toolCall: {
+            id: 'call-mismatch', name: 'update_block',
+            arguments: JSON.stringify({ content: 'Must not land.' }),
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(vi.mocked(bridge.sendAsync).mock.calls.filter(
+      ([type, payload]) => type === 'recordThreadToolApplication'
+        && payload?.requestId === mismatchedRequestId,
+    )[0]?.[1]).toMatchObject({
+      before: 'Original paragraph.',
+      applied: false,
+      failure: 'thread_mismatch',
+    }));
+    expect(serializeMarkdown(liveView!.state.doc)).toBe(changed);
+    const notes = [...document.querySelectorAll('.conversation-tool-note')];
+    expect(notes[notes.length - 1]?.textContent).toBe("couldn't apply — conversation changed");
+  });
+
+  it('renders a persisted pending tool call as a proposal, never a normal answer', async () => {
+    const updatedAt = new Date().toISOString();
+    const anchored: Stream = {
+      ...stream,
+      id: 'pending-tool-stream',
+      document: {
+        ...stream.document,
+        streamId: 'pending-tool-stream',
+      },
+      conversationAnchors: [{
+        threadId: 'pending-tool-thread',
+        anchorStart: 1,
+        anchorEnd: 20,
+        anchorText: 'Original paragraph.',
+        detached: false,
+        ephemeral: false,
+        updatedAt,
+      }],
+    };
+    vi.mocked(bridge.sendAsync).mockImplementation((async (type) => {
+      if (type === 'loadStreamThread') return {
+        thread: {
+          threadId: 'pending-tool-thread', streamId: anchored.id, title: 'Rewrite', workingText: '',
+          anchorText: 'Original paragraph.', anchorStart: 1, anchorEnd: 20,
+          detached: false, ephemeral: false, revision: 0, createdAt: updatedAt, updatedAt,
+          exchanges: [{
+            requestId: 'pending-tool-request', streamId: anchored.id, threadId: 'pending-tool-thread',
+            verb: 'thread', userInput: 'Rewrite it', responseRaw: 'Replacement **markdown**.',
+            sourceManifest: JSON.stringify({
+              version: 2, kind: 'threadAI', requestId: 'pending-tool-request',
+              anchor: { kind: 'stream', text: 'Original paragraph.', from: 1, to: 20 },
+              streamDocument: { sent: true, charCount: 19 }, note: { sent: false },
+              turns: { includedRequestIds: [], totalAtSend: 0 }, sourceContextMode: 'none',
+              sources: [], pinned: [],
+              updateBlock: { before: 'Original paragraph.', after: 'Replacement **markdown**.' },
+            }),
+            createdAt: updatedAt,
+          }],
+        },
+      };
+      return { revision: 2 };
+    }) as typeof bridge.sendAsync);
+    await renderStream(anchored);
+    const block = editor().querySelector('p') as HTMLParagraphElement;
+    await vi.waitFor(() => expect(block.classList.contains('conversation-block-anchored')).toBe(true));
+    vi.spyOn(block, 'getBoundingClientRect').mockReturnValue({
+      left: 10, right: 310, top: 0, bottom: 28, width: 300, height: 28, x: 10, y: 0,
+      toJSON: () => ({}),
+    });
+    await act(async () => {
+      block.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 320 }));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => expect(document.querySelector('.conversation-tool-note')?.textContent)
+      .toBe('Proposed edit (not applied)'));
+    expect(document.querySelector('.conversation-turn--ai .conversation-turn-text')?.textContent)
+      .toBe('Replacement **markdown**.');
   });
 
   it('promotes saved turns in order with citation links and visible AI provenance', async () => {

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -19,6 +19,7 @@ import {
   recordThreadToolApplication,
   saveStreamThread,
   type ConversationToolCall,
+  type ConversationToolFailure,
   type DocumentAIVerb,
   type SourceTitlePayload,
   type StreamDocumentConflictPayload,
@@ -78,6 +79,7 @@ import {
   updateConversationBlockMarkdown,
 } from '../richtext/operations';
 import { DocumentSession, type SaveState } from '../richtext/session';
+import { serializeMarkdown } from '../richtext/markdown';
 import {
   addProvenanceSpans,
   hashProvenanceText,
@@ -103,7 +105,11 @@ import {
 } from '../utils/pdfAnchorSelection';
 import { computeSelectionMenuPlacement } from '../utils/selectionMenuPlacement';
 import { formatRelativeTime } from '../utils/relativeTime';
-import { manifestCitations, threadAIReceiptWithUpdateResult } from '../threads/context';
+import {
+  manifestCitations,
+  parseThreadAISentFacts,
+  threadAIReceiptWithUpdateResult,
+} from '../threads/context';
 import {
   activeFormats,
   toggleBlockquote,
@@ -1275,43 +1281,67 @@ export function RichStreamEditor({
     const currentEditor = editorRef.current;
     const surface = currentEditor && conversationSurface(currentEditor.view.state);
     const currentThread = surface && conversationLiveStatesRef.current[surface.key]?.thread;
-    const before = currentEditor && surface
-      ? conversationAnchorText(currentEditor.view.state.doc, surface.anchor)
-      : '';
+    const expanded = expandedConversationRef.current;
+    const persistedThread = Object.values(conversationLiveStatesRef.current)
+      .find((state) => state.thread?.threadId === exchange.threadId)?.thread;
+    const persistedBefore = persistedThread?.anchorText
+      ?? (expanded && expanded.threadId === exchange.threadId
+        ? expanded.anchorText
+        : parseThreadAISentFacts(exchange.sourceManifest)?.anchor.text ?? '');
+    const surfaceMatches = surface?.anchor.threadId === exchange.threadId;
+    let before = persistedBefore;
+    let beforeSerializationFailed = false;
+    if (currentEditor && surface && surfaceMatches && surface.anchor.from < surface.anchor.to) {
+      try {
+        before = serializeMarkdown(currentEditor.view.state.doc.cut(surface.anchor.from, surface.anchor.to));
+      } catch {
+        beforeSerializationFailed = true;
+      }
+    }
     let applied = false;
-    if (currentEditor
-      && surface
-      && exchange.threadId === surface.anchor.threadId
-      && expandedConversationRef.current?.ephemeral !== true
-      && currentThread?.ephemeral !== true
-      && surface.anchor.from < surface.anchor.to
-      && !hasConversationAnchorTextDrifted(
+    let failure: ConversationToolFailure | undefined;
+    if (beforeSerializationFailed) failure = 'apply_error';
+    else if (!currentEditor || !surface) failure = 'surface_closed';
+    else if (!surfaceMatches) failure = 'thread_mismatch';
+    else if (expandedConversationRef.current?.ephemeral === true || currentThread?.ephemeral === true) {
+      failure = 'apply_error';
+    } else if (!currentThread?.anchorText || surface.anchor.from >= surface.anchor.to
+      || hasConversationAnchorTextDrifted(
         currentEditor.view.state.doc,
         surface.anchor,
-        currentThread?.anchorText ?? expandedConversationRef.current?.anchorText ?? '',
-      )) {
+        currentThread.anchorText,
+      )) failure = 'passage_changed';
+    else {
       try {
-        const replaced = updateConversationBlockMarkdown(currentEditor.view, surface.anchor, content, {
+        const result = updateConversationBlockMarkdown(currentEditor.view, surface.anchor, content, {
           requestId: exchange.requestId,
           model: exchange.model,
           verb: exchange.verb,
           threadId: surface.anchor.threadId,
         });
-        applied = true;
-        window.setTimeout(() => {
-          if (currentEditor.view.isDestroyed) return;
-          const highlighted = aiWritingRange(currentEditor.view.state);
-          if (highlighted?.from !== replaced.from || highlighted.to !== replaced.to) return;
-          currentEditor.view.dispatch(
-            setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
-          );
-        }, 1_200);
+        if (!result.applied) failure = result.failure;
+        else {
+          applied = true;
+          window.setTimeout(() => {
+            if (currentEditor.view.isDestroyed) return;
+            const highlighted = aiWritingRange(currentEditor.view.state);
+            if (highlighted?.from !== result.from || highlighted.to !== result.to) return;
+            currentEditor.view.dispatch(
+              setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
+            );
+          }, 1_200);
+        }
       } catch {
-        applied = false;
+        failure = 'apply_error';
       }
     }
 
-    const localManifest = threadAIReceiptWithUpdateResult(exchange.sourceManifest, before, applied);
+    const applicationFailure = applied ? undefined : failure ?? 'apply_error';
+    const localManifest = threadAIReceiptWithUpdateResult(
+      exchange.sourceManifest,
+      before,
+      applicationFailure,
+    );
     const localExchange = localManifest ? { ...exchange, sourceManifest: localManifest } : exchange;
     try {
       return (await recordThreadToolApplication({
@@ -1319,7 +1349,7 @@ export function RichStreamEditor({
         requestId: exchange.requestId,
         before,
         applied,
-        failure: applied ? undefined : 'passage_changed',
+        failure: applicationFailure,
       })).exchange;
     } catch {
       addToast('The edit result could not be saved to the conversation.', 'info');

--- a/Web/src/components/RichStreamEditor.tsx
+++ b/Web/src/components/RichStreamEditor.tsx
@@ -16,7 +16,9 @@ import {
   deleteStreamThread,
   getExchange,
   listConversations,
+  recordThreadToolApplication,
   saveStreamThread,
+  type ConversationToolCall,
   type DocumentAIVerb,
   type SourceTitlePayload,
   type StreamDocumentConflictPayload,
@@ -73,6 +75,7 @@ import {
   selectText,
   setAIWritingRange,
   streamAIMarkdown,
+  updateConversationBlockMarkdown,
 } from '../richtext/operations';
 import { DocumentSession, type SaveState } from '../richtext/session';
 import {
@@ -100,7 +103,7 @@ import {
 } from '../utils/pdfAnchorSelection';
 import { computeSelectionMenuPlacement } from '../utils/selectionMenuPlacement';
 import { formatRelativeTime } from '../utils/relativeTime';
-import { manifestCitations } from '../threads/context';
+import { manifestCitations, threadAIReceiptWithUpdateResult } from '../threads/context';
 import {
   activeFormats,
   toggleBlockquote,
@@ -712,7 +715,7 @@ export function RichStreamEditor({
       updateConversationLiveState(expanded.key, (state) => ({ ...state, closing: false }));
       if (!currentEditor || !anchor) return;
       window.requestAnimationFrame(() => {
-        if (currentEditor.view.isDestroyed) return;
+        if (currentEditor.view.isDestroyed || expandedConversationRef.current) return;
         const pos = Math.max(0, Math.min(anchor.from, currentEditor.view.state.doc.content.size));
         currentEditor.view.dispatch(currentEditor.view.state.tr.setSelection(
           TextSelection.near(currentEditor.view.state.doc.resolve(pos)),
@@ -1258,6 +1261,71 @@ export function RichStreamEditor({
       addToast("Couldn't add the reply.", 'error');
     }
   }, [addToast, keepExpandedConversation]);
+
+  const applyConversationUpdateBlock = useCallback(async (
+    exchange: AIExchangeJSON,
+    toolCall: ConversationToolCall,
+  ): Promise<AIExchangeJSON> => {
+    let argumentsValue: unknown;
+    try { argumentsValue = JSON.parse(toolCall.arguments) as unknown; } catch { return exchange; }
+    if (!argumentsValue || typeof argumentsValue !== 'object' || Array.isArray(argumentsValue)) return exchange;
+    const content = (argumentsValue as Record<string, unknown>).content;
+    if (typeof content !== 'string') return exchange;
+
+    const currentEditor = editorRef.current;
+    const surface = currentEditor && conversationSurface(currentEditor.view.state);
+    const currentThread = surface && conversationLiveStatesRef.current[surface.key]?.thread;
+    const before = currentEditor && surface
+      ? conversationAnchorText(currentEditor.view.state.doc, surface.anchor)
+      : '';
+    let applied = false;
+    if (currentEditor
+      && surface
+      && exchange.threadId === surface.anchor.threadId
+      && expandedConversationRef.current?.ephemeral !== true
+      && currentThread?.ephemeral !== true
+      && surface.anchor.from < surface.anchor.to
+      && !hasConversationAnchorTextDrifted(
+        currentEditor.view.state.doc,
+        surface.anchor,
+        currentThread?.anchorText ?? expandedConversationRef.current?.anchorText ?? '',
+      )) {
+      try {
+        const replaced = updateConversationBlockMarkdown(currentEditor.view, surface.anchor, content, {
+          requestId: exchange.requestId,
+          model: exchange.model,
+          verb: exchange.verb,
+          threadId: surface.anchor.threadId,
+        });
+        applied = true;
+        window.setTimeout(() => {
+          if (currentEditor.view.isDestroyed) return;
+          const highlighted = aiWritingRange(currentEditor.view.state);
+          if (highlighted?.from !== replaced.from || highlighted.to !== replaced.to) return;
+          currentEditor.view.dispatch(
+            setAIWritingRange(currentEditor.view.state.tr, null).setMeta('addToHistory', false),
+          );
+        }, 1_200);
+      } catch {
+        applied = false;
+      }
+    }
+
+    const localManifest = threadAIReceiptWithUpdateResult(exchange.sourceManifest, before, applied);
+    const localExchange = localManifest ? { ...exchange, sourceManifest: localManifest } : exchange;
+    try {
+      return (await recordThreadToolApplication({
+        streamId: stream.id,
+        requestId: exchange.requestId,
+        before,
+        applied,
+        failure: applied ? undefined : 'passage_changed',
+      })).exchange;
+    } catch {
+      addToast('The edit result could not be saved to the conversation.', 'info');
+      return localExchange;
+    }
+  }, [addToast, stream.id]);
 
   const discardPDFQuote = useCallback((streamId: unknown, highlightId: unknown) => {
     if (typeof highlightId === 'string') {
@@ -2557,6 +2625,7 @@ export function RichStreamEditor({
           createThread={createPersistedConversation}
           hasDrifted={conversationHasDrifted}
           onPromote={promoteConversationTurn}
+          onUpdateBlock={applyConversationUpdateBlock}
           onKeep={() => { void keepExpandedConversation(); }}
           onCollapse={collapseConversation}
         />,

--- a/Web/src/richtext/conversationAnchors.test.ts
+++ b/Web/src/richtext/conversationAnchors.test.ts
@@ -162,6 +162,7 @@ describe('conversation anchor lifecycle', () => {
     expect(stored).toHaveLength(200);
     expect([...stored]).toHaveLength(100);
     expect(hasConversationAnchorTextDrifted(ed.view.state.doc, anchor, stored)).toBe(false);
+    expect(hasConversationAnchorTextDrifted(ed.view.state.doc, anchor, '')).toBe(true);
 
     ed.view.dispatch(ed.view.state.tr.insertText('changed', anchor.from + 100, anchor.from + 102));
     expect(hasConversationAnchorTextDrifted(

--- a/Web/src/richtext/conversationAnchors.ts
+++ b/Web/src/richtext/conversationAnchors.ts
@@ -183,7 +183,8 @@ export function hasConversationAnchorTextDrifted(
   anchor: ConversationAnchor,
   originalText: string,
 ): boolean {
-  return anchor.from >= anchor.to || !conversationAnchorText(doc, anchor).includes(originalText);
+  return !originalText || anchor.from >= anchor.to
+    || !conversationAnchorText(doc, anchor).includes(originalText);
 }
 
 export function conversationAnchorFromJSON(json: ConversationAnchorJSON): ConversationAnchor {

--- a/Web/src/richtext/editor.css
+++ b/Web/src/richtext/editor.css
@@ -197,11 +197,16 @@
 .conversation-drift-note,
 .conversation-status,
 .conversation-load-error,
+.conversation-tool-note,
 .conversation-error {
   margin: 0;
   color: var(--text-muted);
   font-size: var(--type-ui-small);
   line-height: var(--type-ui-line-height);
+}
+
+.conversation-tool-note {
+  grid-column: 2 / -1;
 }
 
 .conversation-load-error button {

--- a/Web/src/richtext/operations.test.ts
+++ b/Web/src/richtext/operations.test.ts
@@ -197,11 +197,13 @@ describe('updating a conversation anchor', () => {
         verb: 'thread',
         threadId: 'thread-1',
       });
+      expect(replaced.applied).toBe(true);
+      if (!replaced.applied) throw new Error(replaced.failure);
 
       expect(ed.view.state.doc.firstChild!.toJSON()).toEqual(first);
       expect(ed.view.state.doc.lastChild!.toJSON()).toEqual(last);
       if (markdown) {
-        expect(aiWritingRange(ed.view.state)).toEqual(replaced);
+        expect(aiWritingRange(ed.view.state)).toEqual({ from: replaced.from, to: replaced.to });
         expect(provenanceSpans(ed.view.state)).toEqual([
           expect.objectContaining({
             from: replaced.from,
@@ -218,6 +220,39 @@ describe('updating a conversation anchor', () => {
       ed.destroy();
       editor = null;
     }
+  });
+
+  it('keeps partial-anchor replacements inline and refuses structural content byte-exactly', () => {
+    const ed = open('Outside before.\n\nPrefix target suffix.\n\nOutside after.');
+    const target = find(ed, 'target');
+    const before = ed.getDocumentJSON();
+    const first = ed.view.state.doc.firstChild!.toJSON();
+    const last = ed.view.state.doc.lastChild!.toJSON();
+    const inline = updateConversationBlockMarkdown(ed.view, target, 'AI **inline**', {
+      requestId: 'inline-update',
+      model: 'test-model',
+      verb: 'thread',
+      threadId: 'thread-1',
+    });
+
+    expect(inline.applied).toBe(true);
+    expect(ed.view.state.doc.firstChild!.toJSON()).toEqual(first);
+    expect(ed.view.state.doc.lastChild!.toJSON()).toEqual(last);
+    expect(ed.view.state.doc.child(1).type.name).toBe('paragraph');
+    const expected = 'Outside before.\n\nPrefix AI **inline** suffix.\n\nOutside after.';
+    expect(ed.getMarkdownProjection()).toBe(expected);
+    expect(ed.view.state.doc.toJSON()).toEqual(parseMarkdown(expected).toJSON());
+    undo(ed);
+    expect(ed.getDocumentJSON()).toBe(before);
+
+    const structuralBefore = ed.getDocumentJSON();
+    expect(updateConversationBlockMarkdown(ed.view, target, '# Heading\n\nSecond block.', {
+      requestId: 'structural-update',
+      model: 'test-model',
+      verb: 'thread',
+      threadId: 'thread-1',
+    })).toEqual({ applied: false, failure: 'partial_anchor' });
+    expect(ed.getDocumentJSON()).toBe(structuralBefore);
   });
 });
 

--- a/Web/src/richtext/operations.test.ts
+++ b/Web/src/richtext/operations.test.ts
@@ -14,6 +14,7 @@ import {
   selectText,
   setImageWidth,
   streamAIMarkdown,
+  updateConversationBlockMarkdown,
 } from './operations';
 import { provenanceSpans } from './provenance';
 
@@ -174,6 +175,49 @@ describe('promoting a conversation answer', () => {
     undo(ed);
     expect(ed.getDocumentJSON()).toBe(before);
     expect(provenanceSpans(ed.view.state)).toEqual([]);
+  });
+});
+
+describe('updating a conversation anchor', () => {
+  it('clamps huge, empty, and block-splitting replacements to the live anchor and undoes byte-exactly', () => {
+    const cases = [
+      'x'.repeat(20_000),
+      '',
+      '# Replacement\n\nFirst paragraph.\n\n- one\n- two\n\n> final block',
+    ];
+    for (const markdown of cases) {
+      const ed = open('Outside before.\n\nTarget text.\n\nOutside after.');
+      const beforeMarkdown = ed.getMarkdownProjection();
+      const beforeJSON = ed.getDocumentJSON();
+      const first = ed.view.state.doc.firstChild!.toJSON();
+      const last = ed.view.state.doc.lastChild!.toJSON();
+      const replaced = updateConversationBlockMarkdown(ed.view, find(ed, 'Target text.'), markdown, {
+        requestId: `update-${markdown.length}`,
+        model: 'test-model',
+        verb: 'thread',
+        threadId: 'thread-1',
+      });
+
+      expect(ed.view.state.doc.firstChild!.toJSON()).toEqual(first);
+      expect(ed.view.state.doc.lastChild!.toJSON()).toEqual(last);
+      if (markdown) {
+        expect(aiWritingRange(ed.view.state)).toEqual(replaced);
+        expect(provenanceSpans(ed.view.state)).toEqual([
+          expect.objectContaining({
+            from: replaced.from,
+            to: replaced.to,
+            origin: 'ai',
+            requestId: `update-${markdown.length}`,
+          }),
+        ]);
+      } else expect(provenanceSpans(ed.view.state)).toEqual([]);
+      undo(ed);
+      expect(ed.getMarkdownProjection()).toBe(beforeMarkdown);
+      expect(ed.getDocumentJSON()).toBe(beforeJSON);
+      expect(provenanceSpans(ed.view.state)).toEqual([]);
+      ed.destroy();
+      editor = null;
+    }
   });
 });
 

--- a/Web/src/richtext/operations.ts
+++ b/Web/src/richtext/operations.ts
@@ -175,26 +175,28 @@ export function updateConversationBlockMarkdown(
   anchor: { from: number; to: number },
   markdown: string,
   attribution: { requestId: string; model?: string | null; verb: string; threadId: string },
-): { from: number; to: number } {
+): { applied: true; from: number; to: number } | { applied: false; failure: 'partial_anchor' } {
   const from = Math.max(0, Math.min(anchor.from, view.state.doc.content.size));
   const to = Math.max(from, Math.min(anchor.to, view.state.doc.content.size));
   if (from >= to) throw new Error('The conversation anchor is detached.');
   const parsed = parseMarkdown(markdown);
   const first = textBlockBounds(view.state.doc, from);
   const last = textBlockBounds(view.state.doc, to - 1);
+  if (!first || !last) throw new Error('The conversation anchor has no text block.');
   const wholeBlocks = first && last
     && from === first.contentFrom
     && to === last.contentTo
     && first.parentStart === last.parentStart;
-  let tr = view.state.tr;
+  const tr = view.state.tr;
   if (wholeBlocks) {
-    try {
-      tr.replace(first.nodeFrom, last.nodeTo, new Slice(parsed.content, 0, 0));
-    } catch {
-      tr = view.state.tr.replace(from, to, Slice.maxOpen(parsed.content));
-    }
+    tr.replace(first.nodeFrom, last.nodeTo, new Slice(parsed.content, 0, 0));
   } else {
-    tr.replace(from, to, Slice.maxOpen(parsed.content));
+    if (first.nodeFrom !== last.nodeFrom
+      || parsed.childCount !== 1
+      || parsed.firstChild?.type !== tickerSchema.nodes.paragraph) {
+      return { applied: false, failure: 'partial_anchor' };
+    }
+    tr.replace(from, to, new Slice(parsed.firstChild.content, 0, 0));
   }
   const replaced = { from: tr.mapping.map(from, -1), to: tr.mapping.map(to, 1) };
   tr.setTime(1);
@@ -211,7 +213,7 @@ export function updateConversationBlockMarkdown(
     }]);
   }
   view.dispatch(tr.scrollIntoView());
-  return replaced;
+  return { applied: true, ...replaced };
 }
 
 function textBlockBounds(doc: ProseNode, pos: number) {

--- a/Web/src/richtext/operations.ts
+++ b/Web/src/richtext/operations.ts
@@ -169,6 +169,66 @@ export function promoteConversationMarkdown(
   return inserted;
 }
 
+/** Replace exactly one conversation anchor, never a model-supplied range. */
+export function updateConversationBlockMarkdown(
+  view: EditorView,
+  anchor: { from: number; to: number },
+  markdown: string,
+  attribution: { requestId: string; model?: string | null; verb: string; threadId: string },
+): { from: number; to: number } {
+  const from = Math.max(0, Math.min(anchor.from, view.state.doc.content.size));
+  const to = Math.max(from, Math.min(anchor.to, view.state.doc.content.size));
+  if (from >= to) throw new Error('The conversation anchor is detached.');
+  const parsed = parseMarkdown(markdown);
+  const first = textBlockBounds(view.state.doc, from);
+  const last = textBlockBounds(view.state.doc, to - 1);
+  const wholeBlocks = first && last
+    && from === first.contentFrom
+    && to === last.contentTo
+    && first.parentStart === last.parentStart;
+  let tr = view.state.tr;
+  if (wholeBlocks) {
+    try {
+      tr.replace(first.nodeFrom, last.nodeTo, new Slice(parsed.content, 0, 0));
+    } catch {
+      tr = view.state.tr.replace(from, to, Slice.maxOpen(parsed.content));
+    }
+  } else {
+    tr.replace(from, to, Slice.maxOpen(parsed.content));
+  }
+  const replaced = { from: tr.mapping.map(from, -1), to: tr.mapping.map(to, 1) };
+  tr.setTime(1);
+  closeHistory(tr);
+  if (replaced.from < replaced.to) {
+    addProvenanceSpans(setAIWritingRange(tr, replaced), [{
+      spanId: crypto.randomUUID(),
+      ...replaced,
+      origin: 'ai',
+      requestId: attribution.requestId,
+      meta: { model: attribution.model ?? null, verb: attribution.verb, threadId: attribution.threadId },
+      textHash: hashProvenanceText(tr.doc, replaced),
+      createdAt: Date.now(),
+    }]);
+  }
+  view.dispatch(tr.scrollIntoView());
+  return replaced;
+}
+
+function textBlockBounds(doc: ProseNode, pos: number) {
+  const $pos = doc.resolve(pos);
+  for (let depth = $pos.depth; depth > 0; depth -= 1) {
+    if (!$pos.node(depth).isTextblock) continue;
+    return {
+      contentFrom: $pos.start(depth),
+      contentTo: $pos.end(depth),
+      nodeFrom: $pos.before(depth),
+      nodeTo: $pos.after(depth),
+      parentStart: $pos.start(depth - 1),
+    };
+  }
+  return null;
+}
+
 function markdownBlockInsertion(view: EditorView, pos: number, markdown: string) {
   const parsed = parseMarkdown(markdown);
   if (parsed.childCount === 0) throw new Error('There is no content to add.');

--- a/Web/src/threads/context.test.ts
+++ b/Web/src/threads/context.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { manifestCitations, parseThreadAISentFacts } from './context';
+import {
+  manifestCitations,
+  parseThreadAISentFacts,
+  threadAIReceiptWithUpdateResult,
+} from './context';
 
 const receipt = {
   version: 1,
@@ -75,5 +79,27 @@ describe('thread AI context receipts', () => {
     expect(manifestCitations(JSON.stringify([{
       sourceId: 'source-1', chunkId: 'chunk-1', page: 0, shortTitle: 'Manual',
     }]))[0].page).toBe(1);
+  });
+
+  it('round-trips pending and applied update_block receipt facts', () => {
+    const pending = {
+      ...receiptV2,
+      updateBlock: { before: 'Old passage.', after: 'New passage.' },
+    };
+    expect(parseThreadAISentFacts(pending)?.updateBlock).toEqual(pending.updateBlock);
+    const applied = threadAIReceiptWithUpdateResult(JSON.stringify(pending), 'Current passage.', true);
+    expect(parseThreadAISentFacts(applied)?.updateBlock).toEqual({
+      before: 'Current passage.',
+      after: 'New passage.',
+      applied: true,
+      failure: undefined,
+    });
+    const failed = threadAIReceiptWithUpdateResult(JSON.stringify(pending), 'Changed passage.', false);
+    expect(parseThreadAISentFacts(failed)?.updateBlock).toEqual({
+      before: 'Changed passage.',
+      after: 'New passage.',
+      applied: false,
+      failure: 'passage_changed',
+    });
   });
 });

--- a/Web/src/threads/context.test.ts
+++ b/Web/src/threads/context.test.ts
@@ -87,19 +87,36 @@ describe('thread AI context receipts', () => {
       updateBlock: { before: 'Old passage.', after: 'New passage.' },
     };
     expect(parseThreadAISentFacts(pending)?.updateBlock).toEqual(pending.updateBlock);
-    const applied = threadAIReceiptWithUpdateResult(JSON.stringify(pending), 'Current passage.', true);
+    const applied = threadAIReceiptWithUpdateResult(JSON.stringify(pending), 'Current passage.');
     expect(parseThreadAISentFacts(applied)?.updateBlock).toEqual({
       before: 'Current passage.',
       after: 'New passage.',
       applied: true,
       failure: undefined,
     });
-    const failed = threadAIReceiptWithUpdateResult(JSON.stringify(pending), 'Changed passage.', false);
+    const failed = threadAIReceiptWithUpdateResult(
+      JSON.stringify(pending),
+      'Changed passage.',
+      'passage_changed',
+    );
     expect(parseThreadAISentFacts(failed)?.updateBlock).toEqual({
       before: 'Changed passage.',
       after: 'New passage.',
       applied: false,
       failure: 'passage_changed',
     });
+    for (const failure of [
+      'partial_anchor', 'surface_closed', 'thread_mismatch', 'apply_error',
+    ] as const) {
+      expect(parseThreadAISentFacts(threadAIReceiptWithUpdateResult(
+        JSON.stringify(pending),
+        'Current passage.',
+        failure,
+      ))?.updateBlock?.failure).toBe(failure);
+    }
+    expect(parseThreadAISentFacts({
+      ...pending,
+      updateBlock: { ...pending.updateBlock, applied: false, failure: 'made_up' },
+    })).toBe(null);
   });
 });

--- a/Web/src/threads/context.ts
+++ b/Web/src/threads/context.ts
@@ -1,4 +1,4 @@
-import type { DocumentAICitation } from '../types/bridge';
+import type { ConversationToolFailure, DocumentAICitation } from '../types/bridge';
 
 export interface ThreadAISourceFact {
   kind: 'passage' | 'wholeSource';
@@ -45,7 +45,7 @@ export interface ThreadAISentFacts {
     before: string;
     after: string;
     applied?: boolean;
-    failure?: 'passage_changed';
+    failure?: ConversationToolFailure;
   };
 }
 
@@ -54,6 +54,14 @@ function object(value: unknown): Record<string, unknown> | null {
     ? value as Record<string, unknown>
     : null;
 }
+
+const updateBlockFailures = new Set<ConversationToolFailure>([
+  'passage_changed',
+  'partial_anchor',
+  'surface_closed',
+  'thread_mismatch',
+  'apply_error',
+]);
 
 function positiveInteger(value: unknown): number | undefined {
   const number = Number(value);
@@ -153,9 +161,10 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   const updateApplied = updateBlock?.applied;
   const updateFailure = updateBlock?.failure;
   if (updateApplied !== undefined && typeof updateApplied !== 'boolean') return null;
-  if (updateFailure != null && updateFailure !== 'passage_changed') return null;
+  if (updateFailure != null && (typeof updateFailure !== 'string'
+    || !updateBlockFailures.has(updateFailure as ConversationToolFailure))) return null;
   if ((updateApplied === true && updateFailure != null)
-    || (updateApplied === false && updateFailure !== 'passage_changed')
+    || (updateApplied === false && updateFailure == null)
     || (updateApplied === undefined && updateFailure != null)) return null;
 
   return {
@@ -190,7 +199,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
       before: updateBlock.before as string,
       after: updateBlock.after as string,
       applied: updateApplied as boolean | undefined,
-      failure: updateFailure === 'passage_changed' ? updateFailure : undefined,
+      failure: updateFailure == null ? undefined : updateFailure as ConversationToolFailure,
     } : undefined,
   };
 }
@@ -198,7 +207,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
 export function threadAIReceiptWithUpdateResult(
   value: string,
   before: string,
-  applied: boolean,
+  failure?: ConversationToolFailure,
 ): string | null {
   let receipt: Record<string, unknown> | null;
   try { receipt = object(JSON.parse(value) as unknown); } catch { return null; }
@@ -209,8 +218,8 @@ export function threadAIReceiptWithUpdateResult(
     updateBlock: {
       ...updateBlock,
       before,
-      applied,
-      failure: applied ? null : 'passage_changed',
+      applied: failure === undefined,
+      failure: failure ?? null,
     },
   });
 }

--- a/Web/src/threads/context.ts
+++ b/Web/src/threads/context.ts
@@ -41,6 +41,12 @@ export interface ThreadAISentFacts {
   sources: ThreadAISourceFact[];
   pinned: ThreadAIPinnedFact[];
   profile?: 'research';
+  updateBlock?: {
+    before: string;
+    after: string;
+    applied?: boolean;
+    failure?: 'passage_changed';
+  };
 }
 
 function object(value: unknown): Record<string, unknown> | null {
@@ -114,6 +120,7 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
   const note = object(receipt?.note);
   const turns = object(receipt?.turns);
   const streamDocument = object(receipt?.streamDocument);
+  const updateBlock = object(receipt?.updateBlock);
   if ((receipt?.version !== 1 && receipt?.version !== 2)
     || receipt.kind !== 'threadAI' || !anchor || !note || !turns) return null;
   if (typeof receipt.requestId !== 'string' || typeof anchor.text !== 'string') return null;
@@ -140,6 +147,16 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
     : [];
   if (receipt.version === 2 && !Array.isArray(receipt.pinned)) return null;
   if (receipt.profile !== undefined && receipt.profile !== 'research') return null;
+  if (receipt.updateBlock !== undefined && (!updateBlock
+    || typeof updateBlock.before !== 'string'
+    || typeof updateBlock.after !== 'string')) return null;
+  const updateApplied = updateBlock?.applied;
+  const updateFailure = updateBlock?.failure;
+  if (updateApplied !== undefined && typeof updateApplied !== 'boolean') return null;
+  if (updateFailure != null && updateFailure !== 'passage_changed') return null;
+  if ((updateApplied === true && updateFailure != null)
+    || (updateApplied === false && updateFailure !== 'passage_changed')
+    || (updateApplied === undefined && updateFailure != null)) return null;
 
   return {
     version: receipt.version,
@@ -169,7 +186,33 @@ export function parseThreadAISentFacts(value: unknown): ThreadAISentFacts | null
       : [],
     pinned,
     profile: receipt.profile,
+    updateBlock: updateBlock ? {
+      before: updateBlock.before as string,
+      after: updateBlock.after as string,
+      applied: updateApplied as boolean | undefined,
+      failure: updateFailure === 'passage_changed' ? updateFailure : undefined,
+    } : undefined,
   };
+}
+
+export function threadAIReceiptWithUpdateResult(
+  value: string,
+  before: string,
+  applied: boolean,
+): string | null {
+  let receipt: Record<string, unknown> | null;
+  try { receipt = object(JSON.parse(value) as unknown); } catch { return null; }
+  const updateBlock = object(receipt?.updateBlock);
+  if (!receipt || !updateBlock || typeof updateBlock.after !== 'string') return null;
+  return JSON.stringify({
+    ...receipt,
+    updateBlock: {
+      ...updateBlock,
+      before,
+      applied,
+      failure: applied ? null : 'passage_changed',
+    },
+  });
 }
 
 function citation(value: unknown, fallbackNumber: number): DocumentAICitation | null {

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -85,6 +85,7 @@ export const WEB_TO_SWIFT_MESSAGE_TYPES = [
   'openSource',
   'quitApp',
   'refreshProxyAuth',
+  'recordThreadToolApplication',
   'removeSource',
   'removeStreamThreadAnchor',
   'retrySourceIndexing',
@@ -156,6 +157,12 @@ export interface DocumentAICitation {
   sourceId: string;
   page: number;
   shortTitle: string;
+}
+
+export interface ConversationToolCall {
+  id: string;
+  name: 'update_block';
+  arguments: string;
 }
 
 export interface SourceTitlePayload {
@@ -304,6 +311,22 @@ export function removeStreamThreadAnchor(input: {
     streamId: input.streamId,
     threadId: input.threadId,
     anchorId: input.anchorId,
+  });
+}
+
+export function recordThreadToolApplication(input: {
+  streamId: string;
+  requestId: string;
+  before: string;
+  applied: boolean;
+  failure?: 'passage_changed';
+}): Promise<{ exchange: AIExchangeJSON }> {
+  return bridge.sendAsync('recordThreadToolApplication', {
+    streamId: input.streamId,
+    requestId: input.requestId,
+    before: input.before,
+    applied: input.applied,
+    failure: input.failure,
   });
 }
 

--- a/Web/src/types/bridge.ts
+++ b/Web/src/types/bridge.ts
@@ -165,6 +165,13 @@ export interface ConversationToolCall {
   arguments: string;
 }
 
+export type ConversationToolFailure =
+  | 'passage_changed'
+  | 'partial_anchor'
+  | 'surface_closed'
+  | 'thread_mismatch'
+  | 'apply_error';
+
 export interface SourceTitlePayload {
   sourceName?: string;
   shortTitle?: string;
@@ -319,7 +326,7 @@ export function recordThreadToolApplication(input: {
   requestId: string;
   before: string;
   applied: boolean;
-  failure?: 'passage_changed';
+  failure?: ConversationToolFailure;
 }): Promise<{ exchange: AIExchangeJSON }> {
   return bridge.sendAsync('recordThreadToolApplication', {
     streamId: input.streamId,

--- a/docs/CONVERSATIONS_PLAN.md
+++ b/docs/CONVERSATIONS_PLAN.md
@@ -64,7 +64,7 @@ sidecar data.
 
 ### Anchor lifecycle rules (verbatim; encode in tests)
 
-1. A conversation anchors to a contiguous range of ProseMirror document positions, initially the full
+1. A conversation anchors to a contiguous UTF-16 range in the canonical document, initially the full
    text of one block. The range maps through every transaction (same mapping discipline as provenance
    spans). The conversation renders after the **last block intersecting the range**.
 2. Block split inside the range: the range now spans both halves; render rule (1) keeps the
@@ -124,7 +124,7 @@ composer empty) collapses. Streaming renders progressively into the last AI turn
 
 ```sql
 -- v30_conversation_anchors
-ALTER TABLE stream_threads ADD COLUMN anchor_start INTEGER;   -- ProseMirror doc position (opaque to Swift)
+ALTER TABLE stream_threads ADD COLUMN anchor_start INTEGER;   -- UTF-16 offset in canonical doc
 ALTER TABLE stream_threads ADD COLUMN anchor_end   INTEGER;
 ALTER TABLE stream_threads ADD COLUMN detached     INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE stream_threads ADD COLUMN ephemeral    INTEGER NOT NULL DEFAULT 0;  -- /chat, D9
@@ -346,16 +346,22 @@ acting on the Stream.
 - Governor reviews every round's diff, runs gates independently, and updates the session/status table
   below. User runs live smokes; DB backup before any launch against the real profile.
 
-| Phase | Branch | Codex session | Status |
+| Phase | Branch | PR | Status |
 |---|---|---|---|
-| C0 | codex/conv-c0 | see memory / PR body | in progress (2026-08-01) |
-| C1 | codex/conv-c1 | — | not started |
-| C2 | codex/conv-c2 | — | not started |
-| C3 | codex/conv-c3 | — | not started |
-| C4 | codex/conv-c4 | — | not started |
-| C5 | codex/conv-c5 | — | not started |
-| C6 | codex/conv-c6 | — | not started |
-| C7 | codex/conv-c7 + Ticker-Proxy | — | blocked on proxy |
+| C0 | codex/conv-c0 | #68 | DONE 2026-08-01 |
+| C1 | codex/conv-c1 | #69 | DONE 2026-08-01 |
+| C2 | codex/conv-c2 | #70 | DONE 2026-08-01 |
+| C3 | codex/conv-c3 | #71 | DONE 2026-08-01 (swift-test correction noted on PR) |
+| C4 | codex/conv-c4 | #72 | DONE 2026-08-01 (v31 profile migration added in C6) |
+| C5 | codex/conv-c5 | #73 | DONE 2026-08-01 |
+| C6 | codex/conv-c6 | #74 | DONE 2026-08-01 |
+| C7 | codex/conv-c7 + Ticker-Proxy `codex/tool-passthrough` (`7c636aa`) | #75 | DONE 2026-08-01 — proxy NOT deployed; deploy before the tool can fire live |
+
+All phases governed by one warm Codex session (`019fbe73-…93f8`) + one proxy session; every phase
+independently gated (exit codes) and Opus-reviewed with fix rounds. Merge order: #68→#75, one at a
+time (retarget-race lesson). User-reserved: PR merges, Fly deploy of the proxy branch, live smokes
+(editor-slice baseline + conversation flows + Quote & discuss round-trip + /chat ephemerality +
+update_block on a real stream), light/dark visual pass on C1.
 
 ---
 

--- a/docs/contracts/bridge.v2.json
+++ b/docs/contracts/bridge.v2.json
@@ -19,7 +19,7 @@
       },
       "documentAIComplete": {
         "requiredPayloadKeys": ["requestId"],
-        "optionalPayloadKeys": ["citations", "sourceContextMode", "exchange", "sentContext"]
+        "optionalPayloadKeys": ["citations", "sourceContextMode", "exchange", "sentContext", "toolCalls", "toolCall"]
       },
       "documentAIError": {
         "requiredPayloadKeys": ["requestId"],
@@ -255,6 +255,11 @@
       },
       "removeStreamThreadAnchor": {
         "requiredPayloadKeys": ["streamId", "threadId", "anchorId"],
+        "requiredCallbackId": true
+      },
+      "recordThreadToolApplication": {
+        "requiredPayloadKeys": ["streamId", "requestId", "before", "applied"],
+        "optionalPayloadKeys": ["failure"],
         "requiredCallbackId": true
       },
       "retrySourceIndexing": {


### PR DESCRIPTION
Phase C7 of `docs/CONVERSATIONS_PLAN.md` (D8) — conversations whose anchor is a live, non-detached, non-PDF stream range offer the model ONE function tool, `update_block {content}`. Application is hard-clamped to the live mapped anchor range (model offsets ignored; partial anchors take inline-only content, structural content refused as `partial_anchor`), one undo step with AI provenance, byte-identical ⌘Z. Detached/drifted/mismatched → honest five-value failure taxonomy; pending-but-never-applied edits render as 'Proposed edit (not applied)', never as prose. Receipts record before/after as like-for-like markdown. Adversarial clamp tests (0..999999 offsets, 20k content, empty, block-splitting structures) assert byte-identity outside the range.

**Proxy half:** Ticker-Proxy branch `codex/tool-passthrough` (`7c636aa`, 266 tests + mix precommit green) — optional tools/tool_choice passthrough after web_search, complete `tool_call` SSE events, `done.tool_calls` flag, 422 on invalid defs, quotas unchanged. **Not deployed** — against today's proxy the client degrades gracefully (no tools honored → no tool events → normal answers; test-covered).

**Review (Opus): pass-with-notes → fix round `90d5a82`** (partial-anchor bleed, PDF-quote exclusion, unapplied-edit honesty, drift-guard no-op, taxonomy, receipt symmetry) + two test-repair micro-rounds surfaced by the governor's suite runs.

**Gates (exit-code-verified):** build 0 · swift 0 · typecheck 0 · webtest 0 (604) · webbuild 0 · contract 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)